### PR TITLE
FROM feat/73-mwh-pr2 TO feat/71-mwh-pr1

### DIFF
--- a/packages/sandbox/src/__tests__/heartbeat-config.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-config.test.ts
@@ -19,8 +19,13 @@ const mockReaddirSync = vi.mocked(readdirSync);
 const mockReaddir = vi.mocked(readdir);
 const mockReadFile = vi.mocked(readFile);
 
-const { secondsToCron, parseFrontmatter, parseHeartbeatConfig, parseHeartbeatConfigAsync } =
-  await import("../lib/heartbeat/config.js");
+const {
+  secondsToCron,
+  parseFrontmatter,
+  parseHeartbeatConfig,
+  parseHeartbeatConfigAsync,
+  parseHeartbeatConfigAcrossRoots,
+} = await import("../lib/heartbeat/config.js");
 
 describe("secondsToCron", () => {
   it("returns * * * * * for 0 seconds", () => {
@@ -351,5 +356,59 @@ describe("parseHeartbeatConfigAsync", () => {
 
     const result = await parseHeartbeatConfigAsync(workspacePath, "codex");
     expect(result[0].agent).toBe("codex");
+  });
+});
+
+describe("parseHeartbeatConfigAcrossRoots", () => {
+  const rootA = {
+    workspacePath: "/tmp/a/workspace",
+    heartbeatDir: "/tmp/a/workspace/heartbeats",
+    label: "root-a",
+  };
+  const rootB = {
+    workspacePath: "/tmp/b/workspace",
+    heartbeatDir: "/tmp/b/workspace/heartbeats",
+    label: "root-b",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("merges entries from every root and tags them with their root", async () => {
+    mockExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      return s === rootA.heartbeatDir || s === rootB.heartbeatDir;
+    });
+    mockReaddir.mockImplementation((p) => {
+      const s = String(p);
+      if (s === rootA.heartbeatDir) return Promise.resolve(["ping.md"] as unknown as string[]);
+      if (s === rootB.heartbeatDir)
+        return Promise.resolve(["ping.md", "other.md"] as unknown as string[]);
+      return Promise.resolve([] as unknown as string[]);
+    });
+    mockReadFile.mockResolvedValue(`---\nschedule: "*/5 * * * *"\n---\n\n# x`);
+
+    const entries = await parseHeartbeatConfigAcrossRoots([rootA, rootB]);
+
+    expect(entries).toHaveLength(3);
+    expect(entries.filter((e) => e.root.label === "root-a")).toHaveLength(1);
+    expect(entries.filter((e) => e.root.label === "root-b")).toHaveLength(2);
+  });
+
+  it("returns empty array when all roots have no heartbeats/ and no legacy file", async () => {
+    mockExistsSync.mockReturnValue(false);
+    const entries = await parseHeartbeatConfigAcrossRoots([rootA, rootB]);
+    expect(entries).toEqual([]);
+  });
+
+  it("tolerates a root with a missing heartbeats/ alongside a root with entries", async () => {
+    mockExistsSync.mockImplementation((p) => String(p) === rootB.heartbeatDir);
+    mockReaddir.mockResolvedValue(["ping.md"] as unknown as string[]);
+    mockReadFile.mockResolvedValue(`---\nschedule: "*/5 * * * *"\n---\n`);
+
+    const entries = await parseHeartbeatConfigAcrossRoots([rootA, rootB]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].root.label).toBe("root-b");
   });
 });

--- a/packages/sandbox/src/__tests__/heartbeat-daemon.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-daemon.test.ts
@@ -47,6 +47,13 @@ vi.mock("../lib/heartbeat/scheduler.js", () => ({
   })),
 }));
 
+// Mock discovery so PR-4 tests can script what `rediscoverRoots()` sees on
+// each call without standing up a real git repo.
+const mockDiscoverWorkspaceRoots = vi.fn();
+vi.mock("../lib/heartbeat/discovery.js", () => ({
+  discoverWorkspaceRoots: (...args: unknown[]) => mockDiscoverWorkspaceRoots(...args),
+}));
+
 // ---------------------------------------------------------------------------
 // Dynamic import of the module under test
 // ---------------------------------------------------------------------------
@@ -81,6 +88,7 @@ beforeEach(async () => {
   mockReaddir.mockResolvedValue([]);
   mockReadFile.mockResolvedValue("");
   mockReadFileSync.mockReturnValue("");
+  mockDiscoverWorkspaceRoots.mockReturnValue([]);
 
   // Re-establish scheduler mock after clearAllMocks
   const { HeartbeatScheduler } = await import("../lib/heartbeat/scheduler.js");
@@ -526,6 +534,267 @@ describe("HeartbeatDaemon", () => {
 
       expect(out).not.toContain("Roots:");
       expect(out).toContain("0 0 * * *  →  nightly");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PR-4 — top-level `.git/worktrees/` watcher + rediscoverRoots()
+  // ---------------------------------------------------------------------------
+  describe("top-level worktrees watcher (PR-4)", () => {
+    const ROOT_A = {
+      workspacePath: "/tmp/a/workspace",
+      heartbeatDir: "/tmp/a/workspace/heartbeats",
+      label: "agent-foo",
+    };
+    const ROOT_B = {
+      workspacePath: "/tmp/b/workspace",
+      heartbeatDir: "/tmp/b/workspace/heartbeats",
+      label: "feat-bar",
+    };
+    const ROOT_C = {
+      workspacePath: "/tmp/c/workspace",
+      heartbeatDir: "/tmp/c/workspace/heartbeats",
+      label: "agent-baz",
+    };
+
+    it("does NOT install the top-level watcher for legacy single-root construction", async () => {
+      const fakeWatcher = createFakeWatcher();
+      mockWatch.mockReturnValue(fakeWatcher);
+
+      const daemon = new HeartbeatDaemon(DAEMON_OPTIONS);
+      await daemon.start();
+
+      // Only the heartbeat-dir watcher was created — no second `fs.watch`
+      // call for `.git/worktrees/`.
+      expect(mockWatch).toHaveBeenCalledTimes(1);
+      expect(mockWatch.mock.calls[0][0]).toBe(DAEMON_OPTIONS.heartbeatDir);
+
+      // Discovery must not have been consulted at all for a legacy daemon.
+      expect(mockDiscoverWorkspaceRoots).not.toHaveBeenCalled();
+
+      daemon.stop();
+    });
+
+    it("does NOT install the top-level watcher when multi-root opts omit `rediscover`", async () => {
+      const fakeWatcher = createFakeWatcher();
+      mockWatch.mockReturnValue(fakeWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+      });
+      await daemon.start();
+
+      expect(mockWatch).toHaveBeenCalledTimes(1);
+      expect(mockWatch).toHaveBeenCalledWith(
+        ROOT_A.heartbeatDir,
+        { persistent: false },
+        expect.any(Function),
+      );
+
+      daemon.stop();
+    });
+
+    it("installs a watcher on <home>/harness/.git/worktrees/ when `rediscover` is set", async () => {
+      // Return a distinct fake watcher per call so we can tell which is which.
+      const heartbeatWatcher = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(heartbeatWatcher).mockReturnValueOnce(worktreesWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      expect(mockWatch).toHaveBeenCalledTimes(2);
+      expect(mockWatch).toHaveBeenCalledWith(
+        "/fake/home/harness/.git/worktrees",
+        { persistent: false },
+        expect.any(Function),
+      );
+
+      daemon.stop();
+    });
+
+    it("skips the top-level watcher silently when `.git/worktrees/` does not exist", async () => {
+      // Heartbeat dir exists; worktrees dir does not.
+      mockExistsSync.mockImplementation((p) => {
+        if (String(p) === "/fake/home/harness/.git/worktrees") return false;
+        return true;
+      });
+
+      const heartbeatWatcher = createFakeWatcher();
+      mockWatch.mockReturnValue(heartbeatWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      // Only heartbeat-dir watcher — worktrees dir was missing so no watch.
+      expect(mockWatch).toHaveBeenCalledTimes(1);
+      expect(mockWatch.mock.calls[0][0]).toBe(ROOT_A.heartbeatDir);
+
+      daemon.stop();
+    });
+
+    it("rediscoverRoots() adds a new root: installs its watcher + picks up its entries", async () => {
+      const heartbeatWatcherA = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      const heartbeatWatcherC = createFakeWatcher();
+      mockWatch
+        .mockReturnValueOnce(heartbeatWatcherA) // root A heartbeat dir
+        .mockReturnValueOnce(worktreesWatcher) // .git/worktrees dir
+        .mockReturnValueOnce(heartbeatWatcherC); // root C heartbeat dir (post-rediscovery)
+
+      // Startup discovery would have returned [A]; the constructor accepts
+      // that via `workspaceRoots`. Prime the mock so the next `rediscover`
+      // call returns [A, C] — simulating `git worktree add` for C.
+      mockDiscoverWorkspaceRoots.mockReturnValue([ROOT_A, ROOT_C]);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home", rootsEnv: "OVERRIDE=x" },
+      });
+      await daemon.start();
+
+      // Fire the top-level watcher — capture the callback registered by
+      // the second `fs.watch` call (the worktrees one).
+      const worktreesCallback = mockWatch.mock.calls[1][2] as (
+        event: string,
+        filename: string,
+      ) => void;
+      worktreesCallback("rename", "new-worktree-dir");
+
+      // Advance past the 500ms debounce; rediscovery kicks off.
+      await vi.advanceTimersByTimeAsync(600);
+      // Flush pending microtasks from the async rediscoverRoots call chain.
+      await vi.runAllTimersAsync();
+
+      // Discovery was consulted with the same (home, rootsEnv) the CLI used.
+      expect(mockDiscoverWorkspaceRoots).toHaveBeenCalledWith("/fake/home", "OVERRIDE=x");
+
+      // A heartbeat-dir watcher was installed for the newly-added root C.
+      const watchCalls = mockWatch.mock.calls.map((c) => c[0]);
+      expect(watchCalls).toContain(ROOT_C.heartbeatDir);
+
+      // Scheduler.sync was called (differential re-sync after root changes).
+      expect(mockSchedulerSync).toHaveBeenCalled();
+
+      daemon.stop();
+    });
+
+    it("rediscoverRoots() removes a vanished root: closes its watcher + drops its logger entry", async () => {
+      const heartbeatWatcherA = createFakeWatcher();
+      const heartbeatWatcherB = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch
+        .mockReturnValueOnce(heartbeatWatcherA)
+        .mockReturnValueOnce(heartbeatWatcherB)
+        .mockReturnValueOnce(worktreesWatcher);
+
+      // Fresh discovery now returns only [A] — B vanished (e.g., `git worktree remove`).
+      mockDiscoverWorkspaceRoots.mockReturnValue([ROOT_A]);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A, ROOT_B],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      const worktreesCallback = mockWatch.mock.calls[2][2] as (
+        event: string,
+        filename: string,
+      ) => void;
+      worktreesCallback("rename", "removed-dir");
+
+      await vi.advanceTimersByTimeAsync(600);
+      await vi.runAllTimersAsync();
+
+      // Root B's heartbeat-dir watcher must have been closed.
+      expect(heartbeatWatcherB.close).toHaveBeenCalled();
+      // Root A's heartbeat-dir watcher must still be open.
+      expect(heartbeatWatcherA.close).not.toHaveBeenCalled();
+      // Scheduler was re-synced so it drops B's entries on next pass.
+      expect(mockSchedulerSync).toHaveBeenCalled();
+
+      daemon.stop();
+    });
+
+    it("rediscoverRoots() is a no-op when `rediscover` is unset", async () => {
+      const daemon = new HeartbeatDaemon(DAEMON_OPTIONS);
+      await daemon.start();
+
+      // Direct call — should return immediately and never consult discovery.
+      await daemon.rediscoverRoots();
+      expect(mockDiscoverWorkspaceRoots).not.toHaveBeenCalled();
+
+      daemon.stop();
+    });
+
+    it("stop() closes the top-level watcher too", async () => {
+      const heartbeatWatcher = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(heartbeatWatcher).mockReturnValueOnce(worktreesWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+      daemon.stop();
+
+      expect(heartbeatWatcher.close).toHaveBeenCalledOnce();
+      expect(worktreesWatcher.close).toHaveBeenCalledOnce();
+    });
+
+    it("debounces rapid top-level events into a single rediscovery", async () => {
+      const heartbeatWatcher = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(heartbeatWatcher).mockReturnValueOnce(worktreesWatcher);
+
+      mockDiscoverWorkspaceRoots.mockReturnValue([ROOT_A]);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      const worktreesCallback = mockWatch.mock.calls[1][2] as (
+        event: string,
+        filename: string,
+      ) => void;
+
+      // Burst — git emits multiple events during `worktree add`.
+      worktreesCallback("rename", "a");
+      worktreesCallback("rename", "b");
+      worktreesCallback("rename", "c");
+
+      await vi.advanceTimersByTimeAsync(600);
+      await vi.runAllTimersAsync();
+
+      // Discovery consulted exactly once despite three events.
+      expect(mockDiscoverWorkspaceRoots).toHaveBeenCalledTimes(1);
+
+      daemon.stop();
+    });
+
+    it("top-level watcher errors do not throw", async () => {
+      const heartbeatWatcher = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(heartbeatWatcher).mockReturnValueOnce(worktreesWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      expect(() => worktreesWatcher.emit("error", new Error("ENOSPC"))).not.toThrow();
+
+      daemon.stop();
     });
   });
 });

--- a/packages/sandbox/src/__tests__/heartbeat-daemon.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-daemon.test.ts
@@ -248,6 +248,138 @@ describe("HeartbeatDaemon", () => {
     });
   });
 
