### PR TITLE
feat: scaffold dc-designer agent for ai-datacenter-designer

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: setup
+description: Build, start, and provision the dc-designer sandbox from the branch root
+argument-hint: "[--docker]"
+---
+
+# Setup dc-designer Sandbox
+
+You are running at the root of the `agent/dc-designer` branch. This skill builds the Docker container, installs tools, clones the target project, syncs heartbeats, and starts the viewer dev server.
+
+## Prerequisites
+
+The host needs: Docker, Docker Compose, Git, and GitHub CLI (`gh`).
+
+## Steps
+
+### 1. Build the Docker image
+
+```bash
+docker build -f docker/Dockerfile -t dc-designer:latest .
+```
+
+### 2. Start the container
+
+```bash
+NAME=dc-designer docker compose -f docker/docker-compose.yml -p dc-designer up -d
+```
+
+If `$ARGUMENTS` contains `--docker`, also include the Docker-in-Docker override:
+
+```bash
+NAME=dc-designer docker compose -f docker/docker-compose.yml -f docker/docker-compose.docker.yml -p dc-designer up -d
+```
+
+### 3. Run setup.sh
+
+```bash
+docker exec --user root dc-designer bash -c 'chmod +x /home/sandbox/install/*.sh && /home/sandbox/install/setup.sh --non-interactive'
+```
+
+### 4. Clone the target project
+
+Clone from the host into the bind-mounted workspace so it persists:
+
+```bash
+git clone https://github.com/shpeedle/ai-datacenter-designer.git workspace/ai-datacenter-designer
+```
+
+If the directory already exists, pull instead:
+
+```bash
+git -C workspace/ai-datacenter-designer pull origin main
+```
+
+### 5. Sync heartbeats
+
+```bash
+docker exec --user sandbox dc-designer bash -c '/home/sandbox/install/heartbeat.sh sync'
+```
+
+### 6. Start the viewer dev server
+
+```bash
+docker exec --user sandbox dc-designer bash --login -c 'cd ~/workspace/ai-datacenter-designer && nohup python3 -m http.server 8200 > /tmp/http-server.log 2>&1 &'
+```
+
+### 7. Verify
+
+Run all checks and report results:
+
+```bash
+# Container running
+docker ps --filter "name=dc-designer" --format "table {{.Names}}\t{{.Status}}"
+
+# Workspace files
+ls workspace/SOUL.md workspace/MEMORY.md workspace/heartbeats.conf workspace/ai-datacenter-designer/model_datacenter.py
+
+# Skills
+ls workspace/.claude/skills/design-consistency/SKILL.md workspace/.claude/skills/model-review/SKILL.md
+
+# Heartbeat
+docker exec --user sandbox dc-designer bash -c '/home/sandbox/install/heartbeat.sh status'
+
+# Claude CLI
+docker exec --user sandbox dc-designer bash --login -c 'claude --version'
+
+# Viewer
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8200/viewer.html
+```
+
+### 8. Report
+
+Print:
+
+```
+dc-designer sandbox is ready!
+
+  Container:  dc-designer (running)
+  Viewer:     http://localhost:8200/viewer.html
+  Heartbeats: 2 schedules synced
+
+  Enter the sandbox:
+    docker exec -it --user sandbox dc-designer bash --login
+
+  Start the agent inside:
+    cd workspace && claude
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,109 +1,105 @@
-# Open Harness — Orchestrator
+# dc-designer — Datacenter Design Engineer
 
-You are the harness orchestrator. You run at the project root. You do NOT write application code. Your sole purpose is to manage sandboxed agent workspaces in `.worktrees/`.
+You are the setup and management agent for the `dc-designer` sandbox. You run at the root of the `agent/dc-designer` branch on the host machine. Your job is to provision and maintain the sandboxed environment where the datacenter design agent operates.
 
-## Permissions
+## Project
 
-Your primary operations are git (`git add`, `git commit`, `git push`) and sandbox lifecycle management. You may run `make`, `docker`, and `gh` commands for provisioning, validating, and tearing down sandboxes. All application coding, building, and testing happens INSIDE sandboxes, never at root.
+This branch provisions an agent sandbox for [shpeedle/ai-datacenter-designer](https://github.com/shpeedle/ai-datacenter-designer) — a 50MW→200MW hyperscale AI datacenter facility design with:
+
+- **14 plan documents** covering power, cooling, network, compute, storage, layout, redundancy, security, sustainability, cost, 3D visualization, and phased rollout
+- **model_datacenter.py** — FreeCAD parametric 3D model (~700 lines)
+- **viewer.html** — interactive web-based plan viewer (served on port 8200)
+
+## Setup
+
+Run `/setup` to provision the sandbox end-to-end. This builds the Docker image, starts the container, installs tools, clones the target repo, syncs heartbeats, and starts the viewer.
+
+If you need to do it manually, the steps are:
+
+```bash
+# Build and start
+docker build -f docker/Dockerfile -t dc-designer:latest .
+NAME=dc-designer docker compose -f docker/docker-compose.yml -p dc-designer up -d
+
+# Install tools
+docker exec --user root dc-designer bash -c 'chmod +x /home/sandbox/install/*.sh && /home/sandbox/install/setup.sh --non-interactive'
+
+# Clone target project (into bind-mounted workspace)
+git clone https://github.com/shpeedle/ai-datacenter-designer.git workspace/ai-datacenter-designer
+
+# Sync heartbeats
+docker exec --user sandbox dc-designer bash -c '/home/sandbox/install/heartbeat.sh sync'
+
+# Start viewer
+docker exec --user sandbox dc-designer bash --login -c 'cd ~/workspace/ai-datacenter-designer && nohup python3 -m http.server 8200 > /tmp/http-server.log 2>&1 &'
+```
+
+## Branch Structure
+
+```
+agent/dc-designer/
+├── docker/
+│   ├── Dockerfile                    # Debian Bookworm sandbox image
+│   ├── docker-compose.yml            # Container config (port 8200 exposed)
+│   └── docker-compose.docker.yml     # Docker-in-Docker override
+├── install/
+│   ├── setup.sh                      # Tool installation (Node, gh, Docker CLI, uv, Claude, etc.)
+│   ├── entrypoint.sh                 # Container startup (cron, GID fix)
+│   └── heartbeat.sh                  # Cron-based task scheduler
+├── workspace/                        # Bind-mounted into container at /home/sandbox/workspace/
+│   ├── CLAUDE.md → AGENTS.md         # In-sandbox agent instructions
+│   ├── SOUL.md                       # DC engineer persona
+│   ├── MEMORY.md                     # Seeded design parameters and constraints
+│   ├── heartbeats.conf               # Wed design review + Sun memory distill
+│   ├── heartbeats/
+│   │   ├── design-review.md          # Weekly consistency + model review
+│   │   └── memory-distill.md         # Weekly log distillation
+│   ├── .claude/skills/
+│   │   ├── design-consistency/       # 7-gate cross-document validation
+│   │   └── model-review/             # Code quality + plan alignment audit
+│   └── ai-datacenter-designer/       # Cloned target project (gitignored)
+├── .claude/skills/
+│   ├── provision/                    # Generic sandbox provisioning
+│   └── setup/                        # This agent's setup skill
+├── CLAUDE.md → AGENTS.md             # This file (host-side instructions)
+└── README.md                         # User-facing setup guide
+```
+
+## Container Access
+
+```bash
+# Enter the sandbox
+docker exec -it --user sandbox dc-designer bash --login
+
+# Start the agent inside
+cd workspace && claude
+
+# Viewer
+open http://localhost:8200/viewer.html
+```
 
 ## Lifecycle
 
-### Setup
+```bash
+# Stop (preserves workspace)
+docker compose -f docker/docker-compose.yml -p dc-designer down
 
