### PR TITLE
FROM feat/77-mwh-pr4 TO feat/75-mwh-pr3

### DIFF
--- a/packages/sandbox/src/__tests__/heartbeat-daemon.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-daemon.test.ts
@@ -47,6 +47,13 @@ vi.mock("../lib/heartbeat/scheduler.js", () => ({
   })),
 }));
 
+// Mock discovery so PR-4 tests can script what `rediscoverRoots()` sees on
+// each call without standing up a real git repo.
+const mockDiscoverWorkspaceRoots = vi.fn();
+vi.mock("../lib/heartbeat/discovery.js", () => ({
+  discoverWorkspaceRoots: (...args: unknown[]) => mockDiscoverWorkspaceRoots(...args),
+}));
+
 // ---------------------------------------------------------------------------
 // Dynamic import of the module under test
 // ---------------------------------------------------------------------------
@@ -81,6 +88,7 @@ beforeEach(async () => {
   mockReaddir.mockResolvedValue([]);
   mockReadFile.mockResolvedValue("");
   mockReadFileSync.mockReturnValue("");
+  mockDiscoverWorkspaceRoots.mockReturnValue([]);
 
   // Re-establish scheduler mock after clearAllMocks
   const { HeartbeatScheduler } = await import("../lib/heartbeat/scheduler.js");
@@ -526,6 +534,267 @@ describe("HeartbeatDaemon", () => {
 
       expect(out).not.toContain("Roots:");
       expect(out).toContain("0 0 * * *  →  nightly");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PR-4 — top-level `.git/worktrees/` watcher + rediscoverRoots()
+  // ---------------------------------------------------------------------------
+  describe("top-level worktrees watcher (PR-4)", () => {
+    const ROOT_A = {
+      workspacePath: "/tmp/a/workspace",
+      heartbeatDir: "/tmp/a/workspace/heartbeats",
+      label: "agent-foo",
+    };
+    const ROOT_B = {
+      workspacePath: "/tmp/b/workspace",
+      heartbeatDir: "/tmp/b/workspace/heartbeats",
+      label: "feat-bar",
+    };
+    const ROOT_C = {
+      workspacePath: "/tmp/c/workspace",
+      heartbeatDir: "/tmp/c/workspace/heartbeats",
+      label: "agent-baz",
+    };
+
+    it("does NOT install the top-level watcher for legacy single-root construction", async () => {
+      const fakeWatcher = createFakeWatcher();
+      mockWatch.mockReturnValue(fakeWatcher);
+
+      const daemon = new HeartbeatDaemon(DAEMON_OPTIONS);
+      await daemon.start();
+
+      // Only the heartbeat-dir watcher was created — no second `fs.watch`
+      // call for `.git/worktrees/`.
+      expect(mockWatch).toHaveBeenCalledTimes(1);
+      expect(mockWatch.mock.calls[0][0]).toBe(DAEMON_OPTIONS.heartbeatDir);
+
+      // Discovery must not have been consulted at all for a legacy daemon.
+      expect(mockDiscoverWorkspaceRoots).not.toHaveBeenCalled();
+
+      daemon.stop();
+    });
+
+    it("does NOT install the top-level watcher when multi-root opts omit `rediscover`", async () => {
+      const fakeWatcher = createFakeWatcher();
+      mockWatch.mockReturnValue(fakeWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+      });
+      await daemon.start();
+
+      expect(mockWatch).toHaveBeenCalledTimes(1);
+      expect(mockWatch).toHaveBeenCalledWith(
+        ROOT_A.heartbeatDir,
+        { persistent: false },
+        expect.any(Function),
+      );
+
+      daemon.stop();
+    });
+
+    it("installs a watcher on <home>/harness/.git/worktrees/ when `rediscover` is set", async () => {
+      // Return a distinct fake watcher per call so we can tell which is which.
+      const heartbeatWatcher = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(heartbeatWatcher).mockReturnValueOnce(worktreesWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      expect(mockWatch).toHaveBeenCalledTimes(2);
+      expect(mockWatch).toHaveBeenCalledWith(
+        "/fake/home/harness/.git/worktrees",
+        { persistent: false },
+        expect.any(Function),
+      );
+
+      daemon.stop();
+    });
+
+    it("skips the top-level watcher silently when `.git/worktrees/` does not exist", async () => {
+      // Heartbeat dir exists; worktrees dir does not.
+      mockExistsSync.mockImplementation((p) => {
+        if (String(p) === "/fake/home/harness/.git/worktrees") return false;
+        return true;
+      });
+
+      const heartbeatWatcher = createFakeWatcher();
+      mockWatch.mockReturnValue(heartbeatWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      // Only heartbeat-dir watcher — worktrees dir was missing so no watch.
+      expect(mockWatch).toHaveBeenCalledTimes(1);
+      expect(mockWatch.mock.calls[0][0]).toBe(ROOT_A.heartbeatDir);
+
+      daemon.stop();
+    });
+
+    it("rediscoverRoots() adds a new root: installs its watcher + picks up its entries", async () => {
+      const heartbeatWatcherA = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      const heartbeatWatcherC = createFakeWatcher();
+      mockWatch
+        .mockReturnValueOnce(heartbeatWatcherA) // root A heartbeat dir
+        .mockReturnValueOnce(worktreesWatcher) // .git/worktrees dir
+        .mockReturnValueOnce(heartbeatWatcherC); // root C heartbeat dir (post-rediscovery)
+
+      // Startup discovery would have returned [A]; the constructor accepts
+      // that via `workspaceRoots`. Prime the mock so the next `rediscover`
+      // call returns [A, C] — simulating `git worktree add` for C.
+      mockDiscoverWorkspaceRoots.mockReturnValue([ROOT_A, ROOT_C]);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home", rootsEnv: "OVERRIDE=x" },
+      });
+      await daemon.start();
+
+      // Fire the top-level watcher — capture the callback registered by
+      // the second `fs.watch` call (the worktrees one).
+      const worktreesCallback = mockWatch.mock.calls[1][2] as (
+        event: string,
+        filename: string,
+      ) => void;
+      worktreesCallback("rename", "new-worktree-dir");
+
+      // Advance past the 500ms debounce; rediscovery kicks off.
+      await vi.advanceTimersByTimeAsync(600);
+      // Flush pending microtasks from the async rediscoverRoots call chain.
+      await vi.runAllTimersAsync();
+
+      // Discovery was consulted with the same (home, rootsEnv) the CLI used.
+      expect(mockDiscoverWorkspaceRoots).toHaveBeenCalledWith("/fake/home", "OVERRIDE=x");
+
+      // A heartbeat-dir watcher was installed for the newly-added root C.
+      const watchCalls = mockWatch.mock.calls.map((c) => c[0]);
+      expect(watchCalls).toContain(ROOT_C.heartbeatDir);
+
+      // Scheduler.sync was called (differential re-sync after root changes).
+      expect(mockSchedulerSync).toHaveBeenCalled();
+
+      daemon.stop();
+    });
+
+    it("rediscoverRoots() removes a vanished root: closes its watcher + drops its logger entry", async () => {
+      const heartbeatWatcherA = createFakeWatcher();
+      const heartbeatWatcherB = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch
+        .mockReturnValueOnce(heartbeatWatcherA)
+        .mockReturnValueOnce(heartbeatWatcherB)
+        .mockReturnValueOnce(worktreesWatcher);
+
+      // Fresh discovery now returns only [A] — B vanished (e.g., `git worktree remove`).
+      mockDiscoverWorkspaceRoots.mockReturnValue([ROOT_A]);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A, ROOT_B],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      const worktreesCallback = mockWatch.mock.calls[2][2] as (
+        event: string,
+        filename: string,
+      ) => void;
+      worktreesCallback("rename", "removed-dir");
+
+      await vi.advanceTimersByTimeAsync(600);
+      await vi.runAllTimersAsync();
+
+      // Root B's heartbeat-dir watcher must have been closed.
+      expect(heartbeatWatcherB.close).toHaveBeenCalled();
+      // Root A's heartbeat-dir watcher must still be open.
+      expect(heartbeatWatcherA.close).not.toHaveBeenCalled();
+      // Scheduler was re-synced so it drops B's entries on next pass.
+      expect(mockSchedulerSync).toHaveBeenCalled();
+
+      daemon.stop();
+    });
+
+    it("rediscoverRoots() is a no-op when `rediscover` is unset", async () => {
+      const daemon = new HeartbeatDaemon(DAEMON_OPTIONS);
+      await daemon.start();
+
+      // Direct call — should return immediately and never consult discovery.
+      await daemon.rediscoverRoots();
+      expect(mockDiscoverWorkspaceRoots).not.toHaveBeenCalled();
+
+      daemon.stop();
+    });
+
+    it("stop() closes the top-level watcher too", async () => {
+      const heartbeatWatcher = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(heartbeatWatcher).mockReturnValueOnce(worktreesWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+      daemon.stop();
+
+      expect(heartbeatWatcher.close).toHaveBeenCalledOnce();
+      expect(worktreesWatcher.close).toHaveBeenCalledOnce();
+    });
+
+    it("debounces rapid top-level events into a single rediscovery", async () => {
+      const heartbeatWatcher = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(heartbeatWatcher).mockReturnValueOnce(worktreesWatcher);
+
+      mockDiscoverWorkspaceRoots.mockReturnValue([ROOT_A]);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      const worktreesCallback = mockWatch.mock.calls[1][2] as (
+        event: string,
+        filename: string,
+      ) => void;
+
+      // Burst — git emits multiple events during `worktree add`.
+      worktreesCallback("rename", "a");
+      worktreesCallback("rename", "b");
+      worktreesCallback("rename", "c");
+
+      await vi.advanceTimersByTimeAsync(600);
+      await vi.runAllTimersAsync();
+
+      // Discovery consulted exactly once despite three events.
+      expect(mockDiscoverWorkspaceRoots).toHaveBeenCalledTimes(1);
+
+      daemon.stop();
+    });
+
+    it("top-level watcher errors do not throw", async () => {
+      const heartbeatWatcher = createFakeWatcher();
+      const worktreesWatcher = createFakeWatcher();
+      mockWatch.mockReturnValueOnce(heartbeatWatcher).mockReturnValueOnce(worktreesWatcher);
+
+      const daemon = new HeartbeatDaemon({
+        workspaceRoots: [ROOT_A],
+        rediscover: { home: "/fake/home" },
+      });
+      await daemon.start();
+
+      expect(() => worktreesWatcher.emit("error", new Error("ENOSPC"))).not.toThrow();
+
+      daemon.stop();
     });
   });
 });

--- a/packages/sandbox/src/cli/heartbeat-daemon.ts
+++ b/packages/sandbox/src/cli/heartbeat-daemon.ts
@@ -21,6 +21,13 @@ const daemon = discovered.length
       workspaceRoots: discovered,
       defaultAgent: process.env.HEARTBEAT_AGENT ?? "claude",
       defaultInterval: parseInt(process.env.HEARTBEAT_INTERVAL ?? "1800", 10),
+      // PR-4 — enable hot worktree add/remove. The daemon watches
+      // `<HOME>/harness/.git/worktrees/` and re-runs the same discovery
+      // call (with the same overrides) whenever git mutates that dir.
+      rediscover: {
+        home: HOME,
+        rootsEnv: process.env.HEARTBEAT_ROOTS,
+      },
     })
   : new HeartbeatDaemon({
       workspacePath: WORKSPACE,

--- a/packages/sandbox/src/lib/heartbeat/daemon.ts
+++ b/packages/sandbox/src/lib/heartbeat/daemon.ts
@@ -7,9 +7,17 @@ import {
 } from "./config.js";
 import { HeartbeatScheduler } from "./scheduler.js";
 import { HeartbeatLogger } from "./logger.js";
+import { discoverWorkspaceRoots } from "./discovery.js";
 import type { RunnerOptions } from "./runner.js";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, watch, type FSWatcher } from "node:fs";
 import { join } from "node:path";
+
+/**
+ * Soft cap: warn (don't fail) when the number of watched roots exceeds this.
+ * Node's default inotify limit is ~8k; realistic worktree counts never get
+ * close, so exceeding this almost always indicates a mis-discovery loop.
+ */
+const ROOT_COUNT_WARN_THRESHOLD = 32;
 
 /**
  * Legacy single-root options — a bare workspace + heartbeat directory.
@@ -34,6 +42,27 @@ export interface MultiRootDaemonOptions {
   workspaceRoots: WorkspaceRoot[];
   defaultAgent?: string;
   defaultInterval?: number;
+  /**
+   * PR-4 — opt-in hot worktree add/remove. When set, the daemon installs a
+   * watcher on `<home>/harness/.git/worktrees/` (git's own worktree-tracking
+   * directory) and re-runs `discoverWorkspaceRoots(home, rootsEnv)` whenever
+   * entries appear or disappear. Newly-discovered roots get a heartbeat-dir
+   * watcher + logger; removed roots have theirs torn down. The scheduler is
+   * differentially re-synced.
+   *
+   * Callers that construct `workspaceRoots` manually (e.g. tests, operators
+   * pinning a fixed list) can omit this — the top-level watcher simply never
+   * starts.
+   */
+  rediscover?: {
+    /** Absolute path used as the HOME argument to `discoverWorkspaceRoots`. */
+    home: string;
+    /**
+     * Raw value of `HEARTBEAT_ROOTS` (or equivalent override string) so
+     * rediscovery honours the same overrides the CLI used at startup.
+     */
+    rootsEnv?: string;
+  };
 }
 
 export type DaemonOptions = LegacyDaemonOptions | MultiRootDaemonOptions;