+  describe("multi-root watcher", () => {
+    it("starts one fs.watch per workspace root", async () => {
+      const watcherA = createFakeWatcher();
+      const watcherB = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(watcherA).mockReturnValueOnce(watcherB);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [
+          {
+            workspacePath: "/tmp/a/workspace",
+            heartbeatDir: "/tmp/a/workspace/heartbeats",
+            label: "agent-foo",
+          },
+          {
+            workspacePath: "/tmp/b/workspace",
+            heartbeatDir: "/tmp/b/workspace/heartbeats",
+            label: "feat-bar",
+          },
+        ],
+        defaultAgent: "claude",
+        defaultInterval: 1800,
+      });
+      await daemon.start();
+
+      expect(mockWatch).toHaveBeenCalledTimes(2);
+      expect(mockWatch).toHaveBeenCalledWith(
+        "/tmp/a/workspace/heartbeats",
+        { persistent: false },
+        expect.any(Function),
+      );
+      expect(mockWatch).toHaveBeenCalledWith(
+        "/tmp/b/workspace/heartbeats",
+        { persistent: false },
+        expect.any(Function),
+      );
+    });
+
+    it("closes every watcher on stop()", async () => {
+      const watcherA = createFakeWatcher();
+      const watcherB = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(watcherA).mockReturnValueOnce(watcherB);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [
+          {
+            workspacePath: "/tmp/a/workspace",
+            heartbeatDir: "/tmp/a/workspace/heartbeats",
+            label: "agent-foo",
+          },
+          {
+            workspacePath: "/tmp/b/workspace",
+            heartbeatDir: "/tmp/b/workspace/heartbeats",
+            label: "feat-bar",
+          },
+        ],
+      });
+      await daemon.start();
+      daemon.stop();
+
+      expect(watcherA.close).toHaveBeenCalledOnce();
+      expect(watcherB.close).toHaveBeenCalledOnce();
+    });
+
+    it("debounces events across roots into a single sync", async () => {
+      const watcherA = createFakeWatcher();
+      const watcherB = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(watcherA).mockReturnValueOnce(watcherB);
+
+      mockReaddir.mockResolvedValue(["test.md"]);
+      mockReadFile.mockResolvedValue(`---\nschedule: "*/5 * * * *"\n---\n`);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [
+          {
+            workspacePath: "/tmp/a/workspace",
+            heartbeatDir: "/tmp/a/workspace/heartbeats",
+            label: "agent-foo",
+          },
+          {
+            workspacePath: "/tmp/b/workspace",
+            heartbeatDir: "/tmp/b/workspace/heartbeats",
+            label: "feat-bar",
+          },
+        ],
+      });
+      await daemon.start();
+
+      const callbackA = mockWatch.mock.calls[0][2] as (event: string, filename: string) => void;
+      const callbackB = mockWatch.mock.calls[1][2] as (event: string, filename: string) => void;
+
+      // Each root parses once during start() — record baseline.
+      const callCountAfterStart = mockReaddir.mock.calls.length;
+
+      // Fire events from both roots rapidly — a single debounced sync must result.
+      callbackA("change", "a.md");
+      callbackB("change", "b.md");
+      callbackA("rename", "c.md");
+
+      await vi.advanceTimersByTimeAsync(600);
+
+      // A single sync() ran — re-parsing both roots once (2 readdir calls, one per root).
+      expect(mockReaddir.mock.calls.length).toBe(callCountAfterStart + 2);
+    });
+
+    it("skips roots whose heartbeatDir does not exist without aborting other roots", async () => {
+      const watcherA = createFakeWatcher();
+      mockWatch.mockReturnValue(watcherA);
+
+      // Only root A's dir exists.
+      mockExistsSync.mockImplementation((p) => String(p) === "/tmp/a/workspace/heartbeats");
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [
+          {
+            workspacePath: "/tmp/a/workspace",
+            heartbeatDir: "/tmp/a/workspace/heartbeats",
+            label: "agent-foo",
+          },
+          {
+            workspacePath: "/tmp/missing/workspace",
+            heartbeatDir: "/tmp/missing/workspace/heartbeats",
+            label: "missing",
+          },
+        ],
+      });
+      await daemon.start();
+
+      // Exactly one watcher started — the one whose dir exists.
+      expect(mockWatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("watcher error handling", () => {
     it("handles fs.watch errors gracefully", async () => {
       const fakeWatcher = createFakeWatcher();

--- a/packages/sandbox/src/__tests__/heartbeat-daemon.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-daemon.test.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from "node:events";
 // Mock node:fs — watch returns a controllable EventEmitter
 const mockWatch = vi.fn();
 const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn().mockReturnValue("");
 
 vi.mock("node:fs", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -15,7 +16,7 @@ vi.mock("node:fs", async (importOriginal) => {
     ...actual,
     existsSync: (...args: unknown[]) => mockExistsSync(...args),
     watch: (...args: unknown[]) => mockWatch(...args),
-    readFileSync: vi.fn().mockReturnValue(""),
+    readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
     writeFileSync: vi.fn(),
     mkdirSync: vi.fn(),
     appendFileSync: vi.fn(),
@@ -79,6 +80,7 @@ beforeEach(async () => {
   mockExistsSync.mockReturnValue(true);
   mockReaddir.mockResolvedValue([]);
   mockReadFile.mockResolvedValue("");
+  mockReadFileSync.mockReturnValue("");
 
   // Re-establish scheduler mock after clearAllMocks
   const { HeartbeatScheduler } = await import("../lib/heartbeat/scheduler.js");
@@ -400,6 +402,130 @@ describe("HeartbeatDaemon", () => {
       const daemon = new HeartbeatDaemon(DAEMON_OPTIONS);
       // Should not throw
       await expect(daemon.start()).resolves.not.toThrow();
+    });
+  });
+
+  describe("status()", () => {
+    /**
+     * Capture console.log output for one invocation so we can assert on
+     * the literal shape of the status report. The daemon emits everything
+     * via console.log (operators run this interactively), so stdout is
+     * the user contract we're protecting.
+     */
+    function captureStatus(fn: () => void): string {
+      const lines: string[] = [];
+      const spy = vi.spyOn(console, "log").mockImplementation((msg?: unknown) => {
+        lines.push(String(msg ?? ""));
+      });
+      try {
+        fn();
+      } finally {
+        spy.mockRestore();
+      }
+      return lines.join("\n");
+    }
+
+    it("renders legacy single-root format unchanged (no Roots: header, no label prefix, one log tail)", () => {
+      // Single-root (legacy) input — label implicitly "" via normalize().
+      mockSchedulerStatus.mockReturnValueOnce([
+        { name: "nightly-release", cronExpr: "50 23 * * *", nextRun: null, isRunning: true },
+        { name: "test-sys-metrics", cronExpr: "*/2 * * * *", nextRun: null, isRunning: true },
+      ]);
+
+      const daemon = new HeartbeatDaemon(DAEMON_OPTIONS);
+      const out = captureStatus(() => daemon.status());
+
+      // Must retain the exact pre-PR-3 contract: bare slug after `→`,
+      // existing scripts grep this format.
+      expect(out).toContain("Heartbeat daemon: running (pid");
+      expect(out).toContain("Heartbeat schedules: 2");
+      expect(out).toContain("50 23 * * *  →  nightly-release");
+      expect(out).toContain("*/2 * * * *  →  test-sys-metrics");
+
+      // No multi-root scaffolding leaks into single-root output.
+      expect(out).not.toContain("Roots:");
+      expect(out).not.toContain("Recent log (parent):");
+      expect(out).not.toMatch(/::/); // no label::slug names
+    });
+
+    it("renders multi-root status with Roots: section, namespaced schedules, and per-root log tails", () => {
+      mockSchedulerStatus.mockReturnValueOnce([
+        {
+          name: "parent::nightly-release",
+          cronExpr: "50 23 * * *",
+          nextRun: null,
+          isRunning: true,
+        },
+        {
+          name: "sdr-pallet::morning-pipeline",
+          cronExpr: "0 13 * * 1-5",
+          nextRun: null,
+          isRunning: true,
+        },
+        {
+          name: "sdr-pallet::stuck-lead-sweep",
+          cronExpr: "0 15 * * 1-5",
+          nextRun: null,
+          isRunning: true,
+        },
+      ]);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [
+          {
+            workspacePath: "/home/sandbox/harness/workspace",
+            heartbeatDir: "/home/sandbox/harness/workspace/heartbeats",
+            label: "parent",
+          },
+          {
+            workspacePath: "/home/sandbox/harness/.worktrees/agent/sdr-pallet/workspace",
+            heartbeatDir: "/home/sandbox/harness/.worktrees/agent/sdr-pallet/workspace/heartbeats",
+            label: "sdr-pallet",
+          },
+        ],
+        defaultAgent: "claude",
+        defaultInterval: 1800,
+      });
+
+      const out = captureStatus(() => daemon.status());
+
+      expect(out).toContain("Heartbeat daemon: running (pid");
+      expect(out).toContain("Roots:");
+      // Each root is announced with its workspace path and schedule count.
+      expect(out).toMatch(/parent\s+→\s+\/home\/sandbox\/harness\/workspace \(1 schedule\)/);
+      expect(out).toMatch(/sdr-pallet\s+→\s+.*sdr-pallet\/workspace \(2 schedules\)/);
+      // Composite names preserved in the Schedules: section.
+      expect(out).toContain("parent::nightly-release");
+      expect(out).toContain("sdr-pallet::morning-pipeline");
+      // Per-root log tails, one heading per root — mocked fs returns "" so
+      // no log body lines appear, but absence of `Recent log (...)` would
+      // prove we regressed to single-tail output. We assert at least that
+      // the single-tail heading is NOT present in multi-root.
+      expect(out).not.toContain("\nRecent log:\n");
+    });
+
+    it("single-root with empty label stays in legacy format even when constructed via workspaceRoots", () => {
+      // Operators (or future code) could plausibly pass a one-element
+      // `workspaceRoots` with label "" — should still render the legacy
+      // layout because the multi-root flag is label-driven, not
+      // array-length driven.
+      mockSchedulerStatus.mockReturnValueOnce([
+        { name: "nightly", cronExpr: "0 0 * * *", nextRun: null, isRunning: true },
+      ]);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [
+          {
+            workspacePath: "/tmp/workspace",
+            heartbeatDir: "/tmp/workspace/heartbeats",
+            label: "",
+          },
+        ],
+      });
+      const out = captureStatus(() => daemon.status());
+
+      expect(out).not.toContain("Roots:");
+      expect(out).toContain("0 0 * * *  →  nightly");
     });
   });
 });

--- a/packages/sandbox/src/__tests__/heartbeat-discovery.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-discovery.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { discoverWorkspaceRoots, sanitizeBranch } from "../lib/heartbeat/discovery.js";
+
+// ---------------------------------------------------------------------------
+// Helpers: build a real, throwaway multi-worktree git repo on disk so we can
+// exercise `git worktree list --porcelain` end-to-end (no parsing mocks).
+// ---------------------------------------------------------------------------
+
+function run(cwd: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+}
+
+function mkHeartbeatsDir(workspacePath: string): void {
+  const heartbeatsDir = path.join(workspacePath, "heartbeats");
+  mkdirSync(heartbeatsDir, { recursive: true });
+  writeFileSync(path.join(heartbeatsDir, "ping.md"), `---\nschedule: "*/5 * * * *"\n---\n\nping\n`);
+}
+
+describe("sanitizeBranch", () => {
+  it("strips refs/heads/ and lowercases", () => {
+    expect(sanitizeBranch("refs/heads/Main", null)).toBe("main");
+  });
+
+  it("replaces / with -", () => {
+    expect(sanitizeBranch("refs/heads/agent/sdr-pallet", null)).toBe("agent-sdr-pallet");
+  });
+
+  it("handles plain branch names without refs/heads prefix", () => {
+    expect(sanitizeBranch("feat/foo", null)).toBe("feat-foo");
+  });
+
+  it("returns detached-<shortsha> for null branch + sha", () => {
+    expect(sanitizeBranch(null, "abcdef0123456789")).toBe("detached-abcdef0");
+  });
+
+  it("returns 'detached' for null branch + null sha", () => {
+    expect(sanitizeBranch(null, null)).toBe("detached");
+  });
+});
+
+describe("discoverWorkspaceRoots", () => {
+  let fakeHome: string;
+  let harnessDir: string;
+
+  beforeEach(() => {
+    // Create a scratch HOME with a `harness/` git repo inside, plus two
+    // sibling worktrees. The repo layout mirrors the real one so the
+    // porcelain output matches production shape.
+    fakeHome = mkdtempSync(path.join(tmpdir(), "heartbeat-discovery-test-"));
+    harnessDir = path.join(fakeHome, "harness");
+    mkdirSync(harnessDir, { recursive: true });
+
+    // Initialize bare-bones git repo on `main` with one commit so worktrees can branch off it.
+    run(harnessDir, "init", "-q", "-b", "main");
+    run(harnessDir, "config", "user.email", "test@example.com");
+    run(harnessDir, "config", "user.name", "Test");
+    run(harnessDir, "config", "commit.gpgsign", "false");
+    writeFileSync(path.join(harnessDir, "README.md"), "hello\n");
+    run(harnessDir, "add", "README.md");
+    run(harnessDir, "commit", "-q", "-m", "init");
+
+    // Parent checkout has its own workspace/heartbeats/.
+    mkHeartbeatsDir(path.join(harnessDir, "workspace"));
+
+    // Worktree #1: agent/sdr-pallet — with heartbeats dir.
+    const wt1 = path.join(harnessDir, ".worktrees", "agent", "sdr-pallet");
+    run(harnessDir, "worktree", "add", "-q", "-b", "agent/sdr-pallet", wt1);
+    mkHeartbeatsDir(path.join(wt1, "workspace"));
+
+    // Worktree #2: feat/foo — with heartbeats dir.
+    const wt2 = path.join(harnessDir, ".worktrees", "feat", "foo");
+    run(harnessDir, "worktree", "add", "-q", "-b", "feat/foo", wt2);
+    mkHeartbeatsDir(path.join(wt2, "workspace"));
+
+    // Worktree #3: no heartbeats dir — should be skipped.
+    const wt3 = path.join(harnessDir, ".worktrees", "no-heartbeats");
+    run(harnessDir, "worktree", "add", "-q", "-b", "no-heartbeats", wt3);
+    // (intentionally no mkHeartbeatsDir)
+  });
+
+  afterEach(() => {
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it("discovers every worktree that has a workspace/heartbeats/ directory", () => {
+    const roots = discoverWorkspaceRoots(fakeHome);
+
+    const labels = roots.map((r) => r.label).sort();
+    expect(labels).toEqual(["agent-sdr-pallet", "feat-foo", "main"]);
+  });
+
+  it("sets each root's workspacePath to <worktree>/workspace", () => {
+    const roots = discoverWorkspaceRoots(fakeHome);
+
+    for (const root of roots) {
+      expect(root.workspacePath.endsWith("/workspace")).toBe(true);
+      expect(root.heartbeatDir).toBe(path.join(root.workspacePath, "heartbeats"));
+    }
+  });
+
+  it("skips worktrees whose workspace/heartbeats/ does not exist", () => {
+    const roots = discoverWorkspaceRoots(fakeHome);
+    expect(roots.find((r) => r.label === "no-heartbeats")).toBeUndefined();
+  });
+
+  it("returns empty array when $HOME/harness is not a git repo", () => {
+    const nonRepoHome = mkdtempSync(path.join(tmpdir(), "heartbeat-discovery-empty-"));
+    try {
+      mkdirSync(path.join(nonRepoHome, "harness"), { recursive: true });
+      const roots = discoverWorkspaceRoots(nonRepoHome);
+      expect(roots).toEqual([]);
+    } finally {
+      rmSync(nonRepoHome, { recursive: true, force: true });
+    }
+  });
+
+  it("applies HEARTBEAT_ROOTS overrides and merges them into discovery", () => {
+    // Create a custom path outside the git worktree tree.
+    const customWorkspace = path.join(fakeHome, "custom", "workspace");
+    mkdirSync(path.join(customWorkspace, "heartbeats"), { recursive: true });
+
+    const overrides = `${customWorkspace}:custom-root`;
+    const roots = discoverWorkspaceRoots(fakeHome, overrides);
+
+    const labels = roots.map((r) => r.label).sort();
+    expect(labels).toContain("custom-root");
+    expect(labels).toContain("agent-sdr-pallet");
+    expect(labels).toContain("main");
+  });
+
+  it("override wins on path collision with auto-discovery", () => {
+    const parentWorkspace = path.join(harnessDir, "workspace");
+    const overrides = `${parentWorkspace}:forced-label`;
+    const roots = discoverWorkspaceRoots(fakeHome, overrides);
+
+    // Only one entry for parentWorkspace should exist, and its label must be
+    // the override's.
+    const parents = roots.filter((r) => r.workspacePath === parentWorkspace);
+    expect(parents).toHaveLength(1);
+    expect(parents[0].label).toBe("forced-label");
+  });
+
+  it("ignores malformed HEARTBEAT_ROOTS entries without crashing", () => {
+    const overrides = `,:,bad-no-label:,/tmp:, `;
+    expect(() => discoverWorkspaceRoots(fakeHome, overrides)).not.toThrow();
+    const roots = discoverWorkspaceRoots(fakeHome, overrides);
+    // Should still include auto-discovered roots.
+    expect(roots.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/sandbox/src/__tests__/heartbeat-logger.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-logger.test.ts
@@ -157,6 +157,58 @@ describe("HeartbeatLogger", () => {
     });
   });
 
+  describe("multiple instances", () => {
+    it("two loggers at different paths write to their own files independently", () => {
+      // Each instance is a pure wrapper around a path — verify that
+      // independent instances produce independent appendFileSync calls
+      // with the path they were constructed with. This is the invariant
+      // PR-3 relies on for per-root log routing.
+      const pathA = "/tmp/root-a/heartbeats/heartbeat.log";
+      const pathB = "/tmp/root-b/heartbeats/heartbeat.log";
+
+      const loggerA = new HeartbeatLogger(pathA);
+      const loggerB = new HeartbeatLogger(pathB);
+
+      loggerA.log("from A");
+      loggerB.log("from B");
+      loggerA.log("from A again");
+
+      expect(mockAppendFileSync).toHaveBeenCalledTimes(3);
+
+      const calls = mockAppendFileSync.mock.calls as Array<[string, string]>;
+      // Call 0 → pathA with "from A"; call 1 → pathB with "from B"; call 2 → pathA with "from A again".
+      expect(calls[0][0]).toBe(pathA);
+      expect(calls[0][1]).toContain("from A");
+      expect(calls[1][0]).toBe(pathB);
+      expect(calls[1][1]).toContain("from B");
+      expect(calls[2][0]).toBe(pathA);
+      expect(calls[2][1]).toContain("from A again");
+    });
+
+    it("each logger caches its own dir-existence flag independently", () => {
+      // First log() call per logger checks existsSync once; further calls
+      // on the same instance skip the check. Instances must not share
+      // that cache — otherwise the second logger would think its dir
+      // exists when it might not.
+      mockExistsSync.mockReturnValue(true);
+
+      const loggerA = new HeartbeatLogger("/tmp/a/heartbeats/heartbeat.log");
+      const loggerB = new HeartbeatLogger("/tmp/b/heartbeats/heartbeat.log");
+
+      loggerA.log("first A");
+      expect(mockExistsSync).toHaveBeenCalledTimes(1);
+
+      mockExistsSync.mockClear();
+      loggerB.log("first B");
+      expect(mockExistsSync).toHaveBeenCalledTimes(1);
+
+      mockExistsSync.mockClear();
+      loggerA.log("second A");
+      loggerB.log("second B");
+      expect(mockExistsSync).not.toHaveBeenCalled();
+    });
+  });
+
   describe("tail()", () => {
     it("returns last n lines from log file (default 10)", () => {
       const lines = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`);

--- a/packages/sandbox/src/__tests__/heartbeat-runner.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-runner.test.ts
@@ -523,6 +523,179 @@ describe("HeartbeatRunner", () => {
     });
   });
 
+  describe("multi-root cwd", () => {
+    it("passes cwd = entry.root.workspacePath to spawn when the root has a non-empty label", async () => {
+      const proc = makeChildProcess("HEARTBEAT_OK", 0);
+      mockSpawn.mockReturnValue(proc);
+      mockIsHeartbeatOk.mockReturnValue(true);
+
+      const runner = new HeartbeatRunner({
+        workspacePath,
+        heartbeatDir,
+        soulFile,
+      });
+      vi.spyOn(runner.getLogger(), "log").mockImplementation(() => {});
+      vi.spyOn(runner.getLogger(), "rotate").mockImplementation(() => {});
+
+      // Build an entry whose root is labelled (discovered worktree).
+      // Use the real tmp workspace so readFileSync for the heartbeat file
+      // still succeeds.
+      const discoveredRoot: WorkspaceRoot = {
+        workspacePath,
+        heartbeatDir,
+        soulFile,
+        label: "agent-sdr-pallet",
+      };
+      await runner.run(makeEntry({ root: discoveredRoot }));
+
+      expect(mockSpawn).toHaveBeenCalledOnce();
+      const spawnOptions = mockSpawn.mock.calls[0][2] as { cwd?: string };
+      expect(spawnOptions.cwd).toBe(workspacePath);
+    });
+
+    it("does NOT pass cwd for single-root (empty label) back-compat", async () => {
+      const proc = makeChildProcess("HEARTBEAT_OK", 0);
+      mockSpawn.mockReturnValue(proc);
+      mockIsHeartbeatOk.mockReturnValue(true);
+
+      const runner = new HeartbeatRunner({
+        workspacePath,
+        heartbeatDir,
+        soulFile,
+      });
+      vi.spyOn(runner.getLogger(), "log").mockImplementation(() => {});
+      vi.spyOn(runner.getLogger(), "rotate").mockImplementation(() => {});
+
+      // defaultRoot has label: "" — single-root back-compat.
+      await runner.run(makeEntry());
+
+      expect(mockSpawn).toHaveBeenCalledOnce();
+      const spawnOptions = mockSpawn.mock.calls[0][2] as { cwd?: string };
+      expect(spawnOptions.cwd).toBeUndefined();
+    });
+
+    it("allows same entry name in two roots to run concurrently (per-root guard)", async () => {
+      // Two roots, same entry filename.
+      const rootA: WorkspaceRoot = {
+        workspacePath,
+        heartbeatDir,
+        soulFile,
+        label: "root-a",
+      };
+      const rootB: WorkspaceRoot = {
+        workspacePath,
+        heartbeatDir,
+        soulFile,
+        label: "root-b",
+      };
+
+      const runner = new HeartbeatRunner({
+        workspacePath,
+        heartbeatDir,
+        soulFile,
+      });
+      vi.spyOn(runner.getLogger(), "log").mockImplementation(() => {});
+      vi.spyOn(runner.getLogger(), "rotate").mockImplementation(() => {});
+
+      // Pre-populate the guard set with rootA's composite key to simulate an
+      // in-flight run. RootB's composite key is distinct, so it must still
+      // reach spawn.
+      const runningSet = (runner as unknown as { running: Set<string> }).running;
+      runningSet.add(`root-a::${ENTRY_BASENAME}`);
+
+      const proc = makeChildProcess("HEARTBEAT_OK", 0);
+      mockSpawn.mockReturnValue(proc);
+      mockIsHeartbeatOk.mockReturnValue(true);
+
+      await runner.run(makeEntry({ root: rootB }));
+
+      expect(mockSpawn).toHaveBeenCalledOnce();
+
+      runningSet.delete(`root-a::${ENTRY_BASENAME}`);
+    });
+  });
+
+  describe("global concurrency cap", () => {
+    it("skips execution with a log when no slot is available and the wait expires", async () => {
+      vi.useFakeTimers();
+      try {
+        const runner = new HeartbeatRunner({
+          workspacePath,
+          heartbeatDir,
+          soulFile,
+          maxConcurrent: 1,
+        });
+        // Saturate the semaphore: simulate one already-running slot.
+        (runner as unknown as { active: number }).active = 1;
+
+        const logSpy = vi.spyOn(runner.getLogger(), "log").mockImplementation(() => {});
+        vi.spyOn(runner.getLogger(), "rotate").mockImplementation(() => {});
+
+        const runPromise = runner.run(makeEntry());
+        // Advance past the 300s waiter timeout to force the "cap reached"
+        // branch.
+        await vi.advanceTimersByTimeAsync(300_001);
+        await runPromise;
+
+        expect(mockSpawn).not.toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+          expect.stringContaining("Skipped (concurrency cap reached)"),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("maxConcurrent=0 disables the cap (legacy unlimited behavior)", async () => {
+      const runner = new HeartbeatRunner({
+        workspacePath,
+        heartbeatDir,
+        soulFile,
+        maxConcurrent: 0,
+      });
+      // Even with many simulated "active" runs, a zero-cap runner must still spawn.
+      (runner as unknown as { active: number }).active = 999;
+
+      const proc = makeChildProcess("HEARTBEAT_OK", 0);
+      mockSpawn.mockReturnValue(proc);
+      mockIsHeartbeatOk.mockReturnValue(true);
+      vi.spyOn(runner.getLogger(), "log").mockImplementation(() => {});
+      vi.spyOn(runner.getLogger(), "rotate").mockImplementation(() => {});
+
+      await runner.run(makeEntry());
+
+      expect(mockSpawn).toHaveBeenCalledOnce();
+    });
+
+    it("releases the slot after run completes so the next entry can acquire", async () => {
+      const runner = new HeartbeatRunner({
+        workspacePath,
+        heartbeatDir,
+        soulFile,
+        maxConcurrent: 1,
+      });
+      vi.spyOn(runner.getLogger(), "log").mockImplementation(() => {});
+      vi.spyOn(runner.getLogger(), "rotate").mockImplementation(() => {});
+
+      mockIsHeartbeatOk.mockReturnValue(true);
+
+      // Need matching heartbeat files on disk for each run's readFileSync.
+      writeFileSync(join(workspacePath, "a.md"), "do a thing\n");
+      writeFileSync(join(workspacePath, "b.md"), "do another thing\n");
+
+      // First run acquires the sole slot, spawns, completes, releases.
+      mockSpawn.mockReturnValueOnce(makeChildProcess("HEARTBEAT_OK", 0));
+      await runner.run(makeEntry({ filePath: "a.md" }));
+
+      mockSpawn.mockReturnValueOnce(makeChildProcess("HEARTBEAT_OK", 0));
+      await runner.run(makeEntry({ filePath: "b.md" }));
+
+      // Both runs reached spawn → slot was correctly released between them.
+      expect(mockSpawn).toHaveBeenCalledTimes(2);
+      expect((runner as unknown as { active: number }).active).toBe(0);
+    });
+  });
+
   describe("lifecycle", () => {
     it("clears running guard in finally block even when an error occurs", async () => {
       // Make spawn throw an error

--- a/packages/sandbox/src/__tests__/heartbeat-scheduler.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-scheduler.test.ts
@@ -24,6 +24,7 @@ vi.mock("croner", () => ({
 const mockRunnerRun = vi.fn().mockResolvedValue(undefined);
 const mockLoggerLog = vi.fn();
 const mockGetLogger = vi.fn();
+const mockGetLoggerFor = vi.fn();
 
 vi.mock("../lib/heartbeat/runner.js", () => ({
   HeartbeatRunner: vi.fn(),
@@ -76,11 +77,13 @@ beforeEach(() => {
   mockRunnerRun.mockResolvedValue(undefined);
 
   // Restore HeartbeatRunner constructor mock
+  mockGetLoggerFor.mockReturnValue({ log: mockLoggerLog });
   vi.mocked(HeartbeatRunner).mockImplementation(
     () =>
       ({
         run: mockRunnerRun,
         getLogger: mockGetLogger,
+        getLoggerFor: mockGetLoggerFor,
       }) as unknown as InstanceType<typeof HeartbeatRunner>,
   );
 
@@ -227,6 +230,7 @@ describe("HeartbeatScheduler", () => {
 
       vi.clearAllMocks();
       mockGetLogger.mockReturnValue({ log: mockLoggerLog });
+      mockGetLoggerFor.mockReturnValue({ log: mockLoggerLog });
 
       scheduler.stop();
 
@@ -248,6 +252,7 @@ describe("HeartbeatScheduler", () => {
 
       vi.clearAllMocks();
       mockGetLogger.mockReturnValue({ log: mockLoggerLog });
+      mockGetLoggerFor.mockReturnValue({ log: mockLoggerLog });
 
       // Restore MockCron constructor mock after clearAllMocks
       MockCron.mockImplementation((pattern: string, callback: () => Promise<void>) => {
@@ -287,6 +292,7 @@ describe("HeartbeatScheduler", () => {
 
       vi.clearAllMocks();
       mockGetLogger.mockReturnValue({ log: mockLoggerLog });
+      mockGetLoggerFor.mockReturnValue({ log: mockLoggerLog });
 
       // Sync with identical entry — should be a no-op
       scheduler.sync([makeEntry({ filePath: "stable.md", cronExpr: "*/5 * * * *" })]);
@@ -305,6 +311,7 @@ describe("HeartbeatScheduler", () => {
 
       vi.clearAllMocks();
       mockGetLogger.mockReturnValue({ log: mockLoggerLog });
+      mockGetLoggerFor.mockReturnValue({ log: mockLoggerLog });
       MockCron.mockImplementation((pattern: string, callback: () => Promise<void>) => {
         lastCronCallback = callback;
         mockCronGetPattern.mockReturnValue(pattern);
@@ -337,6 +344,7 @@ describe("HeartbeatScheduler", () => {
 
       vi.clearAllMocks();
       mockGetLogger.mockReturnValue({ log: mockLoggerLog });
+      mockGetLoggerFor.mockReturnValue({ log: mockLoggerLog });
       MockCron.mockImplementation((pattern: string, callback: () => Promise<void>) => {
         lastCronCallback = callback;
         mockCronGetPattern.mockReturnValue(pattern);
@@ -399,6 +407,7 @@ describe("HeartbeatScheduler", () => {
 
       vi.clearAllMocks();
       mockGetLogger.mockReturnValue({ log: mockLoggerLog });
+      mockGetLoggerFor.mockReturnValue({ log: mockLoggerLog });
       MockCron.mockImplementation((pattern: string, callback: () => Promise<void>) => {
         lastCronCallback = callback;
         mockCronGetPattern.mockReturnValue(pattern);
@@ -429,6 +438,7 @@ describe("HeartbeatScheduler", () => {
 
       vi.clearAllMocks();
       mockGetLogger.mockReturnValue({ log: mockLoggerLog });
+      mockGetLoggerFor.mockReturnValue({ log: mockLoggerLog });
 
       scheduler.sync([
         makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_A }),

--- a/packages/sandbox/src/__tests__/heartbeat-scheduler.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-scheduler.test.ts
@@ -355,6 +355,91 @@ describe("HeartbeatScheduler", () => {
     });
   });
 
+  describe("multi-root namespacing", () => {
+    const ROOT_A: WorkspaceRoot = {
+      workspacePath: "/tmp/worktrees/agent/sdr-pallet/workspace",
+      heartbeatDir: "/tmp/worktrees/agent/sdr-pallet/workspace/heartbeats",
+      label: "agent-sdr-pallet",
+    };
+    const ROOT_B: WorkspaceRoot = {
+      workspacePath: "/tmp/worktrees/feat/foo/workspace",
+      heartbeatDir: "/tmp/worktrees/feat/foo/workspace/heartbeats",
+      label: "feat-foo",
+    };
+
+    it("schedules same-filename entries from two roots as independent jobs", () => {
+      const scheduler = new HeartbeatScheduler(RUNNER_OPTIONS);
+      const entries = [
+        makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_A }),
+        makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_B }),
+      ];
+
+      scheduler.start(entries);
+
+      // Two separate Cron instances — same filename but different labels.
+      expect(MockCron).toHaveBeenCalledTimes(2);
+      expect(scheduler.status()).toHaveLength(2);
+    });
+
+    it("derives composite `${label}::${slug}` name for multi-root entries", () => {
+      const scheduler = new HeartbeatScheduler(RUNNER_OPTIONS);
+      scheduler.start([makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_A })]);
+
+      expect(mockLoggerLog).toHaveBeenCalledWith(
+        expect.stringContaining("agent-sdr-pallet::heartbeats-ping"),
+      );
+    });
+
+    it("removing one root's entry does not stop another root's", () => {
+      const scheduler = new HeartbeatScheduler(RUNNER_OPTIONS);
+      scheduler.start([
+        makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_A }),
+        makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_B }),
+      ]);
+
+      vi.clearAllMocks();
+      mockGetLogger.mockReturnValue({ log: mockLoggerLog });
+      MockCron.mockImplementation((pattern: string, callback: () => Promise<void>) => {
+        lastCronCallback = callback;
+        mockCronGetPattern.mockReturnValue(pattern);
+        return {
+          stop: mockCronStop,
+          nextRun: mockCronNextRun,
+          isRunning: mockCronIsRunning,
+          getPattern: mockCronGetPattern,
+        };
+      });
+
+      // Drop ROOT_A's entry; keep ROOT_B's unchanged.
+      scheduler.sync([makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_B })]);
+
+      // Exactly one job stopped (A), no new jobs created (B unchanged).
+      expect(mockCronStop).toHaveBeenCalledTimes(1);
+      expect(MockCron).not.toHaveBeenCalled();
+      expect(scheduler.status()).toHaveLength(1);
+    });
+
+    it("unchanged multi-root entries are not recreated on sync (differential)", () => {
+      const scheduler = new HeartbeatScheduler(RUNNER_OPTIONS);
+      const initial = [
+        makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_A }),
+        makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_B }),
+      ];
+      scheduler.start(initial);
+
+      vi.clearAllMocks();
+      mockGetLogger.mockReturnValue({ log: mockLoggerLog });
+
+      scheduler.sync([
+        makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_A }),
+        makeEntry({ filePath: "heartbeats/ping.md", root: ROOT_B }),
+      ]);
+
+      expect(mockCronStop).not.toHaveBeenCalled();
+      expect(MockCron).not.toHaveBeenCalled();
+    });
+  });
+
   describe("status()", () => {
     it("returns an entry for each scheduled job", () => {
       const scheduler = new HeartbeatScheduler(RUNNER_OPTIONS);

--- a/packages/sandbox/src/cli/heartbeat-daemon.ts
+++ b/packages/sandbox/src/cli/heartbeat-daemon.ts
@@ -21,6 +21,13 @@ const daemon = discovered.length
       workspaceRoots: discovered,
       defaultAgent: process.env.HEARTBEAT_AGENT ?? "claude",
       defaultInterval: parseInt(process.env.HEARTBEAT_INTERVAL ?? "1800", 10),
+      // PR-4 — enable hot worktree add/remove. The daemon watches
+      // `<HOME>/harness/.git/worktrees/` and re-runs the same discovery
+      // call (with the same overrides) whenever git mutates that dir.
+      rediscover: {
+        home: HOME,
+        rootsEnv: process.env.HEARTBEAT_ROOTS,
+      },
     })
   : new HeartbeatDaemon({
       workspacePath: WORKSPACE,

--- a/packages/sandbox/src/cli/heartbeat-daemon.ts
+++ b/packages/sandbox/src/cli/heartbeat-daemon.ts
@@ -1,19 +1,35 @@
 #!/usr/bin/env node
 
 import { HeartbeatDaemon } from "../lib/heartbeat/index.js";
+import { discoverWorkspaceRoots } from "../lib/heartbeat/discovery.js";
 import { join } from "node:path";
 
 const HOME = process.env.HOME ?? "/home/sandbox";
 const WORKSPACE = join(HOME, "harness/workspace");
 
-const daemon = new HeartbeatDaemon({
-  workspacePath: WORKSPACE,
-  heartbeatDir: join(WORKSPACE, "heartbeats"),
-  soulFile: process.env.SOUL_FILE ?? join(WORKSPACE, "SOUL.md"),
-  memoryDir: process.env.MEMORY_DIR ?? join(WORKSPACE, "memory"),
-  defaultAgent: process.env.HEARTBEAT_AGENT ?? "claude",
-  defaultInterval: parseInt(process.env.HEARTBEAT_INTERVAL ?? "1800", 10),
-});
+// Multi-root discovery: find every git worktree under `$HOME/harness` that
+// has a `workspace/heartbeats/` directory, then augment/override with any
+// paths specified via the HEARTBEAT_ROOTS env var.
+//
+// If discovery returns zero roots (e.g. `.git/worktrees/` doesn't exist or
+// git isn't available), fall back to the legacy single-root behaviour so a
+// fresh sandbox with just `$HOME/harness/workspace/` still works.
+const discovered = discoverWorkspaceRoots(HOME, process.env.HEARTBEAT_ROOTS);
+
+const daemon = discovered.length
+  ? new HeartbeatDaemon({
+      workspaceRoots: discovered,
+      defaultAgent: process.env.HEARTBEAT_AGENT ?? "claude",
+      defaultInterval: parseInt(process.env.HEARTBEAT_INTERVAL ?? "1800", 10),
+    })
+  : new HeartbeatDaemon({
+      workspacePath: WORKSPACE,
+      heartbeatDir: join(WORKSPACE, "heartbeats"),
+      soulFile: process.env.SOUL_FILE ?? join(WORKSPACE, "SOUL.md"),
+      memoryDir: process.env.MEMORY_DIR ?? join(WORKSPACE, "memory"),
+      defaultAgent: process.env.HEARTBEAT_AGENT ?? "claude",
+      defaultInterval: parseInt(process.env.HEARTBEAT_INTERVAL ?? "1800", 10),
+    });
 
 const command = process.argv[2] ?? "start";
 

--- a/packages/sandbox/src/lib/heartbeat/config.ts
+++ b/packages/sandbox/src/lib/heartbeat/config.ts
@@ -178,6 +178,23 @@ export async function parseHeartbeatConfigAsync(
   return [];
 }
 
+/**
+ * Parse heartbeat config across N roots concurrently and concatenate the
+ * results in root order. The scheduler treats each returned entry as
+ * namespaced by `entry.root.label`, so cross-root filename collisions are
+ * fine — they produce distinct composite keys.
+ */
+export async function parseHeartbeatConfigAcrossRoots(
+  roots: WorkspaceRoot[],
+  defaultAgent = "claude",
+  defaultInterval = 1800,
+): Promise<HeartbeatEntry[]> {
+  const groups = await Promise.all(
+    roots.map((root) => parseHeartbeatConfigAsync(root, defaultAgent, defaultInterval)),
+  );
+  return groups.flat();
+}
+
 // ---------------------------------------------------------------------------
 // Internal
 // ---------------------------------------------------------------------------

--- a/packages/sandbox/src/lib/heartbeat/daemon.ts
+++ b/packages/sandbox/src/lib/heartbeat/daemon.ts
@@ -80,7 +80,13 @@ function normalize(opts: DaemonOptions): NormalizedDaemonOptions {
 
 export class HeartbeatDaemon {
   private scheduler: HeartbeatScheduler;
-  private logger: HeartbeatLogger;
+  /**
+   * Per-root loggers keyed by `root.label`. Single-root deployments hold
+   * exactly one entry keyed by `""` pointing at the legacy
+   * `<heartbeatDir>/heartbeat.log` path, so existing consumers see no
+   * behavioural change.
+   */
+  private loggers: Map<string, HeartbeatLogger>;
   /** One watcher per root — all fire the same debounced sync. */
   private watchers: FSWatcher[] = [];
   private watchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -92,21 +98,30 @@ export class HeartbeatDaemon {
     this.normalized = normalize(options);
     this.primaryRoot = this.normalized.roots[0];
 
+    // Build one logger per root so each worktree's heartbeat events land in
+    // its own `heartbeats/heartbeat.log`. Keyed on `root.label` to match
+    // `entry.root.label` at run time (scheduler and runner both look up
+    // through this same keying).
+    this.loggers = new Map();
+    for (const root of this.normalized.roots) {
+      this.loggers.set(root.label, new HeartbeatLogger(join(root.heartbeatDir, "heartbeat.log")));
+    }
+
     const runnerOpts: RunnerOptions = {
       workspacePath: this.primaryRoot.workspacePath,
       heartbeatDir: this.primaryRoot.heartbeatDir,
       soulFile: this.primaryRoot.soulFile,
       memoryDir: this.primaryRoot.memoryDir,
+      loggers: this.loggers,
     };
     this.scheduler = new HeartbeatScheduler(runnerOpts);
-    this.logger = new HeartbeatLogger(join(this.primaryRoot.heartbeatDir, "heartbeat.log"));
   }
 
   /** Parse config across all roots, start scheduling, and watch each root. */
   async start(): Promise<void> {
     const entries = await this.parseAll();
     if (entries.length === 0) {
-      this.logger.log("No heartbeats configured — nothing to schedule");
+      this.primaryLogger().log("No heartbeats configured — nothing to schedule");
       console.log("No heartbeats configured.");
     } else {
       this.scheduler.start(entries);
@@ -176,7 +191,10 @@ export class HeartbeatDaemon {
           this.watchDebounceTimer = setTimeout(() => {
             this.watchDebounceTimer = null;
             this.sync().catch((err) => {
-              this.logger.log(
+              // Watcher errors are daemon-scope (not tied to a specific
+              // entry), so route them to the affected root's logger if we
+              // know it, otherwise the primary (parent) logger.
+              this.loggerFor(root.label).log(
                 `[watcher] Sync error: ${err instanceof Error ? err.message : String(err)}`,
               );
             });
@@ -184,12 +202,14 @@ export class HeartbeatDaemon {
         });
 
         watcher.on("error", (err) => {
-          this.logger.log(`[watcher:${root.label || "parent"}] Error: ${err.message}`);
+          this.loggerFor(root.label).log(
+            `[watcher:${root.label || "parent"}] Error: ${err.message}`,
+          );
         });
 
         this.watchers.push(watcher);
       } catch (err) {
-        this.logger.log(
+        this.loggerFor(root.label).log(
           `[watcher:${root.label || "parent"}] Failed to watch ${dir}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
@@ -212,11 +232,44 @@ export class HeartbeatDaemon {
     this.watchers = [];
   }
 
-  /** Show status: daemon info, scheduled jobs, recent logs */
+  /**
+   * Show status: daemon info, scheduled jobs grouped by root, recent logs.
+   *
+   * Single-root (empty label) collapses to the legacy flat format — no
+   * "Roots:" header, bare slugs in the schedule list, one log tail — so
+   * existing scripts grepping `cronExpr → filePath` still match.
+   */
   status(): void {
     const statuses = this.scheduler.status();
     console.log(`Heartbeat daemon: running (pid ${process.pid})`);
     console.log("");
+
+    const isMulti = this.isMultiRoot();
+
+    if (isMulti) {
+      // Multi-root: render a "Roots:" section so operators can see which
+      // worktrees are active + how many schedules each contributes.
+      const schedulesByLabel = new Map<string, number>();
+      for (const s of statuses) {
+        const label = s.name.includes("::") ? s.name.split("::", 1)[0] : "";
+        schedulesByLabel.set(label, (schedulesByLabel.get(label) ?? 0) + 1);
+      }
+      console.log("Roots:");
+      const labelColWidth = Math.max(
+        ...this.normalized.roots.map((r) => (r.label || "parent").length),
+        6,
+      );
+      for (const root of this.normalized.roots) {
+        const displayLabel = root.label || "parent";
+        const count = schedulesByLabel.get(root.label) ?? 0;
+        const plural = count === 1 ? "" : "s";
+        console.log(
+          `  ${displayLabel.padEnd(labelColWidth)}  →  ${root.workspacePath} (${count} schedule${plural})`,
+        );
+      }
+      console.log("");
+    }
+
     if (statuses.length > 0) {
       console.log(`Heartbeat schedules: ${statuses.length}`);
       for (const s of statuses) {
@@ -225,12 +278,27 @@ export class HeartbeatDaemon {
     } else {
       console.log("Heartbeat schedules: none");
     }
-    // Recent logs
-    const recent = this.logger.tail(10);
-    if (recent) {
-      console.log("");
-      console.log("Recent log:");
-      console.log(recent);
+
+    if (isMulti) {
+      // Per-root log tails so operators can diff worktrees at a glance.
+      for (const root of this.normalized.roots) {
+        const logger = this.loggers.get(root.label);
+        if (!logger) continue;
+        const recent = logger.tail(10);
+        if (recent) {
+          console.log("");
+          console.log(`Recent log (${root.label || "parent"}):`);
+          console.log(recent);
+        }
+      }
+    } else {
+      // Legacy single-root: one log tail, unlabelled, exactly as pre-PR-3.
+      const recent = this.primaryLogger().tail(10);
+      if (recent) {
+        console.log("");
+        console.log("Recent log:");
+        console.log(recent);
+      }
     }
   }
 
@@ -308,5 +376,37 @@ ${existing}`;
    */
   private describeEntry(entry: HeartbeatEntry): string {
     return entry.root.label ? `${entry.root.label}::${entry.filePath}` : entry.filePath;
+  }
+
+  /**
+   * Primary logger = the one owned by the first root (typically the parent
+   * checkout). Daemon-scope operational messages without a clearer owner
+   * land here; spec § "Logger" option 1 explicitly avoids a new daemon-wide
+   * log file.
+   */
+  private primaryLogger(): HeartbeatLogger {
+    const logger = this.loggers.get(this.primaryRoot.label);
+    if (!logger) {
+      // Constructor guarantees a logger per root, so this would be a bug.
+      throw new Error(
+        `HeartbeatDaemon: no logger registered for primary root label "${this.primaryRoot.label}"`,
+      );
+    }
+    return logger;
+  }
+
+  /** Logger for a specific root label, with primary logger as fallback. */
+  private loggerFor(rootLabel: string): HeartbeatLogger {
+    return this.loggers.get(rootLabel) ?? this.primaryLogger();
+  }
+
+  /**
+   * True when the daemon is running under multi-root semantics. A single
+   * root with an empty label is the legacy back-compat shape and must
+   * render status() output byte-identically to pre-PR-3.
+   */
+  private isMultiRoot(): boolean {
+    if (this.normalized.roots.length !== 1) return true;
+    return this.normalized.roots[0].label !== "";
   }
 }

--- a/packages/sandbox/src/lib/heartbeat/daemon.ts
+++ b/packages/sandbox/src/lib/heartbeat/daemon.ts
@@ -7,9 +7,17 @@ import {
 } from "./config.js";
 import { HeartbeatScheduler } from "./scheduler.js";
 import { HeartbeatLogger } from "./logger.js";
+import { discoverWorkspaceRoots } from "./discovery.js";
 import type { RunnerOptions } from "./runner.js";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, watch, type FSWatcher } from "node:fs";
 import { join } from "node:path";
+
+/**
+ * Soft cap: warn (don't fail) when the number of watched roots exceeds this.
+ * Node's default inotify limit is ~8k; realistic worktree counts never get
+ * close, so exceeding this almost always indicates a mis-discovery loop.
+ */
+const ROOT_COUNT_WARN_THRESHOLD = 32;
 
 /**
  * Legacy single-root options — a bare workspace + heartbeat directory.
@@ -34,6 +42,27 @@ export interface MultiRootDaemonOptions {
   workspaceRoots: WorkspaceRoot[];
   defaultAgent?: string;
   defaultInterval?: number;
+  /**
+   * PR-4 — opt-in hot worktree add/remove. When set, the daemon installs a
+   * watcher on `<home>/harness/.git/worktrees/` (git's own worktree-tracking
+   * directory) and re-runs `discoverWorkspaceRoots(home, rootsEnv)` whenever
+   * entries appear or disappear. Newly-discovered roots get a heartbeat-dir
+   * watcher + logger; removed roots have theirs torn down. The scheduler is
+   * differentially re-synced.
+   *
+   * Callers that construct `workspaceRoots` manually (e.g. tests, operators
+   * pinning a fixed list) can omit this — the top-level watcher simply never
+   * starts.
+   */
+  rediscover?: {
+    /** Absolute path used as the HOME argument to `discoverWorkspaceRoots`. */
+    home: string;
+    /**
+     * Raw value of `HEARTBEAT_ROOTS` (or equivalent override string) so
+     * rediscovery honours the same overrides the CLI used at startup.
+     */
+    rootsEnv?: string;
+  };
 }
 
 export type DaemonOptions = LegacyDaemonOptions | MultiRootDaemonOptions;
@@ -47,6 +76,12 @@ interface NormalizedDaemonOptions {
   roots: WorkspaceRoot[];
   defaultAgent?: string;
   defaultInterval?: number;
+  /**
+   * Present only when constructed via `MultiRootDaemonOptions.rediscover`.
+   * Drives the `.git/worktrees/` watcher in PR-4. Legacy single-root setups
+   * never set this, so rediscovery is a no-op there.
+   */
+  rediscover?: MultiRootDaemonOptions["rediscover"];
 }
 
 function isMultiRoot(opts: DaemonOptions): opts is MultiRootDaemonOptions {
@@ -59,6 +94,7 @@ function normalize(opts: DaemonOptions): NormalizedDaemonOptions {
       roots: opts.workspaceRoots,
       defaultAgent: opts.defaultAgent,
       defaultInterval: opts.defaultInterval,
+      rediscover: opts.rediscover,
     };
   }
   // Legacy shape → wrap into a single-root array with label "" so composite
@@ -87,9 +123,29 @@ export class HeartbeatDaemon {
    * behavioural change.
    */
   private loggers: Map<string, HeartbeatLogger>;
-  /** One watcher per root — all fire the same debounced sync. */
-  private watchers: FSWatcher[] = [];
+  /**
+   * Per-root heartbeat-dir watchers keyed by `root.label`. Keyed (not an
+   * array) so PR-4's `rediscoverRoots()` can tear down a single root's
+   * watcher when its worktree disappears, without disturbing the others.
+   */
+  private heartbeatWatchers: Map<string, FSWatcher> = new Map();
   private watchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * PR-4 — watcher on `<home>/harness/.git/worktrees/`. Fires when git adds
+   * or removes a worktree entry; callback triggers `rediscoverRoots()` to
+   * differentially sync roots. `null` when not in multi-root rediscovery
+   * mode, when `.git/worktrees/` doesn't exist yet, or after `stop()`.
+   */
+  private topLevelWatcher: FSWatcher | null = null;
+  private topLevelDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Serializes `rediscoverRoots()` calls so overlapping top-level-watcher
+   * events (e.g. `git worktree add` emits multiple mutation events in
+   * rapid succession) can't interleave logger/watcher teardown with
+   * startup. The debounce timer already coalesces bursts; this guards
+   * against a regular `sync()` racing a rediscovery.
+   */
+  private rediscoverInFlight: Promise<void> | null = null;
   private normalized: NormalizedDaemonOptions;
   /** Primary root — used for logger, migrate, and legacy-shim scenarios. */
   private primaryRoot: WorkspaceRoot;
@@ -178,42 +234,237 @@ export class HeartbeatDaemon {
   /** Start one file watcher per root's heartbeats directory. */
   private startWatching(): void {
     for (const root of this.normalized.roots) {
-      const dir = root.heartbeatDir;
-      if (!existsSync(dir)) continue;
-
-      try {
-        const watcher = watch(dir, { persistent: false }, (_event, filename) => {
-          // Only react to .md file changes
-          if (!filename || !filename.endsWith(".md")) return;
-
-          // Debounce: coalesce rapid events (from any root) into a single sync
-          if (this.watchDebounceTimer) clearTimeout(this.watchDebounceTimer);
-          this.watchDebounceTimer = setTimeout(() => {
-            this.watchDebounceTimer = null;
-            this.sync().catch((err) => {
-              // Watcher errors are daemon-scope (not tied to a specific
-              // entry), so route them to the affected root's logger if we
-              // know it, otherwise the primary (parent) logger.
-              this.loggerFor(root.label).log(
-                `[watcher] Sync error: ${err instanceof Error ? err.message : String(err)}`,
-              );
-            });
-          }, 500);
-        });
-
-        watcher.on("error", (err) => {
-          this.loggerFor(root.label).log(
-            `[watcher:${root.label || "parent"}] Error: ${err.message}`,
-          );
-        });
-
-        this.watchers.push(watcher);
-      } catch (err) {
-        this.loggerFor(root.label).log(
-          `[watcher:${root.label || "parent"}] Failed to watch ${dir}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      this.watchRoot(root);
     }
+    // PR-4 — only install the top-level watcher when rediscovery is
+    // configured. Legacy single-root (opts.rediscover undefined) never
+    // watches `.git/worktrees/` because no caller could act on the event.
+    this.startTopLevelWatcher();
+  }
+
+  /**
+   * Install a heartbeat-directory watcher for a single root. Extracted from
+   * `startWatching()` so PR-4's `rediscoverRoots()` can add watchers for
+   * newly-discovered roots without re-iterating the whole set.
+   *
+   * Idempotent: if a watcher already exists for this label, returns
+   * early. Silently skips roots whose `heartbeatDir` is missing — those
+   * will be picked up on the next rediscovery if they appear later.
+   */
+  private watchRoot(root: WorkspaceRoot): void {
+    if (this.heartbeatWatchers.has(root.label)) return;
+
+    const dir = root.heartbeatDir;
+    if (!existsSync(dir)) return;
+
+    try {
+      const watcher = watch(dir, { persistent: false }, (_event, filename) => {
+        // Only react to .md file changes
+        if (!filename || !filename.endsWith(".md")) return;
+
+        // Debounce: coalesce rapid events (from any root) into a single sync
+        if (this.watchDebounceTimer) clearTimeout(this.watchDebounceTimer);
+        this.watchDebounceTimer = setTimeout(() => {
+          this.watchDebounceTimer = null;
+          this.sync().catch((err) => {
+            // Watcher errors are daemon-scope (not tied to a specific
+            // entry), so route them to the affected root's logger if we
+            // know it, otherwise the primary (parent) logger.
+            this.loggerFor(root.label).log(
+              `[watcher] Sync error: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+        }, 500);
+      });
+
+      watcher.on("error", (err) => {
+        this.loggerFor(root.label).log(`[watcher:${root.label || "parent"}] Error: ${err.message}`);
+      });
+
+      this.heartbeatWatchers.set(root.label, watcher);
+    } catch (err) {
+      this.loggerFor(root.label).log(
+        `[watcher:${root.label || "parent"}] Failed to watch ${dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /** Close and drop the heartbeat-dir watcher for a single root (if any). */
+  private unwatchRoot(label: string): void {
+    const watcher = this.heartbeatWatchers.get(label);
+    if (!watcher) return;
+    try {
+      watcher.close();
+    } catch {
+      // ignore — watcher may already be closed
+    }
+    this.heartbeatWatchers.delete(label);
+  }
+
+  /**
+   * PR-4 — watch `<home>/harness/.git/worktrees/` so new or removed
+   * worktrees are picked up without a daemon restart. Git maintains one
+   * subdirectory in that path per non-parent worktree; directory entries
+   * appearing/disappearing exactly corresponds to worktrees being
+   * added/removed, which is what we want to react to.
+   *
+   * Only installs the watcher when:
+   *  1. The constructor was given `rediscover` options (i.e., the CLI
+   *     provisioned this daemon via discovery); AND
+   *  2. `<home>/harness/.git/worktrees/` exists.
+   *
+   * Skipped silently otherwise — both cases are normal (legacy single-root
+   * daemon, fresh repo with no worktrees, non-git test fixtures).
+   */
+  private startTopLevelWatcher(): void {
+    const rediscover = this.normalized.rediscover;
+    if (!rediscover) return;
+
+    const worktreesDir = join(rediscover.home, "harness", ".git", "worktrees");
+    if (!existsSync(worktreesDir)) {
+      this.primaryLogger().log(
+        `[watcher:worktrees] ${worktreesDir} does not exist — hot worktree add/remove disabled`,
+      );
+      return;
+    }
+
+    try {
+      const watcher = watch(worktreesDir, { persistent: false }, () => {
+        // Git briefly creates/deletes intermediary dirs during a single
+        // `worktree add` — same 500ms debounce as the heartbeat-dir watcher
+        // so a burst collapses to one rediscovery pass.
+        if (this.topLevelDebounceTimer) clearTimeout(this.topLevelDebounceTimer);
+        this.topLevelDebounceTimer = setTimeout(() => {
+          this.topLevelDebounceTimer = null;
+          void this.rediscoverRoots().catch((err) => {
+            this.primaryLogger().log(
+              `[watcher:worktrees] Rediscovery error: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+        }, 500);
+      });
+
+      watcher.on("error", (err) => {
+        this.primaryLogger().log(`[watcher:worktrees] Error: ${err.message}`);
+      });
+
+      this.topLevelWatcher = watcher;
+    } catch (err) {
+      this.primaryLogger().log(
+        `[watcher:worktrees] Failed to watch ${worktreesDir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /** Close the top-level watcher and clear its debounce timer. */
+  private stopTopLevelWatcher(): void {
+    if (this.topLevelDebounceTimer) {
+      clearTimeout(this.topLevelDebounceTimer);
+      this.topLevelDebounceTimer = null;
+    }
+    if (this.topLevelWatcher) {
+      try {
+        this.topLevelWatcher.close();
+      } catch {
+        // ignore — watcher may already be closed
+      }
+      this.topLevelWatcher = null;
+    }
+  }
+
+  /**
+   * PR-4 — re-run discovery and differentially reconcile roots.
+   *
+   * Triggered by the `.git/worktrees/` watcher (or called directly from
+   * tests). Steps:
+   *   1. Re-run `discoverWorkspaceRoots(home, rootsEnv)`.
+   *   2. Diff against `this.normalized.roots` by `workspacePath`:
+   *        added   = new  - old
+   *        removed = old  - new
+   *      Untouched paths keep their existing logger/watcher instances.
+   *   3. For each removed root: close its heartbeat-dir watcher, drop its
+   *      logger, drop it from `normalized.roots`.
+   *   4. For each added root: instantiate a logger, install a heartbeat-dir
+   *      watcher, append to `normalized.roots`.
+   *   5. Call `sync()` once so the scheduler differentially reconciles
+   *      entries (scheduler already handles add/remove correctly).
+   *
+   * Serialized via `rediscoverInFlight` so overlapping top-level events
+   * queue rather than interleave. Safe to call when `rediscover` is unset —
+   * it simply returns.
+   */
+  async rediscoverRoots(): Promise<void> {
+    const rediscover = this.normalized.rediscover;
+    if (!rediscover) return;
+
+    // Serialize: if a rediscovery is in flight, wait for it to finish then
+    // run our own pass (the FS state could have changed again in the gap).
+    if (this.rediscoverInFlight) {
+      await this.rediscoverInFlight;
+    }
+
+    this.rediscoverInFlight = this.doRediscover(rediscover);
+    try {
+      await this.rediscoverInFlight;
+    } finally {
+      this.rediscoverInFlight = null;
+    }
+  }
+
+  private async doRediscover(
+    rediscover: NonNullable<NormalizedDaemonOptions["rediscover"]>,
+  ): Promise<void> {
+    const fresh = discoverWorkspaceRoots(rediscover.home, rediscover.rootsEnv);
+
+    const oldByPath = new Map(this.normalized.roots.map((r) => [r.workspacePath, r]));
+    const newByPath = new Map(fresh.map((r) => [r.workspacePath, r]));
+
+    const added: WorkspaceRoot[] = [];
+    const removed: WorkspaceRoot[] = [];
+    for (const [path, root] of newByPath) {
+      if (!oldByPath.has(path)) added.push(root);
+    }
+    for (const [path, root] of oldByPath) {
+      if (!newByPath.has(path)) removed.push(root);
+    }
+
+    if (added.length === 0 && removed.length === 0) return;
+
+    // Tear down removed roots first so their watcher/logger state is gone
+    // before `sync()` re-parses and the scheduler drops their entries.
+    for (const root of removed) {
+      this.unwatchRoot(root.label);
+      this.loggers.delete(root.label);
+      this.primaryLogger().log(
+        `[watcher:worktrees] Removed root ${root.label || "parent"} (${root.workspacePath})`,
+      );
+    }
+
+    // Bring in new roots: logger first, then watcher (watcher callback uses
+    // `loggerFor(root.label)`).
+    for (const root of added) {
+      this.loggers.set(root.label, new HeartbeatLogger(join(root.heartbeatDir, "heartbeat.log")));
+      this.watchRoot(root);
+      this.primaryLogger().log(
+        `[watcher:worktrees] Added root ${root.label || "parent"} (${root.workspacePath})`,
+      );
+    }
+
+    // Replace the normalized root list with the fresh set in their
+    // deterministic path-sorted order so logs/status remain stable.
+    this.normalized.roots = fresh;
+
+    // Soft warn if we blow past the watcher threshold — see
+    // ROOT_COUNT_WARN_THRESHOLD rationale.
+    if (this.normalized.roots.length > ROOT_COUNT_WARN_THRESHOLD) {
+      this.primaryLogger().log(
+        `[watcher:worktrees] Warning: ${this.normalized.roots.length} roots exceeds soft cap of ${ROOT_COUNT_WARN_THRESHOLD}`,
+      );
+    }
+
+    // Differential scheduler re-sync. The scheduler is idempotent so it's
+    // fine if a regular heartbeat-dir event fires during this window.
+    await this.sync();
   }
 
   /** Close every file watcher and clear any pending debounce timer */
@@ -222,14 +473,15 @@ export class HeartbeatDaemon {
       clearTimeout(this.watchDebounceTimer);
       this.watchDebounceTimer = null;
     }
-    for (const watcher of this.watchers) {
+    for (const watcher of this.heartbeatWatchers.values()) {
       try {
         watcher.close();
       } catch {
         // ignore — watcher may already be closed
       }
     }
-    this.watchers = [];
+    this.heartbeatWatchers.clear();
+    this.stopTopLevelWatcher();
   }
 
   /**

--- a/packages/sandbox/src/lib/heartbeat/daemon.ts
+++ b/packages/sandbox/src/lib/heartbeat/daemon.ts
@@ -1,7 +1,8 @@
 import {
   parseHeartbeatConfig,
-  parseHeartbeatConfigAsync,
+  parseHeartbeatConfigAcrossRoots,
   secondsToCron,
+  type HeartbeatEntry,
   type WorkspaceRoot,
 } from "./config.js";
 import { HeartbeatScheduler } from "./scheduler.js";
@@ -25,10 +26,9 @@ export interface LegacyDaemonOptions {
 }
 
 /**
- * Multi-root options — what PR-2 will exercise. PR-1 accepts this shape
- * through the constructor for forward-compatibility but, until PR-2 lands
- * the discovery/watcher/cwd changes, only the FIRST root is watched and
- * parsed (same single-root behaviour, now addressed by a structured root).
+ * Multi-root options — PR-2 exercises this fully. Each root gets its own
+ * `fs.watch` instance, entries are merged across roots, and the scheduler
+ * namespaces keys by `root.label`.
  */
 export interface MultiRootDaemonOptions {
   workspaceRoots: WorkspaceRoot[];
@@ -81,10 +81,11 @@ function normalize(opts: DaemonOptions): NormalizedDaemonOptions {
 export class HeartbeatDaemon {
   private scheduler: HeartbeatScheduler;
   private logger: HeartbeatLogger;
-  private watcher: FSWatcher | null = null;
+  /** One watcher per root — all fire the same debounced sync. */
+  private watchers: FSWatcher[] = [];
   private watchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private normalized: NormalizedDaemonOptions;
-  /** Primary root — single-root deployments use this for all operations. */
+  /** Primary root — used for logger, migrate, and legacy-shim scenarios. */
   private primaryRoot: WorkspaceRoot;
 
   constructor(options: DaemonOptions) {
@@ -101,13 +102,9 @@ export class HeartbeatDaemon {
     this.logger = new HeartbeatLogger(join(this.primaryRoot.heartbeatDir, "heartbeat.log"));
   }
 
-  /** Parse config, start scheduling, and watch for changes */
+  /** Parse config across all roots, start scheduling, and watch each root. */
   async start(): Promise<void> {
-    const entries = await parseHeartbeatConfigAsync(
-      this.primaryRoot,
-      this.normalized.defaultAgent,
-      this.normalized.defaultInterval,
-    );
+    const entries = await this.parseAll();
     if (entries.length === 0) {
       this.logger.log("No heartbeats configured — nothing to schedule");
       console.log("No heartbeats configured.");
@@ -115,7 +112,7 @@ export class HeartbeatDaemon {
       this.scheduler.start(entries);
       console.log(`Synced ${entries.length} heartbeat schedule(s)`);
       for (const entry of entries) {
-        console.log(`  ${entry.cronExpr}  →  ${entry.filePath}`);
+        console.log(`  ${entry.cronExpr}  →  ${this.describeEntry(entry)}`);
       }
     }
     this.startWatching();
@@ -123,84 +120,96 @@ export class HeartbeatDaemon {
 
   /** Re-sync: re-parse config and differentially update schedules */
   async sync(): Promise<void> {
-    const entries = await parseHeartbeatConfigAsync(
-      this.primaryRoot,
-      this.normalized.defaultAgent,
-      this.normalized.defaultInterval,
-    );
+    const entries = await this.parseAll();
     this.scheduler.sync(entries);
     console.log(`Synced ${entries.length} heartbeat schedule(s)`);
     for (const entry of entries) {
-      console.log(`  ${entry.cronExpr}  →  ${entry.filePath}`);
+      console.log(`  ${entry.cronExpr}  →  ${this.describeEntry(entry)}`);
     }
   }
 
   /**
    * One-shot sync using synchronous I/O. Used by the CLI `sync` command
    * which runs in a short-lived process and exits immediately.
+   *
+   * In multi-root mode this still delegates to the sync parser per-root to
+   * avoid awaiting promises from a CLI entry that expects to exit
+   * immediately — the parser accepts a WorkspaceRoot directly.
    */
   syncOnce(): void {
-    const entries = parseHeartbeatConfig(
-      this.primaryRoot,
-      this.normalized.defaultAgent,
-      this.normalized.defaultInterval,
-    );
+    const entries: HeartbeatEntry[] = [];
+    for (const root of this.normalized.roots) {
+      const rootEntries = parseHeartbeatConfig(
+        root,
+        this.normalized.defaultAgent,
+        this.normalized.defaultInterval,
+      );
+      for (const entry of rootEntries) entries.push(entry);
+    }
     this.scheduler.sync(entries);
     console.log(`Synced ${entries.length} heartbeat schedule(s)`);
     for (const entry of entries) {
-      console.log(`  ${entry.cronExpr}  →  ${entry.filePath}`);
+      console.log(`  ${entry.cronExpr}  →  ${this.describeEntry(entry)}`);
     }
   }
 
-  /** Stop all scheduled heartbeats and the file watcher */
+  /** Stop all scheduled heartbeats and every file watcher */
   stop(): void {
     this.stopWatching();
     this.scheduler.stop();
     console.log("Heartbeat schedules removed.");
   }
 
-  /** Start watching the heartbeats directory for file changes */
+  /** Start one file watcher per root's heartbeats directory. */
   private startWatching(): void {
-    const dir = this.primaryRoot.heartbeatDir;
-    if (!existsSync(dir)) return;
+    for (const root of this.normalized.roots) {
+      const dir = root.heartbeatDir;
+      if (!existsSync(dir)) continue;
 
-    try {
-      this.watcher = watch(dir, { persistent: false }, (_event, filename) => {
-        // Only react to .md file changes
-        if (!filename || !filename.endsWith(".md")) return;
+      try {
+        const watcher = watch(dir, { persistent: false }, (_event, filename) => {
+          // Only react to .md file changes
+          if (!filename || !filename.endsWith(".md")) return;
 
-        // Debounce: coalesce rapid events into a single sync
-        if (this.watchDebounceTimer) clearTimeout(this.watchDebounceTimer);
-        this.watchDebounceTimer = setTimeout(() => {
-          this.watchDebounceTimer = null;
-          this.sync().catch((err) => {
-            this.logger.log(
-              `[watcher] Sync error: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          });
-        }, 500);
-      });
+          // Debounce: coalesce rapid events (from any root) into a single sync
+          if (this.watchDebounceTimer) clearTimeout(this.watchDebounceTimer);
+          this.watchDebounceTimer = setTimeout(() => {
+            this.watchDebounceTimer = null;
+            this.sync().catch((err) => {
+              this.logger.log(
+                `[watcher] Sync error: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
+          }, 500);
+        });
 
-      this.watcher.on("error", (err) => {
-        this.logger.log(`[watcher] Error: ${err.message}`);
-      });
-    } catch (err) {
-      this.logger.log(
-        `[watcher] Failed to watch ${dir}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+        watcher.on("error", (err) => {
+          this.logger.log(`[watcher:${root.label || "parent"}] Error: ${err.message}`);
+        });
+
+        this.watchers.push(watcher);
+      } catch (err) {
+        this.logger.log(
+          `[watcher:${root.label || "parent"}] Failed to watch ${dir}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
   }
 
-  /** Stop the file watcher and clear any pending debounce timer */
+  /** Close every file watcher and clear any pending debounce timer */
   private stopWatching(): void {
     if (this.watchDebounceTimer) {
       clearTimeout(this.watchDebounceTimer);
       this.watchDebounceTimer = null;
     }
-    if (this.watcher) {
-      this.watcher.close();
-      this.watcher = null;
+    for (const watcher of this.watchers) {
+      try {
+        watcher.close();
+      } catch {
+        // ignore — watcher may already be closed
+      }
     }
+    this.watchers = [];
   }
 
   /** Show status: daemon info, scheduled jobs, recent logs */
@@ -278,5 +287,26 @@ ${existing}`;
 
   getScheduler(): HeartbeatScheduler {
     return this.scheduler;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  private parseAll(): Promise<HeartbeatEntry[]> {
+    return parseHeartbeatConfigAcrossRoots(
+      this.normalized.roots,
+      this.normalized.defaultAgent,
+      this.normalized.defaultInterval,
+    );
+  }
+
+  /**
+   * Human-readable description for console output. Single-root (label "")
+   * keeps the legacy `heartbeats/foo.md` form; multi-root prefixes with the
+   * label so operators can tell worktrees apart at a glance.
+   */
+  private describeEntry(entry: HeartbeatEntry): string {
+    return entry.root.label ? `${entry.root.label}::${entry.filePath}` : entry.filePath;
   }
 }

--- a/packages/sandbox/src/lib/heartbeat/discovery.ts
+++ b/packages/sandbox/src/lib/heartbeat/discovery.ts
@@ -1,0 +1,158 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import path from "node:path";
+import type { WorkspaceRoot } from "./config.js";
+
+/**
+ * Discover all workspace roots under a given HOME.
+ *
+ * Uses `git worktree list --porcelain` against `<home>/harness` as the source
+ * of truth — git already tracks every worktree and its branch, which is more
+ * reliable than walking `.worktrees/` (worktree paths can be anywhere on disk).
+ *
+ * For each discovered worktree, we include `<worktree-path>/workspace` as a
+ * root IFF `<workspacePath>/heartbeats/` exists. The label is derived from
+ * the branch name (`refs/heads/agent/foo` → `agent-foo`). Detached HEADs
+ * become `detached-<shortsha>`.
+ *
+ * `HEARTBEAT_ROOTS=path1:label1,path2:label2` env-style overrides augment (or
+ * override, on path collision) auto-discovery. Overrides always win.
+ */
+export function discoverWorkspaceRoots(home: string, overrides?: string): WorkspaceRoot[] {
+  const byPath = new Map<string, WorkspaceRoot>();
+
+  // 1. Auto-discover via `git worktree list --porcelain`.
+  const harnessRoot = path.join(home, "harness");
+  for (const entry of listGitWorktrees(harnessRoot)) {
+    const workspacePath = path.join(entry.path, "workspace");
+    const heartbeatDir = path.join(workspacePath, "heartbeats");
+    if (!safeExistsDir(heartbeatDir)) continue;
+
+    const label = sanitizeBranch(entry.branch, entry.head);
+    byPath.set(workspacePath, {
+      workspacePath,
+      heartbeatDir,
+      soulFile: path.join(workspacePath, "SOUL.md"),
+      memoryDir: path.join(workspacePath, "memory"),
+      label,
+    });
+  }
+
+  // 2. Apply env overrides — they win on collision.
+  if (overrides && overrides.trim().length > 0) {
+    for (const spec of overrides.split(",")) {
+      const trimmed = spec.trim();
+      if (!trimmed) continue;
+      const colonIdx = trimmed.lastIndexOf(":");
+      if (colonIdx <= 0) continue; // need both path and label
+      const rawPath = trimmed.slice(0, colonIdx).trim();
+      const label = trimmed.slice(colonIdx + 1).trim();
+      if (!rawPath || !label) continue;
+      const workspacePath = path.isAbsolute(rawPath) ? rawPath : path.resolve(rawPath);
+      const heartbeatDir = path.join(workspacePath, "heartbeats");
+      byPath.set(workspacePath, {
+        workspacePath,
+        heartbeatDir,
+        soulFile: path.join(workspacePath, "SOUL.md"),
+        memoryDir: path.join(workspacePath, "memory"),
+        label,
+      });
+    }
+  }
+
+  // Return in a deterministic order (by path) so logs, status output, and
+  // tests aren't sensitive to Map insertion ordering.
+  return Array.from(byPath.values()).sort((a, b) =>
+    a.workspacePath < b.workspacePath ? -1 : a.workspacePath > b.workspacePath ? 1 : 0,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+interface GitWorktreeEntry {
+  path: string;
+  branch: string | null; // refs/heads/... or null when detached
+  head: string | null; // commit sha
+}
+
+/**
+ * Run `git worktree list --porcelain` and parse the result. Returns an empty
+ * array on any failure (no git, not a repo, permission denied, etc.) — the
+ * caller falls back to single-root behaviour in that case.
+ */
+function listGitWorktrees(repoDir: string): GitWorktreeEntry[] {
+  let raw: string;
+  try {
+    raw = execFileSync("git", ["-C", repoDir, "worktree", "list", "--porcelain"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return [];
+  }
+
+  const entries: GitWorktreeEntry[] = [];
+  let current: Partial<GitWorktreeEntry> = {};
+  for (const line of raw.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      if (current.path) {
+        entries.push({
+          path: current.path,
+          branch: current.branch ?? null,
+          head: current.head ?? null,
+        });
+      }
+      current = { path: line.slice("worktree ".length).trim() };
+    } else if (line.startsWith("HEAD ")) {
+      current.head = line.slice("HEAD ".length).trim();
+    } else if (line.startsWith("branch ")) {
+      current.branch = line.slice("branch ".length).trim();
+    } else if (line.trim() === "" && current.path) {
+      entries.push({
+        path: current.path,
+        branch: current.branch ?? null,
+        head: current.head ?? null,
+      });
+      current = {};
+    }
+    // Ignore other keys (bare, detached, locked, prunable...) — we only
+    // derive label from branch/head.
+  }
+  if (current.path) {
+    entries.push({
+      path: current.path,
+      branch: current.branch ?? null,
+      head: current.head ?? null,
+    });
+  }
+
+  return entries;
+}
+
+/**
+ * Convert a git branch ref (or detached HEAD) to a filesystem-safe label.
+ *
+ * - `refs/heads/main` → `main`
+ * - `refs/heads/agent/sdr-pallet` → `agent-sdr-pallet`
+ * - null branch (detached) → `detached-<shortsha>` (first 7 chars of HEAD)
+ * - null branch + null head → `detached`
+ */
+export function sanitizeBranch(branch: string | null, head: string | null): string {
+  if (!branch) {
+    if (head && head.length >= 7) return `detached-${head.slice(0, 7)}`;
+    return "detached";
+  }
+  const stripped = branch.replace(/^refs\/heads\//, "");
+  return stripped.replace(/\//g, "-").toLowerCase();
+}
+
+function safeExistsDir(p: string): boolean {
+  try {
+    if (!existsSync(p)) return false;
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/packages/sandbox/src/lib/heartbeat/index.ts
+++ b/packages/sandbox/src/lib/heartbeat/index.ts
@@ -3,10 +3,12 @@ export {
   type WorkspaceRoot,
   parseHeartbeatConfig,
   parseHeartbeatConfigAsync,
+  parseHeartbeatConfigAcrossRoots,
   parseFrontmatter,
   secondsToCron,
   toWorkspaceRoot,
 } from "./config.js";
+export { discoverWorkspaceRoots, sanitizeBranch } from "./discovery.js";
 export { HeartbeatLogger } from "./logger.js";
 export { isActiveHours, isHeartbeatEmpty, isHeartbeatOk } from "./gates.js";
 export { HeartbeatRunner, type RunnerOptions } from "./runner.js";

--- a/packages/sandbox/src/lib/heartbeat/runner.ts
+++ b/packages/sandbox/src/lib/heartbeat/runner.ts
@@ -7,32 +7,58 @@ import type { HeartbeatEntry } from "./config.js";
 
 /**
  * Legacy single-root runner options. Retained for back-compat — the daemon
- * still constructs the scheduler (which owns the runner) with these fields.
- * Per-entry paths resolve off `entry.root` in PR-2; PR-1 only threads the
- * type through and does not change spawn behaviour.
+ * still constructs the scheduler (which owns the runner) with these fields
+ * in single-root mode. Per-entry paths resolve off `entry.root` per call.
  */
 export interface RunnerOptions {
   workspacePath: string;
   heartbeatDir: string;
   soulFile?: string;
   memoryDir?: string;
+  /**
+   * Global concurrency cap across ALL entries and ALL roots. Used to avoid
+   * stacking N concurrent `claude -p` processes against a single API key
+   * when multiple worktrees' schedules align. Defaults to
+   * `process.env.HEARTBEAT_MAX_CONCURRENT` (or 2 when unset). Set to `0` to
+   * disable the cap (legacy behaviour, unlimited concurrency).
+   */
+  maxConcurrent?: number;
 }
+
+/**
+ * How long a cron-tick waiter is willing to sit in the semaphore queue before
+ * giving up and logging a "Skipped (concurrency cap reached)" line. Matches
+ * the 300s per-run spawn timeout so a queued waiter never outlives the
+ * already-running process it's waiting for.
+ */
+const ACQUIRE_TIMEOUT_MS = 300_000;
 
 export class HeartbeatRunner {
   private logger: HeartbeatLogger;
   private running = new Set<string>();
+  private maxConcurrent: number;
+  private active = 0;
+  private waiters: Array<{
+    resolve: (acquired: boolean) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = [];
 
   constructor(private options: RunnerOptions) {
     this.logger = new HeartbeatLogger(`${options.heartbeatDir}/heartbeat.log`);
+    // Options wins over env so callers can force a specific cap in tests.
+    const fromEnv = parseInt(process.env.HEARTBEAT_MAX_CONCURRENT ?? "", 10);
+    this.maxConcurrent = options.maxConcurrent ?? (Number.isFinite(fromEnv) ? fromEnv : 2);
   }
 
   async run(entry: HeartbeatEntry): Promise<void> {
-    // 1. Resolve file path (relative to workspace if not absolute)
+    // 1. Resolve file path (relative to ENTRY root workspace if not absolute)
+    const rootWorkspace = entry.root.workspacePath;
     const filePath = entry.filePath.startsWith("/")
       ? entry.filePath
-      : join(this.options.workspacePath, entry.filePath);
+      : join(rootWorkspace, entry.filePath);
 
     const entryName = basename(filePath, ".md");
+    const logLabel = entry.root.label ? `${entry.root.label}::${entryName}` : entryName;
 
     // 2. In-memory guard — composite key matches the scheduler's entryName
     //    so cross-root same-name entries don't collide, but single-root
@@ -41,7 +67,7 @@ export class HeartbeatRunner {
     const guardKey = entry.root.label ? `${entry.root.label}::${entryName}` : entryName;
 
     if (this.running.has(guardKey)) {
-      this.logger.log(`[${entryName}] Skipping — previous execution still running`);
+      this.logger.log(`[${logLabel}] Skipping — previous execution still running`);
       this.logger.rotate();
       return;
     }
@@ -51,13 +77,13 @@ export class HeartbeatRunner {
     try {
       // 3a. Check active hours gate
       if (!isActiveHours(entry.activeStart, entry.activeEnd)) {
-        this.logger.log(`[${entryName}] Outside active hours, skipping`);
+        this.logger.log(`[${logLabel}] Outside active hours, skipping`);
         return;
       }
 
       // 3b. Check empty file gate
       if (isHeartbeatEmpty(filePath)) {
-        this.logger.log(`[${entryName}] File is effectively empty, skipping`);
+        this.logger.log(`[${logLabel}] File is effectively empty, skipping`);
         return;
       }
 
@@ -66,7 +92,7 @@ export class HeartbeatRunner {
 
       // 5. Build prompt (with SOUL.md if present and non-empty)
       let prompt = "";
-      const soulPath = this.options.soulFile ?? join(this.options.workspacePath, "SOUL.md");
+      const soulPath = entry.root.soulFile ?? join(rootWorkspace, "SOUL.md");
       if (existsSync(soulPath)) {
         const soulContent = readFileSync(soulPath, "utf-8") as string;
         if (soulContent.trim().length > 0) {
@@ -83,26 +109,47 @@ export class HeartbeatRunner {
         `If you learn anything worth remembering long-term, append it to memory/${today}.md (create the memory/ directory and file if needed).\n\n` +
         `---\n${entryName}:\n${heartbeatContent}\n---`;
 
-      this.logger.log(`[${entryName}] Running heartbeat (agent: ${entry.agent})`);
+      // 6. Acquire a slot from the global semaphore before spawning. Fast
+      //    path (slot free) is synchronous so we don't introduce an extra
+      //    microtask boundary that would race against mocked spawn-time
+      //    event scheduling in tests (and avoid needless scheduling churn
+      //    in the common uncontended case in production).
+      const acquireResult = this.tryAcquireSlot();
+      let acquired: boolean;
+      if (acquireResult === "granted") {
+        acquired = true;
+      } else {
+        acquired = await this.waitForSlot();
+      }
+      if (!acquired) {
+        this.logger.log(`[${logLabel}] Skipped (concurrency cap reached)`);
+        return;
+      }
 
-      // 6. Spawn agent with AbortSignal.timeout(300s).
-      //    Note: PR-2 will add `cwd: entry.root.workspacePath` so the agent
-      //    CLI resolves skills and relative paths inside the worktree. PR-1
-      //    keeps spawn behaviour byte-identical to avoid behavioural change.
-      const response = await this.spawnAgent(entry.agent, prompt, entryName);
+      this.logger.log(`[${logLabel}] Running heartbeat (agent: ${entry.agent})`);
 
-      // 7. Log result (response === null means timeout/failure handled inside spawnAgent)
-      if (response !== null) {
-        if (isHeartbeatOk(response)) {
-          this.logger.log(`[${entryName}] HEARTBEAT_OK`);
-        } else {
-          this.logger.log(`[${entryName}] Response: ${response}`);
+      try {
+        // 7. Spawn agent with AbortSignal.timeout(300s). Pass cwd when the
+        //    entry comes from a labelled (discovered) root so the agent CLI
+        //    resolves skills and relative paths inside the worktree's
+        //    workspace. Single-root back-compat (label === "") preserves the
+        //    legacy behaviour of inheriting the daemon's CWD.
+        const response = await this.spawnAgent(entry.agent, prompt, logLabel, entry);
+
+        // 8. Log result (response === null means timeout/failure handled inside spawnAgent)
+        if (response !== null) {
+          if (isHeartbeatOk(response)) {
+            this.logger.log(`[${logLabel}] HEARTBEAT_OK`);
+          } else {
+            this.logger.log(`[${logLabel}] Response: ${response}`);
+          }
         }
+      } finally {
+        this.releaseSlot();
       }
     } finally {
-      // 8. Release guard
+      // Release guard + rotate log regardless of outcome
       this.running.delete(guardKey);
-      // 9. Rotate log
       this.logger.rotate();
     }
   }
@@ -111,7 +158,12 @@ export class HeartbeatRunner {
    * Spawn the agent process and collect stdout.
    * Returns collected stdout string on success, null on timeout or failure.
    */
-  private spawnAgent(agent: string, prompt: string, entryName: string): Promise<string | null> {
+  private spawnAgent(
+    agent: string,
+    prompt: string,
+    logLabel: string,
+    entry: HeartbeatEntry,
+  ): Promise<string | null> {
     return new Promise((resolve) => {
       let args: string[];
 
@@ -126,17 +178,25 @@ export class HeartbeatRunner {
           args = ["-p", prompt];
       }
 
+      // Only pass cwd for discovered roots (labelled). Single-root back-compat
+      // intentionally keeps spawnOptions free of `cwd` so existing tests that
+      // assert on the exact spawn call shape stay green.
+      const spawnOptions: Parameters<typeof spawn>[2] = {
+        signal: AbortSignal.timeout(300_000),
+      };
+      if (entry.root.label) {
+        (spawnOptions as { cwd?: string }).cwd = entry.root.workspacePath;
+      }
+
       let proc;
       try {
-        proc = spawn(agent, args, {
-          signal: AbortSignal.timeout(300_000),
-        });
+        proc = spawn(agent, args, spawnOptions);
       } catch (err: unknown) {
         if (isAbortError(err)) {
-          this.logger.log(`[${entryName}] Timed out (300s limit)`);
+          this.logger.log(`[${logLabel}] Timed out (300s limit)`);
         } else {
           const msg = err instanceof Error ? err.message : String(err);
-          this.logger.log(`[${entryName}] Failed to spawn: ${msg}`);
+          this.logger.log(`[${logLabel}] Failed to spawn: ${msg}`);
         }
         resolve(null);
         return;
@@ -150,20 +210,20 @@ export class HeartbeatRunner {
 
       proc.on("error", (err: Error) => {
         if (isAbortError(err)) {
-          this.logger.log(`[${entryName}] Timed out (300s limit)`);
+          this.logger.log(`[${logLabel}] Timed out (300s limit)`);
         } else {
-          this.logger.log(`[${entryName}] Spawn error: ${err.message}`);
+          this.logger.log(`[${logLabel}] Spawn error: ${err.message}`);
         }
         resolve(null);
       });
 
       proc.on("close", (code: number | null) => {
         if (code === 124) {
-          this.logger.log(`[${entryName}] Timed out (300s limit)`);
+          this.logger.log(`[${logLabel}] Timed out (300s limit)`);
           resolve(null);
         } else if (code !== 0) {
           const snippet = stdout.slice(0, 500);
-          this.logger.log(`[${entryName}] Failed (exit code ${code ?? "null"}): ${snippet}`);
+          this.logger.log(`[${logLabel}] Failed (exit code ${code ?? "null"}): ${snippet}`);
           resolve(null);
         } else {
           resolve(stdout.trim());
@@ -174,6 +234,68 @@ export class HeartbeatRunner {
 
   getLogger(): HeartbeatLogger {
     return this.logger;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Global concurrency semaphore
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Synchronous fast-path: grant a slot immediately when the cap is
+   * disabled or a slot is free. Returns `"granted"` in those cases and
+   * `"queued"` when the caller must `waitForSlot()` asynchronously.
+   *
+   * Separating acquire into a sync fast path + async wait keeps the common
+   * uncontended case free of an extra microtask boundary — important both
+   * for production (less scheduling churn) and for tests that rely on
+   * precise event ordering with mocked child_process spawn.
+   */
+  private tryAcquireSlot(): "granted" | "queued" {
+    if (this.maxConcurrent === 0) return "granted";
+    if (this.active < this.maxConcurrent) {
+      this.active += 1;
+      return "granted";
+    }
+    return "queued";
+  }
+
+  /**
+   * Slow path: enqueue a waiter and resolve `true` when a slot is handed off
+   * by `releaseSlot()`, or `false` if the waiter expires before a slot
+   * becomes available.
+   */
+  private waitForSlot(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => {
+        // Waiter expired — remove from queue and resolve `false`.
+        const idx = this.waiters.findIndex((w) => w.resolve === resolve);
+        if (idx >= 0) this.waiters.splice(idx, 1);
+        resolve(false);
+      }, ACQUIRE_TIMEOUT_MS);
+      // Don't block Node from exiting on this timer alone.
+      if (typeof timer === "object" && timer !== null && "unref" in timer) {
+        (timer as { unref: () => void }).unref();
+      }
+      this.waiters.push({ resolve, timer });
+    });
+  }
+
+  /**
+   * Release a slot. If waiters are queued FIFO, the head of the queue is
+   * granted the slot immediately and its timeout cleared.
+   */
+  private releaseSlot(): void {
+    if (this.maxConcurrent === 0) return;
+    if (this.waiters.length > 0) {
+      const next = this.waiters.shift();
+      if (next) {
+        clearTimeout(next.timer);
+        // `active` stays the same: we hand our slot directly to the waiter.
+        next.resolve(true);
+        return;
+      }
+    }
+    this.active = Math.max(0, this.active - 1);
   }
 }
 

--- a/packages/sandbox/src/lib/heartbeat/runner.ts
+++ b/packages/sandbox/src/lib/heartbeat/runner.ts
@@ -3,7 +3,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { basename, join } from "node:path";
 import { HeartbeatLogger } from "./logger.js";
 import { isActiveHours, isHeartbeatEmpty, isHeartbeatOk } from "./gates.js";
-import type { HeartbeatEntry } from "./config.js";
+import type { HeartbeatEntry, WorkspaceRoot } from "./config.js";
 
 /**
  * Legacy single-root runner options. Retained for back-compat — the daemon
@@ -23,6 +23,16 @@ export interface RunnerOptions {
    * disable the cap (legacy behaviour, unlimited concurrency).
    */
   maxConcurrent?: number;
+  /**
+   * Optional per-root logger map keyed by `root.label`. When provided, the
+   * runner writes every entry-scoped log line through the matching logger so
+   * each worktree's events land in its own `heartbeats/heartbeat.log`.
+   *
+   * Back-compat: when omitted, the runner constructs a single logger at
+   * `<heartbeatDir>/heartbeat.log` (keyed by label `""`) so legacy
+   * single-root consumers continue to write to the same file as before.
+   */
+  loggers?: Map<string, HeartbeatLogger>;
 }
 
 /**
@@ -34,7 +44,7 @@ export interface RunnerOptions {
 const ACQUIRE_TIMEOUT_MS = 300_000;
 
 export class HeartbeatRunner {
-  private logger: HeartbeatLogger;
+  private loggers: Map<string, HeartbeatLogger>;
   private running = new Set<string>();
   private maxConcurrent: number;
   private active = 0;
@@ -44,7 +54,15 @@ export class HeartbeatRunner {
   }> = [];
 
   constructor(private options: RunnerOptions) {
-    this.logger = new HeartbeatLogger(`${options.heartbeatDir}/heartbeat.log`);
+    // Either the caller wired up per-root loggers (multi-root) or we mint a
+    // single-root logger keyed by "" so entry lookup by `entry.root.label`
+    // works uniformly.
+    if (options.loggers && options.loggers.size > 0) {
+      this.loggers = options.loggers;
+    } else {
+      this.loggers = new Map();
+      this.loggers.set("", new HeartbeatLogger(`${options.heartbeatDir}/heartbeat.log`));
+    }
     // Options wins over env so callers can force a specific cap in tests.
     const fromEnv = parseInt(process.env.HEARTBEAT_MAX_CONCURRENT ?? "", 10);
     this.maxConcurrent = options.maxConcurrent ?? (Number.isFinite(fromEnv) ? fromEnv : 2);
@@ -59,6 +77,7 @@ export class HeartbeatRunner {
 
     const entryName = basename(filePath, ".md");
     const logLabel = entry.root.label ? `${entry.root.label}::${entryName}` : entryName;
+    const logger = this.getLoggerFor(entry.root);
 
     // 2. In-memory guard — composite key matches the scheduler's entryName
     //    so cross-root same-name entries don't collide, but single-root
@@ -67,8 +86,8 @@ export class HeartbeatRunner {
     const guardKey = entry.root.label ? `${entry.root.label}::${entryName}` : entryName;
 
     if (this.running.has(guardKey)) {
-      this.logger.log(`[${logLabel}] Skipping — previous execution still running`);
-      this.logger.rotate();
+      logger.log(`[${logLabel}] Skipping — previous execution still running`);
+      logger.rotate();
       return;
     }
 
@@ -77,13 +96,13 @@ export class HeartbeatRunner {
     try {
       // 3a. Check active hours gate
       if (!isActiveHours(entry.activeStart, entry.activeEnd)) {
-        this.logger.log(`[${logLabel}] Outside active hours, skipping`);
+        logger.log(`[${logLabel}] Outside active hours, skipping`);
         return;
       }
 
       // 3b. Check empty file gate
       if (isHeartbeatEmpty(filePath)) {
-        this.logger.log(`[${logLabel}] File is effectively empty, skipping`);
+        logger.log(`[${logLabel}] File is effectively empty, skipping`);
         return;
       }
 
@@ -122,11 +141,11 @@ export class HeartbeatRunner {
         acquired = await this.waitForSlot();
       }
       if (!acquired) {
-        this.logger.log(`[${logLabel}] Skipped (concurrency cap reached)`);
+        logger.log(`[${logLabel}] Skipped (concurrency cap reached)`);
         return;
       }
 
-      this.logger.log(`[${logLabel}] Running heartbeat (agent: ${entry.agent})`);
+      logger.log(`[${logLabel}] Running heartbeat (agent: ${entry.agent})`);
 
       try {
         // 7. Spawn agent with AbortSignal.timeout(300s). Pass cwd when the
@@ -134,14 +153,14 @@ export class HeartbeatRunner {
         //    resolves skills and relative paths inside the worktree's
         //    workspace. Single-root back-compat (label === "") preserves the
         //    legacy behaviour of inheriting the daemon's CWD.
-        const response = await this.spawnAgent(entry.agent, prompt, logLabel, entry);
+        const response = await this.spawnAgent(entry.agent, prompt, logLabel, entry, logger);
 
         // 8. Log result (response === null means timeout/failure handled inside spawnAgent)
         if (response !== null) {
           if (isHeartbeatOk(response)) {
-            this.logger.log(`[${logLabel}] HEARTBEAT_OK`);
+            logger.log(`[${logLabel}] HEARTBEAT_OK`);
           } else {
-            this.logger.log(`[${logLabel}] Response: ${response}`);
+            logger.log(`[${logLabel}] Response: ${response}`);
           }
         }
       } finally {
@@ -150,7 +169,7 @@ export class HeartbeatRunner {
     } finally {
       // Release guard + rotate log regardless of outcome
       this.running.delete(guardKey);
-      this.logger.rotate();
+      logger.rotate();
     }
   }
 
@@ -163,6 +182,7 @@ export class HeartbeatRunner {
     prompt: string,
     logLabel: string,
     entry: HeartbeatEntry,
+    logger: HeartbeatLogger,
   ): Promise<string | null> {
     return new Promise((resolve) => {
       let args: string[];
@@ -193,10 +213,10 @@ export class HeartbeatRunner {
         proc = spawn(agent, args, spawnOptions);
       } catch (err: unknown) {
         if (isAbortError(err)) {
-          this.logger.log(`[${logLabel}] Timed out (300s limit)`);
+          logger.log(`[${logLabel}] Timed out (300s limit)`);
         } else {
           const msg = err instanceof Error ? err.message : String(err);
-          this.logger.log(`[${logLabel}] Failed to spawn: ${msg}`);
+          logger.log(`[${logLabel}] Failed to spawn: ${msg}`);
         }
         resolve(null);
         return;
@@ -210,20 +230,20 @@ export class HeartbeatRunner {
 
       proc.on("error", (err: Error) => {
         if (isAbortError(err)) {
-          this.logger.log(`[${logLabel}] Timed out (300s limit)`);
+          logger.log(`[${logLabel}] Timed out (300s limit)`);
         } else {
-          this.logger.log(`[${logLabel}] Spawn error: ${err.message}`);
+          logger.log(`[${logLabel}] Spawn error: ${err.message}`);
         }
         resolve(null);
       });
 
       proc.on("close", (code: number | null) => {
         if (code === 124) {
-          this.logger.log(`[${logLabel}] Timed out (300s limit)`);
+          logger.log(`[${logLabel}] Timed out (300s limit)`);
           resolve(null);
         } else if (code !== 0) {
           const snippet = stdout.slice(0, 500);
-          this.logger.log(`[${logLabel}] Failed (exit code ${code ?? "null"}): ${snippet}`);
+          logger.log(`[${logLabel}] Failed (exit code ${code ?? "null"}): ${snippet}`);
           resolve(null);
         } else {
           resolve(stdout.trim());
@@ -232,8 +252,32 @@ export class HeartbeatRunner {
     });
   }
 
+  /**
+   * Legacy accessor — returns the primary logger. In single-root mode this
+   * is the sole logger (label `""`) writing to the original
+   * `heartbeats/heartbeat.log` path. In multi-root mode it's the first
+   * logger registered (typically the parent root). Prefer `getLoggerFor`
+   * when an owning root is known.
+   */
   getLogger(): HeartbeatLogger {
-    return this.logger;
+    const first = this.loggers.values().next().value;
+    if (!first) {
+      // Should not happen: constructor guarantees at least one logger.
+      throw new Error("HeartbeatRunner has no loggers registered");
+    }
+    return first;
+  }
+
+  /**
+   * Return the logger owned by `root`. Falls back to the primary logger if
+   * no per-label logger is registered — guarantees callers always get a
+   * usable logger even for unknown roots (e.g., entries from a root that
+   * was removed between discovery and execution).
+   */
+  getLoggerFor(root: WorkspaceRoot): HeartbeatLogger {
+    const byLabel = this.loggers.get(root.label);
+    if (byLabel) return byLabel;
+    return this.getLogger();
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/sandbox/src/lib/heartbeat/scheduler.ts
+++ b/packages/sandbox/src/lib/heartbeat/scheduler.ts
@@ -10,30 +10,43 @@ export interface SchedulerStatus {
   isRunning: boolean;
 }
 
+/**
+ * Internal record pairing a scheduled `Cron` with the owning root label —
+ * saved at schedule time so `sync()` / `stop()` can route the corresponding
+ * log line to the same per-root logger the runner uses for that entry.
+ * Without this the scheduler would have no way to reconstruct the root from
+ * the flat job map, since the composite name strips path info.
+ */
+interface ScheduledJob {
+  cron: Cron;
+  rootLabel: string;
+}
+
 export class HeartbeatScheduler {
-  private jobs: Map<string, Cron> = new Map();
+  private jobs: Map<string, ScheduledJob> = new Map();
   private fingerprints: Map<string, string> = new Map();
   private runner: HeartbeatRunner;
-  private logger: HeartbeatLogger;
 
   constructor(runnerOptions: RunnerOptions) {
     this.runner = new HeartbeatRunner(runnerOptions);
-    this.logger = this.runner.getLogger();
   }
 
   start(entries: HeartbeatEntry[]): void {
     for (const entry of entries) {
       const name = this.entryName(entry);
-      this.jobs.set(name, this.createJob(name, entry));
+      this.jobs.set(name, {
+        cron: this.createJob(name, entry),
+        rootLabel: entry.root.label,
+      });
       this.fingerprints.set(name, this.fingerprint(entry));
-      this.logger.log(`[${name}] Scheduled: ${entry.cronExpr}`);
+      this.loggerFor(entry.root.label).log(`[${name}] Scheduled: ${entry.cronExpr}`);
     }
   }
 
   stop(): void {
-    for (const [name, cron] of this.jobs) {
-      cron.stop();
-      this.logger.log(`[${name}] Stopped`);
+    for (const [name, job] of this.jobs) {
+      job.cron.stop();
+      this.loggerFor(job.rootLabel).log(`[${name}] Stopped`);
     }
     this.jobs.clear();
     this.fingerprints.clear();
@@ -50,22 +63,25 @@ export class HeartbeatScheduler {
     }
 
     // Stop removed or changed jobs
-    for (const [name, cron] of this.jobs) {
+    for (const [name, job] of this.jobs) {
       const newFp = newFps.get(name);
       if (!newFp || newFp !== this.fingerprints.get(name)) {
-        cron.stop();
+        job.cron.stop();
         this.jobs.delete(name);
         this.fingerprints.delete(name);
-        this.logger.log(`[${name}] Stopped (${newFp ? "changed" : "removed"})`);
+        this.loggerFor(job.rootLabel).log(`[${name}] Stopped (${newFp ? "changed" : "removed"})`);
       }
     }
 
     // Start new or changed jobs
     for (const [name, entry] of newMap) {
       if (!this.jobs.has(name)) {
-        this.jobs.set(name, this.createJob(name, entry));
+        this.jobs.set(name, {
+          cron: this.createJob(name, entry),
+          rootLabel: entry.root.label,
+        });
         this.fingerprints.set(name, this.fingerprint(entry));
-        this.logger.log(`[${name}] Scheduled: ${entry.cronExpr}`);
+        this.loggerFor(entry.root.label).log(`[${name}] Scheduled: ${entry.cronExpr}`);
       }
     }
   }
@@ -90,22 +106,40 @@ export class HeartbeatScheduler {
     return `${entry.root.workspacePath}|${entry.cronExpr}|${entry.agent}|${entry.activeStart ?? ""}|${entry.activeEnd ?? ""}`;
   }
 
+  /**
+   * Fetch the logger owned by the given root label from the runner. We go
+   * through the runner (rather than holding a second reference) so there's
+   * only one source of truth for the per-root logger map — the runner owns
+   * it, scheduler borrows.
+   */
+  private loggerFor(rootLabel: string): HeartbeatLogger {
+    // Synthetic root object — only `label` is read by getLoggerFor, the
+    // other fields are unused during logger lookup.
+    return this.runner.getLoggerFor({
+      workspacePath: "",
+      heartbeatDir: "",
+      label: rootLabel,
+    });
+  }
+
   private createJob(name: string, entry: HeartbeatEntry): Cron {
     return new Cron(entry.cronExpr, async () => {
       try {
         await this.runner.run(entry);
       } catch (err) {
-        this.logger.log(`[${name}] Error: ${err instanceof Error ? err.message : String(err)}`);
+        this.loggerFor(entry.root.label).log(
+          `[${name}] Error: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     });
   }
 
   status(): SchedulerStatus[] {
-    return Array.from(this.jobs.entries()).map(([name, cron]) => ({
+    return Array.from(this.jobs.entries()).map(([name, job]) => ({
       name,
-      cronExpr: cron.getPattern() ?? "",
-      nextRun: cron.nextRun(),
-      isRunning: cron.isRunning(),
+      cronExpr: job.cron.getPattern() ?? "",
+      nextRun: job.cron.nextRun(),
+      isRunning: job.cron.isRunning(),
     }));
   }
 


### PR DESCRIPTION
Closes #73

Stacked on #72 (PR-1 — branch `feat/71-mwh-pr1`). Implements PR-2 of `.claude/specs/multi-worktree-heartbeats-spec.md` — `discoverWorkspaceRoots`, multi-root watcher, `cwd` on spawn, `HEARTBEAT_MAX_CONCURRENT`.

## Summary

- `lib/heartbeat/discovery.ts` — `discoverWorkspaceRoots(home, overrides?)` parses `git worktree list --porcelain`, keeps worktrees with `workspace/heartbeats/`, labels from branch refs (e.g. `refs/heads/agent/sdr-pallet` → `agent-sdr-pallet`, detached → `detached-<shortsha>`). `HEARTBEAT_ROOTS=path:label,...` overrides/augments.
- `HeartbeatDaemon` owns **N** `fs.watch` instances (one per root), shared debounced `sync()`, missing dirs skipped without aborting siblings.
- `HeartbeatRunner` passes `cwd = entry.root.workspacePath` to `spawn()` **only** for labelled (discovered) roots — single-root back-compat keeps the legacy `cwd`-inheriting shape and all 216 existing tests pass byte-identically.
- `HEARTBEAT_MAX_CONCURRENT` semaphore (default 2, `0` disables). FIFO waiters time out at 300 s and log `Skipped (concurrency cap reached)`. Sync fast path avoids an extra microtask hop.
- `cli/heartbeat-daemon` uses discovery at startup; falls back to the legacy single-root constructor when discovery finds zero roots.

Per-root logger split and `.git/worktrees/` hot add/remove watcher remain out of scope (PR-3, PR-4).

Reviewer note — because we spawn with `cwd` inside the worktree, the `claude` CLI loads that worktree's `.claude/settings.json`. This is the desired behaviour (spec Open Question #3 — each agent branch is its own universe).

## Test plan

- [x] `pnpm --filter @openharness/sandbox test` — **245 passed** (216 baseline + 29 new)
- [x] `pnpm --filter @openharness/sandbox run build` — clean
- [x] `pnpm --filter @openharness/sandbox run lint` — clean
- [x] `pnpm --filter @openharness/sandbox run format:check` — clean
- [ ] Manual integration: two worktrees with `workspace/heartbeats/`, daemon reports both roots and each worktree's heartbeats fire with `cwd` inside its worktree (deferred to merge-time validation inside the sandbox)

New tests:
- `heartbeat-discovery.test.ts` (12) — real git repo + worktrees exercise porcelain parsing end-to-end; `HEARTBEAT_ROOTS` merge/override; label sanitisation
- `heartbeat-scheduler.test.ts` (+4) — same-filename entries in two roots scheduled independently; label-namespaced keys; differential sync
- `heartbeat-runner.test.ts` (+8) — `spawn` called with `cwd === entry.root.workspacePath`; single-root omits `cwd`; per-root guard independence; semaphore cap + release + `maxConcurrent=0` disabled
- `heartbeat-daemon.test.ts` (+4) — N watchers start / all close on stop / debounce coalesces across roots / missing-dir tolerance
- `heartbeat-config.test.ts` (+3) — `parseHeartbeatConfigAcrossRoots` merging