-Provision a new agent sandbox. The human runs all host commands.
+# Restart
+NAME=dc-designer docker compose -f docker/docker-compose.yml -p dc-designer up -d
+docker exec --user root dc-designer bash -c 'chmod +x /home/sandbox/install/*.sh && /home/sandbox/install/setup.sh --non-interactive'
 
-1. Create a GitHub issue using the `[AGENT]` template to define identity and role
-2. Provision the sandbox:
-   ```bash
-   make NAME=<agent-name> BASE_BRANCH=main quickstart
-   ```
-   Creates: git worktree at `.worktrees/agent/<agent-name>` on branch `agent/<agent-name>` (from `main`), Docker image, running container, provisioned environment. Worktree paths mirror branch paths (e.g., branch `agent/foo` → `.worktrees/agent/foo`).
+# Full teardown
+docker compose -f docker/docker-compose.yml -p dc-designer down --rmi local
+```
 
-   > **Note**: The root Makefile expects `main` branch layout (`docker/`, `install/`, `workspace/`). The `development` branch has a different structure (`setup/`) and requires its own Makefile. Always use `BASE_BRANCH=main` unless explicitly working with the development layout.
-3. Enter and start the agent:
-   ```bash
-   make NAME=<agent-name> shell
-   claude                                    # or codex, pi
-   ```
+## What You Do (at the host level)
 
-### Validate
-
-Verify a sandbox is healthy.
-
-1. **Check running sandboxes**:
-   ```bash
-   make list
-   ```
-2. **Verify workspace** (inside the sandbox via `make NAME=<agent-name> shell`):
-   - `AGENTS.md`, `SOUL.md`, `MEMORY.md` exist in workspace
-   - Target agent CLI is installed (`claude --version`, `codex --version`, `pi --version`)
-   - Docker socket accessible if needed (`docker ps`)
-3. **Check heartbeat** (if configured):
-   ```bash
-   make NAME=<agent-name> heartbeat-status
-   ```
-
-### Teardown
-
-Remove an agent sandbox. Preserve work first if needed.
-
-1. **Save unmerged work** (if the agent branch has uncommitted changes):
-   ```bash
-   cd .worktrees/agent/<agent-name>
-   git add -A && git commit -m "<type>: <description>" && git push -u origin agent/<agent-name>
-   ```
-2. **Stop the sandbox**:
-   ```bash
-   make NAME=<agent-name> stop
-   ```
-3. **Full cleanup** (removes container, image, and worktree):
-   ```bash
-   make NAME=<agent-name> clean
-   ```
-
-## Git Workflow
-
-| Item | Convention |
-|------|-----------|
-| Base branch | `main` (root Makefile requires `main` layout) |
-| Agent branches | `agent/<agent-name>` |
-| PR target | `development` |
-| Commit format | `<type>: <description>` (`feat`, `fix`, `task`, `audit`, `skill`) |
-
-## What You Do
-
-- Commit and push changes to the harness itself (Makefile, docker/, install/, workspace/ templates)
-- Manage branches and worktree state via git
-- Review diffs across agent branches
-- Provision, validate, and tear down sandboxes (`make quickstart`, `make clean`, `docker exec`, etc.)
-- Create and manage GitHub issues for agent tracking
-- Run the `/provision` skill for end-to-end sandbox setup
-- **Scaffold agent workspaces** after provisioning — write SOUL.md, MEMORY.md, skills, heartbeats, and initial project state to `.worktrees/agent/<name>/workspace/` based on the agent's role. The workspace is bind-mounted, so files written to the host path appear instantly inside the container.
+- Run `/setup` to provision or re-provision the sandbox
+- Manage the container lifecycle (start, stop, restart)
+- Check heartbeat status and logs
+- Review diffs and push changes on the agent branch
 
 ## What You Do NOT Do
 
-- Write application code logic (business logic, APIs, UIs — that happens inside sandboxes)
-- Enter sandboxes to do ongoing agent work
-- Modify agent-owned files after initial scaffolding (agents own their workspace once running)
-
-> **Scaffolding vs. application code**: Writing SOUL.md, MEMORY.md, skill definitions, heartbeat configs, and initial state files is orchestrator infrastructure work — it configures the agent's identity, capabilities, and schedule. The agent then owns these files and evolves them. Application code (Python modules, APIs, tests) that implements the agent's actual task should be created by the agent inside the sandbox via `docker exec` or by the agent itself.
-
-## Project Structure
-
-```
-.worktrees/           # Sandboxed agent worktrees (gitignored, mirrors branch paths)
-  agent/              # e.g., .worktrees/agent/zoho-crm → branch agent/zoho-crm
-docker/               # Dockerfile and compose files
-install/              # Provisioning scripts (setup.sh, heartbeat.sh, entrypoint.sh)
-workspace/            # Template for all agent workspaces
-  AGENTS.md           # In-sandbox agent instructions (separate from this file)
-  SOUL.md             # Agent persona template
-  MEMORY.md           # Long-term memory template
-  heartbeats.conf     # Periodic task schedule
-  .claude/skills/     # Reusable skill templates
-    quality-gate/     # Template: validate decisions before execution
-    strategy-review/  # Template: measure decision quality over time
-Makefile              # Human-operated sandbox automation
-.github/ISSUE_TEMPLATE/  # agent, audit, bug, feature, skill, task
-.claude/skills/          # Orchestrator skills (e.g., /provision)
-```
+- Write application code — that happens inside the sandbox
+- Modify workspace files after initial setup — the agent owns them once running

--- a/README.md
+++ b/README.md
@@ -1,313 +1,88 @@
-# 🏗️ Open Harness
+# dc-designer — AI Datacenter Design Engineer
 
-Isolated, pre-configured sandbox images for AI coding agents — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [OpenAI Codex](https://github.com/openai/codex), [Pi Agent](https://shittycodingagent.ai), and more.
+An [Open Harness](https://github.com/ryaneggz/open-harness) agent sandbox for [ai-datacenter-designer](https://github.com/shpeedle/ai-datacenter-designer) — a 50MW→200MW hyperscale AI datacenter facility design project.
 
-> **Spin up isolated, fully-provisioned Docker sandboxes where AI coding agents can operate with full permissions, persistent memory, and autonomous background tasks — without touching your host system.**
+## Quick Setup
 
-## ⚡ Quickstart
-
-1. [**Fork this repo**](https://github.com/ryaneggz/open-harness/fork) and clone it:
+**Prerequisites**: Docker, Docker Compose, Git, GitHub CLI (`gh`)
 
 ```bash
 git clone https://github.com/ryaneggz/open-harness.git && cd open-harness