@@ -47,6 +76,12 @@ interface NormalizedDaemonOptions {
   roots: WorkspaceRoot[];
   defaultAgent?: string;
   defaultInterval?: number;
+  /**
+   * Present only when constructed via `MultiRootDaemonOptions.rediscover`.
+   * Drives the `.git/worktrees/` watcher in PR-4. Legacy single-root setups
+   * never set this, so rediscovery is a no-op there.
+   */
+  rediscover?: MultiRootDaemonOptions["rediscover"];
 }
 
 function isMultiRoot(opts: DaemonOptions): opts is MultiRootDaemonOptions {
@@ -59,6 +94,7 @@ function normalize(opts: DaemonOptions): NormalizedDaemonOptions {
       roots: opts.workspaceRoots,
       defaultAgent: opts.defaultAgent,
       defaultInterval: opts.defaultInterval,
+      rediscover: opts.rediscover,
     };
   }
   // Legacy shape → wrap into a single-root array with label "" so composite
@@ -87,9 +123,29 @@ export class HeartbeatDaemon {
    * behavioural change.
    */
   private loggers: Map<string, HeartbeatLogger>;
-  /** One watcher per root — all fire the same debounced sync. */
-  private watchers: FSWatcher[] = [];
+  /**
+   * Per-root heartbeat-dir watchers keyed by `root.label`. Keyed (not an
+   * array) so PR-4's `rediscoverRoots()` can tear down a single root's
+   * watcher when its worktree disappears, without disturbing the others.
+   */
+  private heartbeatWatchers: Map<string, FSWatcher> = new Map();
   private watchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * PR-4 — watcher on `<home>/harness/.git/worktrees/`. Fires when git adds
+   * or removes a worktree entry; callback triggers `rediscoverRoots()` to
+   * differentially sync roots. `null` when not in multi-root rediscovery
+   * mode, when `.git/worktrees/` doesn't exist yet, or after `stop()`.
+   */
+  private topLevelWatcher: FSWatcher | null = null;
+  private topLevelDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Serializes `rediscoverRoots()` calls so overlapping top-level-watcher
+   * events (e.g. `git worktree add` emits multiple mutation events in
+   * rapid succession) can't interleave logger/watcher teardown with
+   * startup. The debounce timer already coalesces bursts; this guards
+   * against a regular `sync()` racing a rediscovery.
+   */
+  private rediscoverInFlight: Promise<void> | null = null;
   private normalized: NormalizedDaemonOptions;
   /** Primary root — used for logger, migrate, and legacy-shim scenarios. */
   private primaryRoot: WorkspaceRoot;
@@ -178,42 +234,237 @@ export class HeartbeatDaemon {
   /** Start one file watcher per root's heartbeats directory. */
   private startWatching(): void {
     for (const root of this.normalized.roots) {
-      const dir = root.heartbeatDir;
-      if (!existsSync(dir)) continue;
-
-      try {
-        const watcher = watch(dir, { persistent: false }, (_event, filename) => {
-          // Only react to .md file changes
-          if (!filename || !filename.endsWith(".md")) return;
-
-          // Debounce: coalesce rapid events (from any root) into a single sync
-          if (this.watchDebounceTimer) clearTimeout(this.watchDebounceTimer);
-          this.watchDebounceTimer = setTimeout(() => {
-            this.watchDebounceTimer = null;
-            this.sync().catch((err) => {
-              // Watcher errors are daemon-scope (not tied to a specific
-              // entry), so route them to the affected root's logger if we
-              // know it, otherwise the primary (parent) logger.
-              this.loggerFor(root.label).log(
-                `[watcher] Sync error: ${err instanceof Error ? err.message : String(err)}`,
-              );
-            });
-          }, 500);
-        });
-
-        watcher.on("error", (err) => {
-          this.loggerFor(root.label).log(
-            `[watcher:${root.label || "parent"}] Error: ${err.message}`,
-          );
-        });
-
-        this.watchers.push(watcher);
-      } catch (err) {
-        this.loggerFor(root.label).log(
-          `[watcher:${root.label || "parent"}] Failed to watch ${dir}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      this.watchRoot(root);
     }
+    // PR-4 — only install the top-level watcher when rediscovery is
+    // configured. Legacy single-root (opts.rediscover undefined) never
+    // watches `.git/worktrees/` because no caller could act on the event.
+    this.startTopLevelWatcher();
+  }
+
+  /**
+   * Install a heartbeat-directory watcher for a single root. Extracted from
+   * `startWatching()` so PR-4's `rediscoverRoots()` can add watchers for
+   * newly-discovered roots without re-iterating the whole set.
+   *
+   * Idempotent: if a watcher already exists for this label, returns
+   * early. Silently skips roots whose `heartbeatDir` is missing — those
+   * will be picked up on the next rediscovery if they appear later.
+   */
+  private watchRoot(root: WorkspaceRoot): void {
+    if (this.heartbeatWatchers.has(root.label)) return;
+
+    const dir = root.heartbeatDir;
+    if (!existsSync(dir)) return;
+
+    try {
+      const watcher = watch(dir, { persistent: false }, (_event, filename) => {
+        // Only react to .md file changes
+        if (!filename || !filename.endsWith(".md")) return;
+
+        // Debounce: coalesce rapid events (from any root) into a single sync
+        if (this.watchDebounceTimer) clearTimeout(this.watchDebounceTimer);
+        this.watchDebounceTimer = setTimeout(() => {
+          this.watchDebounceTimer = null;
+          this.sync().catch((err) => {
+            // Watcher errors are daemon-scope (not tied to a specific
+            // entry), so route them to the affected root's logger if we
+            // know it, otherwise the primary (parent) logger.
+            this.loggerFor(root.label).log(
+              `[watcher] Sync error: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+        }, 500);
+      });
+
+      watcher.on("error", (err) => {
+        this.loggerFor(root.label).log(`[watcher:${root.label || "parent"}] Error: ${err.message}`);
+      });
+
+      this.heartbeatWatchers.set(root.label, watcher);
+    } catch (err) {
+      this.loggerFor(root.label).log(
+        `[watcher:${root.label || "parent"}] Failed to watch ${dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /** Close and drop the heartbeat-dir watcher for a single root (if any). */
+  private unwatchRoot(label: string): void {
+    const watcher = this.heartbeatWatchers.get(label);
+    if (!watcher) return;
+    try {
+      watcher.close();
+    } catch {
+      // ignore — watcher may already be closed
+    }
+    this.heartbeatWatchers.delete(label);
+  }
+
+  /**
+   * PR-4 — watch `<home>/harness/.git/worktrees/` so new or removed
+   * worktrees are picked up without a daemon restart. Git maintains one
+   * subdirectory in that path per non-parent worktree; directory entries
+   * appearing/disappearing exactly corresponds to worktrees being
+   * added/removed, which is what we want to react to.
+   *
+   * Only installs the watcher when:
+   *  1. The constructor was given `rediscover` options (i.e., the CLI
+   *     provisioned this daemon via discovery); AND
+   *  2. `<home>/harness/.git/worktrees/` exists.
+   *
+   * Skipped silently otherwise — both cases are normal (legacy single-root
+   * daemon, fresh repo with no worktrees, non-git test fixtures).
+   */
+  private startTopLevelWatcher(): void {
+    const rediscover = this.normalized.rediscover;
+    if (!rediscover) return;
+
+    const worktreesDir = join(rediscover.home, "harness", ".git", "worktrees");
+    if (!existsSync(worktreesDir)) {
+      this.primaryLogger().log(
+        `[watcher:worktrees] ${worktreesDir} does not exist — hot worktree add/remove disabled`,
+      );
+      return;
+    }
+
+    try {
+      const watcher = watch(worktreesDir, { persistent: false }, () => {
+        // Git briefly creates/deletes intermediary dirs during a single
+        // `worktree add` — same 500ms debounce as the heartbeat-dir watcher
+        // so a burst collapses to one rediscovery pass.
+        if (this.topLevelDebounceTimer) clearTimeout(this.topLevelDebounceTimer);
+        this.topLevelDebounceTimer = setTimeout(() => {
+          this.topLevelDebounceTimer = null;
+          void this.rediscoverRoots().catch((err) => {
+            this.primaryLogger().log(
+              `[watcher:worktrees] Rediscovery error: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+        }, 500);
+      });
+
+      watcher.on("error", (err) => {
+        this.primaryLogger().log(`[watcher:worktrees] Error: ${err.message}`);
+      });
+
+      this.topLevelWatcher = watcher;
+    } catch (err) {
+      this.primaryLogger().log(
+        `[watcher:worktrees] Failed to watch ${worktreesDir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /** Close the top-level watcher and clear its debounce timer. */
+  private stopTopLevelWatcher(): void {
+    if (this.topLevelDebounceTimer) {
+      clearTimeout(this.topLevelDebounceTimer);
+      this.topLevelDebounceTimer = null;
+    }
+    if (this.topLevelWatcher) {
+      try {
+        this.topLevelWatcher.close();
+      } catch {
+        // ignore — watcher may already be closed
+      }
+      this.topLevelWatcher = null;
+    }
+  }
+
+  /**
+   * PR-4 — re-run discovery and differentially reconcile roots.
+   *
+   * Triggered by the `.git/worktrees/` watcher (or called directly from
+   * tests). Steps:
+   *   1. Re-run `discoverWorkspaceRoots(home, rootsEnv)`.
+   *   2. Diff against `this.normalized.roots` by `workspacePath`:
+   *        added   = new  - old
+   *        removed = old  - new
+   *      Untouched paths keep their existing logger/watcher instances.
+   *   3. For each removed root: close its heartbeat-dir watcher, drop its
+   *      logger, drop it from `normalized.roots`.
+   *   4. For each added root: instantiate a logger, install a heartbeat-dir
+   *      watcher, append to `normalized.roots`.
+   *   5. Call `sync()` once so the scheduler differentially reconciles
+   *      entries (scheduler already handles add/remove correctly).
+   *
+   * Serialized via `rediscoverInFlight` so overlapping top-level events
+   * queue rather than interleave. Safe to call when `rediscover` is unset —
+   * it simply returns.
+   */
+  async rediscoverRoots(): Promise<void> {
+    const rediscover = this.normalized.rediscover;
+    if (!rediscover) return;
+
+    // Serialize: if a rediscovery is in flight, wait for it to finish then
+    // run our own pass (the FS state could have changed again in the gap).
+    if (this.rediscoverInFlight) {
+      await this.rediscoverInFlight;
+    }
+
+    this.rediscoverInFlight = this.doRediscover(rediscover);
+    try {
+      await this.rediscoverInFlight;
+    } finally {
+      this.rediscoverInFlight = null;
+    }
+  }
+
+  private async doRediscover(
+    rediscover: NonNullable<NormalizedDaemonOptions["rediscover"]>,
+  ): Promise<void> {
+    const fresh = discoverWorkspaceRoots(rediscover.home, rediscover.rootsEnv);
+
+    const oldByPath = new Map(this.normalized.roots.map((r) => [r.workspacePath, r]));
+    const newByPath = new Map(fresh.map((r) => [r.workspacePath, r]));
+
+    const added: WorkspaceRoot[] = [];
+    const removed: WorkspaceRoot[] = [];
+    for (const [path, root] of newByPath) {
+      if (!oldByPath.has(path)) added.push(root);
+    }
+    for (const [path, root] of oldByPath) {
+      if (!newByPath.has(path)) removed.push(root);
+    }
+
+    if (added.length === 0 && removed.length === 0) return;
+
+    // Tear down removed roots first so their watcher/logger state is gone
+    // before `sync()` re-parses and the scheduler drops their entries.
+    for (const root of removed) {
+      this.unwatchRoot(root.label);
+      this.loggers.delete(root.label);
+      this.primaryLogger().log(
+        `[watcher:worktrees] Removed root ${root.label || "parent"} (${root.workspacePath})`,
+      );
+    }
+
+    // Bring in new roots: logger first, then watcher (watcher callback uses
+    // `loggerFor(root.label)`).
+    for (const root of added) {
+      this.loggers.set(root.label, new HeartbeatLogger(join(root.heartbeatDir, "heartbeat.log")));
+      this.watchRoot(root);
+      this.primaryLogger().log(
+        `[watcher:worktrees] Added root ${root.label || "parent"} (${root.workspacePath})`,
+      );
+    }
+
+    // Replace the normalized root list with the fresh set in their
+    // deterministic path-sorted order so logs/status remain stable.
+    this.normalized.roots = fresh;
+
+    // Soft warn if we blow past the watcher threshold — see
+    // ROOT_COUNT_WARN_THRESHOLD rationale.
+    if (this.normalized.roots.length > ROOT_COUNT_WARN_THRESHOLD) {
+      this.primaryLogger().log(
+        `[watcher:worktrees] Warning: ${this.normalized.roots.length} roots exceeds soft cap of ${ROOT_COUNT_WARN_THRESHOLD}`,
+      );
+    }
+
+    // Differential scheduler re-sync. The scheduler is idempotent so it's
+    // fine if a regular heartbeat-dir event fires during this window.
+    await this.sync();
   }
 
   /** Close every file watcher and clear any pending debounce timer */
@@ -222,14 +473,15 @@ export class HeartbeatDaemon {
       clearTimeout(this.watchDebounceTimer);
       this.watchDebounceTimer = null;
     }
-    for (const watcher of this.watchers) {
+    for (const watcher of this.heartbeatWatchers.values()) {
       try {
         watcher.close();
       } catch {
         // ignore — watcher may already be closed
       }
     }
-    this.watchers = [];
+    this.heartbeatWatchers.clear();
+    this.stopTopLevelWatcher();
   }
 
   /**


### PR DESCRIPTION
Closes #77

Stacked on #76 → #74 → #72. Implements PR-4 of .claude/specs/multi-worktree-heartbeats-spec.md — top-level .git/worktrees/ watcher for hot add/remove.

## What changed

- `HeartbeatDaemon` gains an optional `rediscover: { home, rootsEnv }` field on multi-root options. When set, the daemon watches `<HOME>/harness/.git/worktrees/` and re-runs `discoverWorkspaceRoots()` whenever git mutates that directory.
- New `rediscoverRoots()` method: diffs fresh discovery against current roots by `workspacePath`, tears down removed roots (watcher + logger), stands up added roots (logger + watcher), then `sync()` reconciles the scheduler.
- Per-root heartbeat-dir watchers moved from an array to a label-keyed `Map` so individual roots can be un-watched cleanly.
- Same 500ms debounce as heartbeat-dir watcher absorbs the burst git emits during `worktree add`.
- `rediscoverInFlight` promise serializes overlapping top-level events.
- CLI opts-in by passing `rediscover` when discovery yields at least one root.
- Legacy single-root construction and multi-root construction without `rediscover` never install the top-level watcher — no behavioural change for existing callers.
- `stop()` now closes the top-level watcher alongside per-root watchers.

## Tests (260 total, 9 new in heartbeat-daemon.test.ts)

- Legacy single-root: top-level watcher is NOT installed.
- Multi-root without `rediscover`: top-level watcher is NOT installed.
- Multi-root with `rediscover`: watches `<home>/harness/.git/worktrees`.
- Missing `.git/worktrees/` is silently skipped.
- Added worktree → new root's heartbeat-dir watcher installed, `sync()` called.
- Removed worktree → removed root's watcher closed, `sync()` called.
- `rediscoverRoots()` is a no-op when `rediscover` is unset.
- `stop()` closes the top-level watcher.
- Rapid event burst debounced to a single discovery pass.
- Top-level watcher errors do not throw.

## Verification

- `pnpm --filter @openharness/sandbox run build` — passes
- `pnpm --filter @openharness/sandbox test` — 260 passed (11 files)
- `pnpm --filter @openharness/sandbox run lint` — clean
- `pnpm --filter @openharness/sandbox run format:check` — clean