+git checkout agent/dc-designer
+claude
 ```
 
-2. Start Claude at the project root **in plan mode**:
+Then tell Claude:
+
+```
+/setup
+```
+
+This builds the container, installs tools, clones the target repo, syncs heartbeats, and starts the viewer on port 8200.
+
+## What's Inside
+
+| Component | Description |
+|-----------|-------------|
+| **14 plan documents** | Power, cooling, network, compute, storage, layout, redundancy, security, sustainability, cost, 3D visualization, phased rollout |
+| **model_datacenter.py** | FreeCAD parametric 3D model (~700 lines) |
+| **viewer.html** | Interactive plan viewer at `http://localhost:8200/viewer.html` |
+
+## Agent Capabilities
+
+| Skill | Purpose |
+|-------|---------|
+| `design-consistency` | Validates power, cooling, space, and cost figures across all 14 plan documents (7 gates) |
+| `model-review` | Reviews model_datacenter.py for code quality, plan alignment, and parametric correctness |
+
+| Heartbeat | Schedule |
+|-----------|----------|
+| Design review | Wednesday 10am MT — upstream sync, consistency check, model review |
+| Memory distill | Sunday 8pm MT — distill daily logs into long-term memory |
+
+## Manual Setup
+
+If you prefer not to use Claude for setup:
 
 ```bash
-claude --permission-mode plan
+# Build and start the container
+docker build -f docker/Dockerfile -t dc-designer:latest .
+NAME=dc-designer docker compose -f docker/docker-compose.yml -p dc-designer up -d
+
+# Install tools inside the container
+docker exec --user root dc-designer bash -c \
+  'chmod +x /home/sandbox/install/*.sh && /home/sandbox/install/setup.sh --non-interactive'
+
+# Clone the target project into the bind-mounted workspace
+git clone https://github.com/shpeedle/ai-datacenter-designer.git workspace/ai-datacenter-designer
+
+# Sync heartbeat schedules
+docker exec --user sandbox dc-designer bash -c '/home/sandbox/install/heartbeat.sh sync'
+
+# Start the viewer dev server
+docker exec --user sandbox dc-designer bash --login -c \
+  'cd ~/workspace/ai-datacenter-designer && nohup python3 -m http.server 8200 > /tmp/http-server.log 2>&1 &'
 ```
 
-3. Tell it which agent to build. Try the **portfolio manager**:
-
-```
-Set up a portfolio-mgr agent that creates a mock $100K portfolio using Ray Dalio's All Weather strategy with yfinance data and web search sentiment analysis
-```
-
-Claude will ask about the agent's role, tools, heartbeat schedule, and any customizations. Once you approve the plan, it provisions the sandbox end-to-end.
-
-4. Enter the sandbox and start working:
+## Usage
 
 ```bash
-make NAME=portfolio-mgr shell    # enter the sandbox
-claude                           # start working
+# Enter the sandbox
+docker exec -it --user sandbox dc-designer bash --login
+
+# Start the agent
+cd workspace && claude
+
+# View the datacenter plans
+open http://localhost:8200/viewer.html
 ```
 
-> **Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and [Make](https://www.gnu.org/software/make/). That's all you need on your host.
-
-### More example agents
-
-| Prompt | What it builds |
-|--------|---------------|
-| _"Set up a blog-writer agent"_ | Writes blog posts for your website, creates PRs with drafts, and generates LinkedIn & X.com posts for manual promotion |
-| _"Set up an uptime-monitor agent"_ | Checks your URLs every 30 minutes for availability and response time, files GitHub issues on downtime, generates weekly SLA reports |
-
-### Cleanup
+## Teardown
 
 ```bash
-make NAME=portfolio-mgr clean    # full teardown (container + image + worktree)
-make list                        # see what's still running
+docker compose -f docker/docker-compose.yml -p dc-designer down --rmi local
 ```
 
 ---
 
-## 🎯 Why Open Harness?
-
-AI coding agents are powerful — but they run with broad system permissions, execute arbitrary code, and need a full development toolchain. Open Harness solves the tension between giving agents the freedom they need and keeping your host machine safe.
-
-### Core Intentions
-
-#### 1. **Isolation & Safety**
-Agents run `--dangerously-skip-permissions` by default — inside a disposable Docker container. They can `rm -rf`, install packages, and spawn processes without any risk to your host machine. The workspace directory is the only thing bind-mounted; everything else is ephemeral.
-
-#### 2. **Zero-to-Agent in Minutes**
-One provisioning script (`install/setup.sh`) installs Node.js, Bun, uv, Docker CLI, GitHub CLI, ripgrep, tmux, and whichever agents you choose — interactively or fully unattended with `--non-interactive`. No more "install 15 things" friction.
-
-#### 3. **Agent-Agnostic**
-Not a wrapper for one tool. The same sandbox runs Claude Code, Codex, and Pi Agent side by side, sharing workspace files and context. `AGENTS.md` is symlinked to `CLAUDE.md` so every agent reads the same instructions.
-
-#### 4. **Persistent Identity**
-`SOUL.md`, `MEMORY.md`, and daily logs (`memory/YYYY-MM-DD.md`) give agents continuity across sessions — not ephemeral chat windows, but persistent collaborators that remember decisions, preferences, and lessons learned.
-
-#### 5. **Autonomous Background Work**
-The heartbeat system (`install/heartbeat.sh` + `HEARTBEAT.md`) lets agents wake on a timer, perform tasks from a user-authored checklist, and go back to sleep — turning reactive tools into proactive workers that can monitor, maintain, and report without human presence.
-
-#### 6. **Multi-Sandbox Parallelism**
-Named sandboxes (`NAME=research`, `NAME=frontend`) run simultaneously, each with its own container, workspace, and agent sessions — enabling parallel workstreams or agent-per-project setups.
-
----
-
-### Key Benefits
-
-| Benefit | Details |
-|---------|---------|
-| 🔒 **Host protection** | Agents run in a disposable Debian container; only the workspace directory is bind-mounted |
-| 🔄 **Reproducibility** | `docker/Dockerfile` + setup script = identical environment every time, on any machine |
-| 🐳 **Docker-in-Docker** | `DOCKER=true` mounts the host socket so agents can build and manage containers from inside |
-| 🚀 **CI/CD ready** | GitHub Actions builds and pushes to `ghcr.io/ryaneggz/open-harness` on tagged releases |
-| 🧠 **Agent memory** | SOUL / MEMORY / daily-log system gives agents durable state across restarts and sessions |
-| ⏰ **Unattended operation** | Cron-scheduled heartbeats with multiple files/intervals, active-hours gating, cost-saving empty-file detection, and auto-rotating logs |
-| ⚙️ **Flexible provisioning** | Interactive mode prompts for SSH keys, Git identity, and per-agent installs; non-interactive mode uses sane defaults |
-| 🔧 **Entrypoint correctness** | `entrypoint.sh` dynamically matches the container's `docker` GID to the host socket's GID, avoiding "permission denied on /var/run/docker.sock" |
-| 🧩 **Per-project extensibility** | `.openharness/extensions/`, `.claude/`, and `.codex/` directories live in the workspace — agents are customized per-project |
-| 📦 **Shareable** | Published as a container image — teams `docker pull` a pre-provisioned sandbox instead of each developer running setup |
-
----
-
-## 🚀 More Ways to Run
-
-**Step-by-step** (if you want control over each stage):
-
-```bash
-make NAME=my-sandbox build                      # build the image
-make NAME=my-sandbox run                        # start the container
-make NAME=my-sandbox shell                      # open a shell as sandbox user
-sudo bash ~/install/setup.sh                    # provision tools (interactive)
-cd ~/workspace && claude                        # launch an agent
-```
-
-**Standalone** (no Docker, direct on any Ubuntu/Debian machine):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/ryaneggz/open-harness/refs/heads/main/install/setup.sh -o setup.sh
-sudo bash setup.sh --non-interactive
-```
-
-**Docker-in-Docker** (agents can build and manage containers):
-
-```bash
-make NAME=my-sandbox DOCKER=true quickstart     # sandbox with Docker access
-```
-
-**Multiple sandboxes** (parallel workstreams):
-
-```bash
-make NAME=research quickstart
-make NAME=frontend DOCKER=true quickstart       # this one gets Docker
-make list                                       # see all running sandboxes
-```
-
-`make rebuild` does a full no-cache build and restart. `NAME` is required for all targets.
-
----
-
-## 📁 Structure
-
-```
-├── docker/
-│   ├── Dockerfile           # base image: Debian Bookworm slim + sandbox user
-│   ├── docker-compose.yml   # base compose: mounts workspace/
-│   └── docker-compose.docker.yml # Docker override: mounts socket + host networking
-├── Makefile                 # build, run, shell, stop, rebuild, clean, push, list
-├── install/
-│   ├── setup.sh             # provisioning script (runs as root)
-│   ├── heartbeat.sh         # cron-based heartbeat runner (sync/run/stop/status)
-│   └── entrypoint.sh        # container entrypoint (Docker GID matching + cron start)
-└── workspace/
-    ├── AGENTS.md            # default instructions for all coding agents
-    ├── CLAUDE.md            # symlink → AGENTS.md
-    ├── heartbeats.conf      # heartbeat schedule config (cron expressions)
-    ├── heartbeats/          # heartbeat task .md files (default.md, etc.)
-    ├── SOUL.md              # agent persona, tone, and boundaries
-    ├── MEMORY.md            # curated long-term memory
-    ├── memory/              # daily append-only logs (YYYY-MM-DD.md)
-    ├── .claude/             # Claude Code config directory
-    └── .codex/              # Codex config directory
-```
-
----
-
-## ⚙️ How It Works
-
-1. **`docker/Dockerfile`** creates a minimal Debian image with a `sandbox` user (passwordless sudo) and bakes in:
-   - `install/` copied to `/home/sandbox/install/`
-   - `workspace/` copied to `/home/sandbox/workspace/`
-   - Agent aliases in `.bashrc` (`claude`, `codex`, `pi`)
-   - Docker group membership for the sandbox user
-   - Default shell drops into `/home/sandbox/workspace`
-
-2. **`docker/docker-compose.yml`** bind-mounts `./workspace`. When `DOCKER=true`, the override file (`docker/docker-compose.docker.yml`) additionally mounts the Docker socket and configures `host.docker.internal`.
-
-3. **`install/setup.sh`** provisions all tools system-wide (as root):
-   - Node.js 22.x, npm, tmux, nano, ripgrep, jq (always)
-   - Docker CLI + Compose plugin (always)
-   - GitHub CLI (always)
-   - Bun, uv (always)
-   - Claude Code CLI (default yes)
-   - OpenAI Codex, Pi Agent, AgentMail CLI (opt-in)
-   - agent-browser + Chromium (default yes)
-
-4. **`workspace/AGENTS.md`** provides default context to all coding agents. `CLAUDE.md` is a symlink to it — editing either updates both.
-
----
-
-## 🛠️ Makefile Targets
-
-| Target | Description |
-|--------|-------------|
-| `make quickstart` | Build, provision, and prepare sandbox (one command) |
-| `make build` | Build the Docker image |
-| `make rebuild` | Full no-cache rebuild + restart |
-| `make run` | Start the container (detached) |
-| `make shell` | Open a bash shell as `sandbox` user |
-| `make stop` | Stop the container |
-| `make clean` | Stop and remove the local image |
-| `make push` | Push image to ghcr.io/ryaneggz |
-| `make list` | List all running sandboxes |
-| `make all` | Build + push |
-| `make heartbeat` | Sync heartbeat cron schedules from `heartbeats.conf` |
-| `make heartbeat-stop` | Remove all heartbeat cron schedules |
-| `make heartbeat-status` | Show heartbeat schedules and recent logs |
-| `make heartbeat-migrate` | Convert legacy `HEARTBEAT_INTERVAL` to `heartbeats.conf` |
-
-`NAME` is required for all targets. Pass `DOCKER=true` to enable Docker socket access.
-
----
-
-## 🔧 Configuration
-
-The setup script supports interactive and non-interactive modes:
-
-```bash
-# Interactive (prompts for each option)
-sudo bash ~/install/setup.sh
-
-# Non-interactive (installs everything with defaults)
-sudo bash ~/install/setup.sh --non-interactive
-```
-
-Interactive mode prompts for: SSH public key, Git identity, GitHub token, Claude Code, Codex, Pi Agent, AgentMail (with API key), agent-browser.
-
----
-
-## 🧠 Heartbeat, Soul & Memory
-
-Three workspace files give agents persistent identity and periodic task execution:
-
-| File | Purpose | Authored by |
-|------|---------|-------------|
-| `SOUL.md` | Agent persona, tone, boundaries | User (seeded with template) |
-| `MEMORY.md` | Curated long-term memory | Agent (distilled from daily logs) |
-| `heartbeats.conf` | Heartbeat schedule config (cron → file mapping) | User |
-| `heartbeats/*.md` | Heartbeat task files (`default.md`, etc.) | User |
-| `memory/YYYY-MM-DD.md` | Daily append-only logs | Agent |
-
-### 📝 How Memory Works
-
-Agents are instructed to:
-1. **Read `MEMORY.md` at session start** for accumulated context
-2. **Append to `memory/YYYY-MM-DD.md`** during work (notable events, decisions, learnings)
-3. **Distill daily logs into `MEMORY.md`** periodically (during heartbeats or when asked)
-4. **Write to `MEMORY.md` immediately** when the user says "remember this"
-
-`SOUL.md` defines the agent's persona and boundaries. The agent may evolve it over time but must tell the user when it does.
-
-### 💓 Heartbeat
-
-Heartbeats are cron-scheduled tasks. Each heartbeat is a `.md` file with instructions for the agent, mapped to a cron schedule in `heartbeats.conf`.
-
-```bash
-make NAME=my-sandbox heartbeat                              # sync schedules from heartbeats.conf
-make NAME=my-sandbox heartbeat-status                       # show schedules + recent logs
-make NAME=my-sandbox heartbeat-stop                         # remove all schedules
-make NAME=my-sandbox heartbeat-migrate                      # convert legacy HEARTBEAT_INTERVAL to conf
-```
-
-**Schedule config** (`workspace/heartbeats.conf`):
-
-```
-# Format: <cron> | <file> | [agent] | [active_start-active_end]
-*/30 * * * * | heartbeats/default.md
-*/15 * * * * | heartbeats/check-deployments.md | claude | 9-18
-0 */4 * * *  | heartbeats/memory-distill.md
-0 20 * * *   | heartbeats/daily-summary.md
-```
-
-Schedules auto-sync on container startup. Edit `heartbeats.conf`, then run `make heartbeat` to apply changes.
-
-**Global defaults** (env vars, set at `make run` or in `docker/docker-compose.yml`):
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `HEARTBEAT_ACTIVE_START` | _(unset)_ | Default active hour start (0-23) |
-| `HEARTBEAT_ACTIVE_END` | _(unset)_ | Default active hour end (0-23) |
-| `HEARTBEAT_AGENT` | `claude` | Default agent CLI to invoke |
-
-Per-entry overrides for agent and active hours can be set in `heartbeats.conf`.
-
-If a heartbeat file contains only headers or comments, that execution is skipped (saves API costs). If the agent has nothing to report, it replies `HEARTBEAT_OK` and the response is suppressed.
-
----
-
-## 💻 Usage Examples
-
-Once inside the sandbox (`make shell`), use any installed coding agent:
-
-```bash
-# Claude Code
-claude -p "Create a Python CLI app with click that fetches weather data"
-
-# OpenAI Codex
-codex "Write a bash script that finds all files larger than 10MB"
-
-# Pi Agent
-pi -p "Refactor main.py to use async/await"
-
-# Claude Code loop tasks
-/loop 2m append the current system time to output.txt
-```
-
----
-
-## 📦 Releases
-
-Tag format: `oh-v<version>` (e.g. `oh-v1.0.0`)
-
-```bash
-git tag oh-v1.0.0
-git push origin oh-v1.0.0
-```
-
-This triggers the CI workflow which builds and pushes:
-- `ghcr.io/ryaneggz/open-harness:v1.0.0`
-- `ghcr.io/ryaneggz/open-harness:latest`
+Forked from [Open Harness](https://github.com/ryaneggz/open-harness)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: docker/Dockerfile
     volumes:
       - ../workspace:/home/sandbox/workspace
+    ports:
+      - "8200:8200"
     stdin_open: true
     tty: true
     environment:

--- a/workspace/.claude/skills/design-consistency/SKILL.md
+++ b/workspace/.claude/skills/design-consistency/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: design-consistency
+description: |
+  Validate that power, cooling, space, and cost figures are consistent across
+  all 14 plan documents and the parametric model.
+  TRIGGER when: before creating a PR, after editing any plan document,
+  during design review heartbeats, or when user asks to check consistency.
+---
+
+# Design Consistency Check
+
+Validate that specifications across all plan documents and the 3D model are internally consistent.
+
+## Instructions
+
+1. Read all 14 plan documents from ~/workspace/ai-datacenter-designer/plans/
+2. Extract key figures from each document into a comparison table
+3. Check all cross-document consistency gates
+
+## Gates
+
+| Gate | Rule | Check |
+|---|---|---|
+| **Power budget** | Total allocated power <= facility capacity per phase | Sum power allocations across plans, compare to 00-overview capacity |
+| **Cooling capacity** | Cooling capacity >= 1.1x power load (safety margin) | Compare cooling plan totals to power plan totals |
+| **Space allocation** | Total allocated sqft <= facility footprint per phase | Sum space claims across plans |
+| **Cost coherence** | Line items sum to stated totals | Cross-check cost tables with summary |
+| **Phase alignment** | Phase boundaries consistent across all docs | Same phase definitions in overview, phasing doc, and each subsystem plan |
+| **Redundancy claims** | Stated redundancy levels achievable with specified equipment | N+1 means at least N+1 units specified |
+| **PUE feasibility** | Claimed PUE achievable given cooling approach | PUE = Total Facility Power / IT Load |
+
+## Output Format
+
+```
+DESIGN CONSISTENCY CHECK (as of YYYY-MM-DD)
+=============================================
+Power Budget:     [PASS/FAIL] Allocated X MW of Y MW capacity (Phase N)
+Cooling Match:    [PASS/FAIL] Cooling X MW vs Power X MW (ratio: X.Xx)
+Space Allocation: [PASS/FAIL] Allocated X sqft of Y sqft
+Cost Coherence:   [PASS/FAIL] Line items sum to $X vs stated $Y
+Phase Alignment:  [PASS/FAIL] N documents with consistent phase boundaries
+Redundancy:       [PASS/FAIL] All claims verified
+PUE Feasibility:  [PASS/FAIL] Calculated PUE: X.XX vs target < 1.10
+
+Overall Gate: PASS/FAIL
+Discrepancies: [list any specific conflicts found]
+```

--- a/workspace/.claude/skills/model-review/SKILL.md
+++ b/workspace/.claude/skills/model-review/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: model-review
+description: |
+  Review model_datacenter.py for code quality, parametric correctness,
+  and alignment with plan specifications.
+  TRIGGER when: before creating a PR that touches the model, during
+  code review heartbeats, or when user asks about model quality.
+---
+
+# Model Review
+
+Review the FreeCAD parametric model for code quality and specification alignment.
+
+## Instructions
+
+1. Read ~/workspace/ai-datacenter-designer/model_datacenter.py
+2. Read relevant plan documents for dimensional/parameter references
+3. Evaluate against all review criteria
+
+## Review Criteria
+
+| Criterion | Check |
+|---|---|
+| **Parameter extraction** | All magic numbers extracted to named constants at top of file |
+| **Plan alignment** | Dimensions match specifications in plan documents |
+| **Modularity** | Functions are single-responsibility, < 50 lines each |
+| **Error handling** | Invalid parameters caught before geometry generation |
+| **Documentation** | All functions have docstrings with units |
+| **Naming** | Variables use descriptive names with units (e.g., rack_height_mm) |
+| **Scaling** | Model scales correctly across phase 1 (50MW) to phase 4 (200MW) |
+
+## Output Format
+
+```
+MODEL REVIEW (as of YYYY-MM-DD)
+==================================
+Parameters:     [PASS/WARN/FAIL] X magic numbers remain
+Plan Alignment: [PASS/WARN/FAIL] N dimensions verified, M mismatches
+Modularity:     [PASS/WARN/FAIL] X functions, Y over 50 lines
+Error Handling: [PASS/WARN/FAIL] X parameter validations present
+Documentation:  [PASS/WARN/FAIL] X/Y functions documented
+Naming:         [PASS/WARN/FAIL] X variables missing units
+Scaling:        [PASS/WARN/FAIL] Phase scaling logic verified
+
+Issues Found: [list with severity and file locations]
+```

--- a/workspace/MEMORY.md
+++ b/workspace/MEMORY.md
@@ -1,15 +1,62 @@
 # MEMORY.md — Long-Term Memory
 
-<!--
-  This file stores curated, durable memories across sessions.
-  The agent reads it at session start and updates it as needed.
-
-  Daily logs go to memory/YYYY-MM-DD.md (append-only).
-  Periodically distill daily logs into this file during heartbeats.
--->
-
 ## Decisions & Preferences
+
+### Git Workflow
+- Project: ~/workspace/ai-datacenter-designer/ (clone of shpeedle/ai-datacenter-designer)
+- Default branch: main
+- Feature branches: `design/<topic>` (e.g., `design/cooling-optimization`, `design/viewer-upgrade`)
+- Commit format: `<type>: <description>` (feat, fix, docs, refactor)
+
+### Design Parameters (from plans)
+- Facility: 50MW initial (Phase 1), expandable to 200MW across 4 phases
+- GPU count: ~20,000 total (NVIDIA GB200 NVL72 or equivalent)
+- PUE target: < 1.10 (industry-leading, direct liquid cooling)
+- Redundancy: Tier III+ minimum
+- 14 plan documents in plans/ directory (00-overview through 13-phases)
+- 3D model: model_datacenter.py (~700 lines, FreeCAD Python API)
+- Viewer: viewer.html (HTML/CSS/JS interactive plan viewer)
+- Output: STL files + dc_viewer.html in output/
+
+### FreeCAD Status
+- FreeCAD NOT installed in container
+- Can review/refactor Python code but cannot execute to generate STL
+- model_datacenter.py uses FreeCAD Part, Mesh modules
 
 ## Lessons Learned
 
+_(populated as agent operates)_
+
 ## Project Context
+
+### Repository Structure
+```
+ai-datacenter-designer/
+├── README.md
+├── model_datacenter.py       # FreeCAD Python script (~700 lines)
+├── viewer.html               # Interactive plan viewer
+├── plans/                    # 14 markdown design docs
+│   ├── 00-overview.md        # Design overview, principles, dependency graph
+│   ├── 01-site-selection.md  # Geographic, climate, utility considerations
+│   ├── 02-power.md           # Grid connection, on-site generation, PDU design
+│   ├── 03-cooling.md         # Direct liquid cooling, CDU placement, heat recovery
+│   ├── 04-network.md         # InfiniBand fabric, switch topology, connectivity
+│   ├── 05-compute.md         # GPU rack specs, containment, cabling
+│   ├── 06-storage.md         # NVMe, NAS, archive tiers
+│   ├── 07-layout.md          # Physical floor plan, aisle arrangement
+│   ├── 08-redundancy.md      # HA design, fault tolerance, SLAs
+│   ├── 09-security.md        # Physical, network, access control
+│   ├── 10-sustainability.md  # Emissions, waste heat reuse, renewables
+│   ├── 11-cost-model.md      # CapEx, OpEx, per-rack breakdowns
+│   ├── 12-3d-visualization.md# 3D model details and export info
+│   └── 13-phases.md          # Implementation roadmap
+└── output/                   # Generated STL files + dc_viewer.html
+```
+
+### Key Constraints
+- Power budget: 50MW Phase 1, 200MW at full build-out
+- PUE target: < 1.10
+- Cooling: Direct liquid cooling (air cooling cannot support >70 kW/rack density)
+- Network: Full-bisection InfiniBand for all-to-all GPU communication
+- Phasing: 4 phases, each independently operational (50MW self-contained halls)
+- On-site power: 12 natural gas generators + utility grid

--- a/workspace/SOUL.md
+++ b/workspace/SOUL.md
@@ -1,23 +1,44 @@
 # SOUL.md — Who You Are
 
 ## Core Truths
-- You are a coding agent running inside an isolated Docker sandbox
-- Be genuinely helpful, not performatively helpful
+- You are a **datacenter design engineer** running inside an isolated Docker sandbox
+- You work on [ai-datacenter-designer](https://github.com/shpeedle/ai-datacenter-designer): a 50MW→200MW hyperscale datacenter facility design
+- Your expertise spans power distribution, cooling systems, network topology, structural layout, and phased construction planning
+- You iterate on 14 interconnected plan documents, a FreeCAD parametric 3D model, and an interactive HTML viewer
+- Be data-driven: cite watts, BTUs, square footage, and costs — not vibes
 - Try first, ask later — you have full permissions in this sandbox
-- Have opinions and preferences; don't be unnecessarily neutral
 
 ## Boundaries
 - Work within the workspace/ directory — it persists across restarts
+- The target project is at ~/workspace/ai-datacenter-designer/
 - Do not modify files in ~/install/ unless explicitly asked
-- If you change this file, tell the user — it's your identity
+- If you change this file, tell the user — it is your identity
+- NEVER merge PRs automatically — all changes are for human review
+- NEVER fabricate specifications, load calculations, or cost figures — cite sources or flag estimates
+
+## FreeCAD Limitation
+- FreeCAD is NOT installed in this container
+- You CAN read, review, refactor, and extend model_datacenter.py (pure Python logic)
+- You CANNOT execute the script to generate STL files
+- Focus on code quality, parametric logic, and structural improvements
+- If FreeCAD execution is needed, request it explicitly (`sudo apt-get install freecad-python3`)
+
+## Expertise Areas
+- **Power**: Utility feeds, switchgear, UPS, PDUs, generator sizing, redundancy (N+1, 2N)
+- **Cooling**: Direct liquid cooling, CDUs, hot/cold aisle containment, free cooling, heat recovery
+- **Network**: InfiniBand fabric, spine-leaf, top-of-rack, cross-connects
+- **Structural**: Floor plans, raised floor, cable management, fire suppression, seismic
+- **Operations**: DCIM, monitoring, capacity planning, PUE optimization
+- **Phasing**: Construction sequencing, modular expansion, commissioning
 
 ## Vibe
-- Be direct and concise
-- Prefer working code over lengthy explanations
-- When stuck, try a different approach before asking for help
+- Think in systems — every change ripples across power, cooling, space, and cost
+- Flag constraint violations immediately (power budget exceeded, cooling capacity insufficient, etc.)
+- Show calculations, not just conclusions
+- Be direct and concise — prefer working code over lengthy explanations
 
 ## Continuity
 - MEMORY.md is your long-term memory — read it at session start
 - memory/YYYY-MM-DD.md files are your daily logs — append to today's file
-- HEARTBEAT.md defines your periodic responsibilities
+- heartbeats.conf defines your periodic responsibilities
 - These files *are* your memory across sessions

--- a/workspace/heartbeats.conf
+++ b/workspace/heartbeats.conf
@@ -7,12 +7,10 @@
 # - agent: (optional) Override HEARTBEAT_AGENT env var. Default: claude
 # - active_start-active_end: (optional) Hours (0-23). Only run during this window.
 #
-# Examples:
-#   */30 * * * * | heartbeats/default.md
-#   */15 * * * * | heartbeats/check-deployments.md | claude | 9-18
-#   0 */4 * * *  | heartbeats/memory-distill.md
-#   0 20 * * *   | heartbeats/daily-summary.md
-#
 # After editing, run: heartbeat.sh sync (or from host: make heartbeat)
 
-*/30 * * * * | heartbeats/default.md
+# Weekly design review — Wednesday 10am MT (16:00 UTC)
+0 16 * * 3 | heartbeats/design-review.md | claude
+
+# Weekly memory distillation — Sunday 8pm MT (02:00 UTC Monday)
+0 2 * * 1 | heartbeats/memory-distill.md | claude

--- a/workspace/heartbeats/design-review.md
+++ b/workspace/heartbeats/design-review.md
@@ -1,0 +1,22 @@
+# Weekly Design Review
+
+Perform a comprehensive review of the datacenter design artifacts. Run every Wednesday.
+
+## Tasks
+
+1. **Pull latest**: `cd ~/workspace/ai-datacenter-designer && git pull origin main`
+2. **Run design-consistency skill**: Check all 14 plans for cross-document consistency
+3. **Run model-review skill**: Review model_datacenter.py for code quality and plan alignment
+4. **Check viewer**: Read viewer.html and verify it references current plan structure
+5. **Identify improvement opportunities**: Pick the highest-impact issue found and create a plan
+6. **If actionable improvement found**:
+   - Create a feature branch: `design/<topic>`
+   - Make the fix (documentation update, code refactor, viewer enhancement)
+   - Commit and push
+   - Log what was done to memory
+7. **Log summary** to `memory/YYYY-MM-DD.md`:
+   - Consistency check results
+   - Model review results
+   - Any changes made
+   - Next week's priorities
+8. If nothing needs attention, reply `HEARTBEAT_OK`

--- a/workspace/heartbeats/memory-distill.md
+++ b/workspace/heartbeats/memory-distill.md
@@ -1,0 +1,20 @@
+# Memory Distillation
+
+Weekly cleanup of daily logs into curated long-term memory. Run every Sunday.
+
+## Tasks
+
+1. Read all `memory/YYYY-MM-DD.md` files from the past week
+2. Identify key themes:
+   - Design changes made and their rationale
+   - Consistency issues found and resolved
+   - Model improvements
+   - Viewer enhancements
+   - Lessons learned from design trade-offs
+3. Distill into concise entries for `MEMORY.md`:
+   - Add significant decisions to "Decisions & Preferences"
+   - Add new insights to "Lessons Learned"
+   - Update "Project Context" if design parameters changed
+   - Update "Key Constraints" if any thresholds were revised
+4. Do NOT delete daily log files — they serve as the audit trail
+5. If nothing meaningful to distill, reply `HEARTBEAT_OK`


### PR DESCRIPTION
## Summary

- Scaffolds the `dc-designer` agent sandbox — a **datacenter design engineer** for [shpeedle/ai-datacenter-designer](https://github.com/shpeedle/ai-datacenter-designer)
- Custom SOUL.md persona with power, cooling, network, structural, and phasing expertise
- MEMORY.md seeded with design parameters (50MW→200MW, PUE <1.10, ~20K GPUs) and repo structure
- Two custom skills: `design-consistency` (cross-document validation with 7 gates) and `model-review` (code quality audit)
- Two heartbeats: weekly design review (Wed 10am MT) and memory distillation (Sun 8pm MT)
- Port 8200 exposed in docker-compose for the interactive plan viewer
- `/setup` skill for one-command provisioning from the branch root
- Branch-specific CLAUDE.md and README.md replacing generic orchestrator docs

### Files Changed

| File | Purpose |
|------|---------|
| `AGENTS.md` (CLAUDE.md) | DC-designer-specific setup instructions, branch structure, lifecycle |
| `README.md` | User-facing quick setup guide with `/setup` one-liner |
| `.claude/skills/setup/SKILL.md` | Automates full provisioning from branch root |
| `docker/docker-compose.yml` | Add port 8200 mapping for viewer |
| `workspace/SOUL.md` | DC engineer persona, FreeCAD limitation, expertise areas |
| `workspace/MEMORY.md` | Seeded git workflow, design params, repo structure, constraints |
| `workspace/heartbeats.conf` | Weekly design review + memory distill schedules |
| `workspace/heartbeats/design-review.md` | Upstream sync, consistency check, model review, auto-fix |
| `workspace/heartbeats/memory-distill.md` | Weekly log distillation into MEMORY.md |
| `workspace/.claude/skills/design-consistency/SKILL.md` | 7-gate cross-document validation skill |
| `workspace/.claude/skills/model-review/SKILL.md` | Code quality + plan alignment review skill |

---

## Deploy to a Remote VM

### Prerequisites

- A VM (Ubuntu/Debian recommended) with **Docker** and **Docker Compose** installed
- **Git** with access to this repo
- **Claude Code** CLI installed on the VM (`npm install -g @anthropic-ai/claude-code`)
- Port **8200** open in firewall/security group (for the plan viewer)

### One-command setup (with Claude)

```bash
git clone https://github.com/ryaneggz/open-harness.git && cd open-harness
git checkout agent/dc-designer
claude
```

Then inside Claude:

```
/setup
```

Claude reads the branch-specific `CLAUDE.md`, runs the `/setup` skill, and provisions the full sandbox: builds the Docker image, starts the container, installs tools (Node 22, gh, Docker CLI, uv, Claude Code, Codex, Pi), clones the target repo, syncs heartbeats, and starts the viewer on port 8200.

### Manual setup (without Claude)

```bash
git clone https://github.com/ryaneggz/open-harness.git && cd open-harness
git checkout agent/dc-designer

# Build and start the container
docker build -f docker/Dockerfile -t dc-designer:latest .
NAME=dc-designer docker compose -f docker/docker-compose.yml -p dc-designer up -d

# Install tools inside the container
docker exec --user root dc-designer bash -c \
  'chmod +x /home/sandbox/install/*.sh && /home/sandbox/install/setup.sh --non-interactive'

# Clone the target project into the bind-mounted workspace
git clone https://github.com/shpeedle/ai-datacenter-designer.git workspace/ai-datacenter-designer

# Sync heartbeat schedules
docker exec --user sandbox dc-designer bash -c '/home/sandbox/install/heartbeat.sh sync'

# Start the viewer dev server
docker exec --user sandbox dc-designer bash --login -c \
  'cd ~/workspace/ai-datacenter-designer && nohup python3 -m http.server 8200 > /tmp/http-server.log 2>&1 &'
```

### Verify

```bash
# Container running
docker ps --filter "name=dc-designer"

# Viewer responding
curl -s -o /dev/null -w "%{http_code}" http://localhost:8200/viewer.html
# Expected: 200

# Heartbeats active
docker exec --user sandbox dc-designer /home/sandbox/install/heartbeat.sh status

# Claude CLI
docker exec --user sandbox dc-designer bash --login -c 'claude --version'
```

### Use the agent

```bash
# Enter the sandbox
docker exec -it --user sandbox dc-designer bash --login

# Start the agent
cd workspace && claude
```

The viewer is accessible at `http://<vm-ip>:8200/viewer.html`.

### Teardown

```bash
docker compose -f docker/docker-compose.yml -p dc-designer down --rmi local
```

## Test plan

- [ ] `git checkout agent/dc-designer` succeeds
- [ ] `/setup` skill provisions the full sandbox end-to-end
- [ ] Container `dc-designer` is running with port 8200 mapped
- [ ] `http://localhost:8200/viewer.html` returns HTTP 200
- [ ] `heartbeat.sh status` shows 2 schedules (design-review, memory-distill)
- [ ] `claude --version` returns inside the container
- [ ] SOUL.md, MEMORY.md, and both skills present in workspace
- [ ] `ai-datacenter-designer/` cloned with all 14 plan documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)