### PR TITLE
FROM task/83-docs-arch TO development

### DIFF
--- a/docs/content/docs/architecture/how-it-works.mdx
+++ b/docs/content/docs/architecture/how-it-works.mdx
@@ -18,7 +18,7 @@ When you start a sandbox (`openharness sandbox` or `docker compose up`), this se
    - Matches the container's Docker group GID to the host socket GID (fixes DinD permissions)
    - Fixes volume ownership (root → sandbox user)
    - Runs conditional SSH server setup if sshd overlay is active
-   - Starts the heartbeat daemon (`heartbeat-daemon start`) to watch `heartbeats/` for scheduled tasks
+   - Starts the heartbeat daemon (`heartbeat-daemon start`) to watch every worktree's `heartbeats/` directory for scheduled tasks — see [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees)
    - Runs `workspace/startup.sh` as the sandbox user
    - Prints first-boot onboarding message if not yet onboarded
    - Execs the container command (`sleep infinity` by default, or `sshd -D` with the sshd overlay)

--- a/docs/content/docs/architecture/meta.json
+++ b/docs/content/docs/architecture/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Architecture",
-  "pages": ["overview", "structure", "how-it-works"]
+  "pages": ["overview", "structure", "orchestrator-worktrees", "how-it-works"]
 }

--- a/docs/content/docs/architecture/orchestrator-worktrees.mdx
+++ b/docs/content/docs/architecture/orchestrator-worktrees.mdx
@@ -1,0 +1,262 @@
+---
+title: "Orchestrator + Worktrees"
+description: "One sandbox, N git worktrees, one heartbeat daemon — the canonical shape for running multiple agents together."
+---
+
+
+Open Harness runs on a single pattern: **one parent sandbox, N git worktrees, one heartbeat daemon**. Every agent is a git branch checked out as a worktree under `.worktrees/`. The sandbox container bind-mounts the entire repo, so all worktrees are visible to one shared toolchain and one shared credential set. A single heartbeat daemon inside the sandbox watches all of them at once.
+
+This page explains the topology, who owns what, and how a new agent comes online. For implementation detail (file paths, scheduler keys, change targets), see the [canonical spec](https://github.com/ryaneggz/open-harness/blob/development/.claude/specs/orchestrator-worktree-architecture.md).
+
+## At a glance
+
+```mermaid
+flowchart TB
+  subgraph host["Host — /home/sandbox/harness"]
+    direction TB
+    gitreg[".git/worktrees/<br/>(git's worktree registry)"]
+    parent["workspace/<br/>(parent-branch workspace)"]
+    subgraph wts[".worktrees/"]
+      direction TB
+      wt1["agent/sdr-pallet/workspace/<br/>heartbeats · crm · memory · .claude/skills"]
+      wt2["feat/71-mwh-pr1/workspace/<br/>(ephemeral PR worktree)"]
+      wt3["… more worktrees …"]
+    end
+  end
+  subgraph box["oh-remote container (bind-mount of host)"]
+    direction TB
+    daemon["heartbeat-daemon<br/>(single Node process)"]
+    tools["Shared toolchain<br/>claude · codex · pi · pnpm · git · gh"]
+    creds["Shared credentials<br/>~/.claude · ~/.pi · ~/.config/gh"]
+  end
+  daemon -. "top-level watch" .-> gitreg
+  daemon -. "heartbeats watch" .-> parent
+  daemon -. "heartbeats watch" .-> wt1
+  daemon -. "heartbeats watch" .-> wt2
+  box -.->|"bind mount"| host
+```
+
+One container. N git worktrees. One daemon watching every worktree's `heartbeats/` directory at once.
+
+## Why this shape
+
+- **Branches have identities.** An `agent/<name>` branch owns a whole workspace — SOUL.md, skills, CRM, heartbeats, memory. Agent identity is files on disk, not runtime config.
+- **One container per agent is too heavy.** A sandbox is a real OS with its own toolchain, credentials, and dev servers. Duplicating that per agent explodes resource use.
+- **Merging agent work back is a git problem.** Git worktrees already solve "multiple branches checked out at once." The natural fit: worktrees on the host, one container for all of them.
+
+## Actors
+
+### Orchestrator
+
+- **Runs at:** the project root (`/home/sandbox/harness`) — usually a Claude Code session attached to the sandbox.
+- **Owns:** harness source (`packages/sandbox/`, `.devcontainer/`, `install/`), git operations, GitHub issues/PRs/releases, sandbox lifecycle skills (`/provision`, `/destroy`, `/repair`), and the one-time scaffold of each new agent's `workspace/`.
+- **Does not write application code.** Agents do that inside their workspaces.
+
+### Worktree agent
+
+- **Runs at:** `.worktrees/<prefix>/<slug>/workspace/` — either as an interactive `claude` session or as a short-lived heartbeat spawn.
+- **Owns:** its `workspace/` subtree (SOUL.md, MEMORY.md, skills, heartbeats, memory, crm, wiki, projects) and its branch history.
+- **Does not touch:** harness source, other worktrees, or the daemon.
+
+### Sandbox container
+
+Default name `oh-remote`. Bind-mounts `/home/sandbox/harness` into the container so all worktrees are visible automatically. Hosts the shared toolchain (`claude`, `codex`, `pi`, `pnpm`, `git`, `gh`, Docker socket) and shared credentials (`~/.claude`, `~/.pi`, `~/.config/gh`). Boots via `install/entrypoint.sh`, which starts the heartbeat daemon under a watchdog.
+
+### Heartbeat daemon
+
+One Node process per sandbox. On startup (and whenever `.git/worktrees/` changes), it runs `git worktree list --porcelain` and includes every worktree whose `workspace/heartbeats/` exists. Each worktree gets its own `fs.watch`, its own log file, and namespaced scheduler keys (`${label}::${slug}`) so two worktrees can ship identically-named heartbeats without collision. Each heartbeat spawn sets `cwd = <worktree>/workspace`, so the agent CLI resolves skills, settings, and relative paths against the correct worktree. See the [heartbeats guide](/docs/guide/heartbeats) for env vars and log layout.
+
+## Lifecycle of a new agent
+
+```mermaid
+sequenceDiagram
+  actor Orc as Orchestrator
+  participant Git as Git / Host FS
+  participant Daemon as Heartbeat Daemon<br/>(inside sandbox)
+  participant Agent as Spawned Agent<br/>(claude -p)
+
+  Orc->>Git: gh issue create --label agent
+  Orc->>Git: git worktree add -b agent/<name><br/>.worktrees/agent/<name> development
+  Git-->>Git: .git/worktrees/<name>/ created
+  Git-->>Daemon: top-level watcher fires
+
+  Daemon->>Git: git worktree list --porcelain
+  Daemon->>Daemon: discoverWorkspaceRoots()<br/>start new per-root fs.watch
+
+  Orc->>Git: scaffold workspace/<br/>(SOUL.md, skills/, heartbeats/, crm/)
+  Orc->>Git: git commit + push
+  Git-->>Daemon: heartbeats/ watcher fires
+  Daemon->>Daemon: sync() — schedule new entries
+
+  Orc->>Git: gh pr create --base development
+  Note over Orc,Agent: orchestrator's job ends here
+
+  Note over Daemon,Agent: cron tick arrives
+  Daemon->>Agent: spawn claude -p<br/>(cwd = <worktree>/workspace)
+  Agent->>Git: writes memory/YYYY-MM-DD.md, crm/...
+  Agent-->>Daemon: stdout (HEARTBEAT_OK or body)
+  Daemon->>Daemon: logger.log(per-root log)
+```
+
+The orchestrator's job ends once the PR is opened. After that, the agent is self-directing on its heartbeat schedule (plus interactive sessions inside the sandbox).
+
+## Discovery
+
+The daemon discovers worktrees from `.git/worktrees/` — git's own authoritative registry — not from walking the filesystem. Rules:
+
+1. Run `git -C <home>/harness worktree list --porcelain`.
+2. Include any worktree whose `<path>/workspace/heartbeats/` exists.
+3. Compute a label: strip `refs/heads/`, replace `/` with `-`, lowercase. `agent/sdr-pallet` → `agent-sdr-pallet`. Detached HEAD → `detached-<shortsha>`.
+4. Honor `HEARTBEAT_ROOTS=path1:label1,path2:label2` overrides. Overrides win on path collisions.
+5. Warn if the discovered root count exceeds 32 (inotify sanity check).
+
+Layout under `.worktrees/` can be nested, flat, or symlinked — discovery doesn't care.
+
+## Spawn semantics
+
+Every heartbeat spawn sets `cwd` to its worktree's `workspace/`:
+
+```ts
+spawn("claude", ["-p", prompt, "--dangerously-skip-permissions"], {
+  cwd: entry.root.workspacePath,        // e.g. .../sdr-pallet/workspace
+  signal: AbortSignal.timeout(300_000),
+});
+```
+
+Consequences:
+
+- `claude` loads that worktree's `workspace/.claude/settings.json` (model, permissions, hooks).
+- Slash-skills resolve against `workspace/.claude/skills/`.
+- Relative paths in prompts (`memory/YYYY-MM-DD.md`, `crm/leads.csv`) land in the right worktree.
+- Credentials are shared — one `gh auth`, one Anthropic key across all agents.
+
+## Isolation properties
+
+| Dimension | Isolated? | Notes |
+|-----------|-----------|-------|
+| Filesystem under `workspace/` | Yes | Each worktree owns its subtree |
+| Git history / branch state | Yes | Worktrees are fully independent |
+| Heartbeat schedules + logs | Yes | Per-root logger, per-root watcher |
+| Agent identity (SOUL.md, skills) | Yes | Per-root, loaded via spawn cwd |
+| Memory + CRM + wiki artifacts | Yes | Per-root directories |
+| Credentials | **No** | One `gh auth`, one Anthropic key |
+| Container runtime | **No** | Same processes, /tmp, network |
+| API quotas | **No** | `HEARTBEAT_MAX_CONCURRENT` smooths bursts |
+| OS / kernel | **No** | One container |
+
+This is **thin isolation** — enough to keep agent artifacts clean and independently committable, not enough to sandbox a hostile agent. All agents in a sandbox must be mutually trusted.
+
+## Worktree vs new sandbox
+
+**Add a new worktree agent when:**
+
+- The work lives on a branch you'd eventually merge back.
+- The agent shares the same stack, credentials, and trust level.
+- You want shared tooling and independent identity.
+- The daemon should schedule it alongside other agents.
+
+**Add a new sandbox when:**
+
+- You need kernel-level isolation (untrusted code, tenant separation).
+- The agent needs a different OS, different base image, or conflicting global tooling.
+- You need isolated rate limits (separate Anthropic account, separate API quota).
+- You're reproducing a customer environment for debugging.
+
+Most "I want to add an agent" cases are the first bucket. New sandboxes are rare.
+
+## Heartbeat firing flow
+
+```mermaid
+sequenceDiagram
+  participant Cron as Croner (per job)
+  participant Runner as HeartbeatRunner
+  participant Sem as Semaphore<br/>(HEARTBEAT_MAX_CONCURRENT)
+  participant Gates as Gates
+  participant Claude as claude CLI
+  participant Logger as Per-root Logger
+
+  Cron->>Runner: tick(entry)
+  Runner->>Sem: tryAcquireSlot()
+
+  alt slot queued > 300s
+    Runner->>Logger: [label::entry] Skipped<br/>(concurrency cap reached)
+  else slot granted
+    Runner->>Runner: concurrency guard<br/>(root, entryName) already running?
+    opt guard hit
+      Runner->>Logger: Skipping — previous still running
+    end
+
+    Runner->>Gates: isActiveHours(start,end)?
+    alt outside window
+      Runner->>Logger: Outside active hours, skipping
+    else active
+      Runner->>Gates: isHeartbeatEmpty(filePath)?
+      alt empty
+        Runner->>Logger: File effectively empty, skipping
+      else has body
+        Runner->>Runner: build prompt<br/>(SOUL.md + heartbeat body + HEARTBEAT_OK rule)
+        Runner->>Claude: spawn(claude, ..., { cwd, signal: 300s })
+        Claude-->>Runner: stdout
+        alt exit 0, contains HEARTBEAT_OK, <300 chars
+          Runner->>Logger: HEARTBEAT_OK
+        else exit 0 with body
+          Runner->>Logger: Response: <body>
+        else timeout / non-zero
+          Runner->>Logger: Timed out / Failed (exit N)
+        end
+      end
+    end
+
+    Runner->>Sem: releaseSlot()
+  end
+```
+
+Key invariants: `cwd` is set per entry, never shared across worktrees. The semaphore is daemon-global and FIFO. Each worktree writes to its own `heartbeats/heartbeat.log`.
+
+## Trust boundary
+
+All worktrees discovered from the main checkout's `.git/worktrees/` are treated as trusted. This is the same trust model as the rest of the sandbox: if you can `git commit` to a branch in this repo, you can make the daemon run code on your behalf. The `--dangerously-skip-permissions` flag on the `claude` spawn makes this explicit. Do not point `HEARTBEAT_ROOTS` at untrusted paths; do not provision a sandbox from a repo you don't own.
+
+## Operational snippets
+
+Add an agent:
+
+```bash
+# From the orchestrator session (project root)
+gh issue create --label agent --title "agent(#N): <name> — <role>"
+git worktree add -b agent/<name> .worktrees/agent/<name> development
+# Scaffold workspace/ for the agent's role
+git commit -m "agent(#N): scaffold <name>"
+git push -u origin agent/<name>
+# Daemon auto-discovers within ~500 ms
+```
+
+Verify it's live:
+
+```bash
+# Inside the sandbox
+heartbeat-daemon status
+# Look for: "Roots:" section includes the agent, per-root schedules listed
+```
+
+Read per-root logs:
+
+```bash
+tail -f /home/sandbox/harness/workspace/heartbeats/heartbeat.log
+tail -f /home/sandbox/harness/.worktrees/agent/<name>/workspace/heartbeats/heartbeat.log
+```
+
+Retire an agent:
+
+```bash
+git worktree remove .worktrees/agent/<name>
+# Daemon drops it on the next .git/worktrees/ mutation
+```
+
+## Further reading
+
+- [How It Works](/docs/architecture/how-it-works) — boot sequence and container environment.
+- [Project Structure](/docs/architecture/structure) — repo layout.
+- [Heartbeats guide](/docs/guide/heartbeats) — multi-root discovery, env vars, log layout.
+- **Canonical spec** — [`.claude/specs/orchestrator-worktree-architecture.md`](https://github.com/ryaneggz/open-harness/blob/development/.claude/specs/orchestrator-worktree-architecture.md) — file-path tables, change-target matrices, failure modes.
+- **Daemon spec** — [`.claude/specs/multi-worktree-heartbeats-spec.md`](https://github.com/ryaneggz/open-harness/blob/development/.claude/specs/multi-worktree-heartbeats-spec.md) — internal daemon design.

--- a/docs/content/docs/architecture/overview.mdx
+++ b/docs/content/docs/architecture/overview.mdx
@@ -3,23 +3,38 @@ title: "Architecture Overview"
 ---
 
 
-Open Harness is a monorepo that provides isolated Docker sandboxes for AI coding agents. The system has three main layers:
+Open Harness is a monorepo that provides isolated Docker sandboxes for AI coding agents, with a shared runtime pattern that lets multiple agents co-exist in one container. The system has four layers:
 
-## CLI & Sandbox Package (`packages/sandbox/`)
+## 1. CLI & Sandbox Package (`packages/sandbox/`)
 
 `@openharness/sandbox` is the core of the system. The `openharness` binary lives in `src/cli/` and handles all user-facing commands: starting, stopping, entering, and cleaning up sandboxes. Container lifecycle operations — Docker Compose command builders and tool definitions — live in `src/tools/` and `src/lib/`. Each tool (sandbox, run, stop, clean, shell, etc.) constructs and executes Docker commands against the `.devcontainer/` configuration.
 
 The package also serves as a Pi Agent extension, registering all tools as both LLM-callable functions and slash commands.
 
-## Container Infrastructure (`.devcontainer/`)
+## 2. Container Infrastructure (`.devcontainer/`)
 
 The Dockerfile and Compose files define the sandbox environment:
 
 - **Dockerfile**: Debian Bookworm with Node.js 22, pnpm, agent CLIs, Docker CLI, GitHub CLI, and dev tools
 - **docker-compose.yml**: Base service with SSH, workspace mount, named volumes for auth persistence
 - **Compose overlays**: Optional services (PostgreSQL, Cloudflare, Docker-in-Docker, SSH) toggled via `.openharness/config.json`
-- **entrypoint.sh**: Container startup logic (Docker GID matching, cron, heartbeat sync)
+- **entrypoint.sh**: Container startup logic (Docker GID matching, cron, heartbeat daemon, onboarding)
+
+## 3. Orchestrator + Worktree Topology
+
+The running configuration is not "one sandbox per agent" — it's **one parent sandbox, N git worktrees, one heartbeat daemon**. Every agent is a git branch checked out as a worktree under `.worktrees/`, each shipping its own `workspace/` (SOUL.md, skills, heartbeats, memory, CRM, wiki). The container bind-mounts the entire repo, so all worktrees are visible to one shared toolchain and one shared credential set.
+
+Ownership splits cleanly:
+
+- **Orchestrator** (session at the project root): owns harness source, git operations, GitHub issues/PRs/releases, and the one-time scaffold of each new agent's workspace.
+- **Worktree agent** (session inside `.worktrees/<prefix>/<slug>/workspace/`): owns its workspace subtree and its branch history.
+
+See [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees) for the full topology, lifecycle, and isolation properties.
+
+## 4. Heartbeat Daemon
+
+A single Node process inside the sandbox watches every worktree's `workspace/heartbeats/` directory at once. It discovers roots from `git worktree list --porcelain` (the authoritative registry), spawns each heartbeat with `cwd` inside the correct worktree, and writes per-root logs. A global semaphore (`HEARTBEAT_MAX_CONCURRENT`, default 2) prevents aligned schedules from saturating shared API quotas. See the [Heartbeats guide](/docs/guide/heartbeats) for configuration detail.
 
 ## Workspace Template (`workspace/`)
 
-The workspace template provides agent identity (SOUL.md, MEMORY.md), operating procedures (AGENTS.md), coding standards (`.claude/rules/`), skills (`.claude/skills/`), and heartbeat schedules. Bind-mounted into the container at `/home/sandbox/harness/workspace/`.
+The workspace template provides agent identity (SOUL.md, MEMORY.md), operating procedures (AGENTS.md), coding standards (`.claude/rules/`), skills (`.claude/skills/`), and heartbeat schedules. Bind-mounted into the container; each worktree carries its own copy, evolved independently on its branch.

--- a/docs/content/docs/architecture/structure.mdx
+++ b/docs/content/docs/architecture/structure.mdx
@@ -75,4 +75,4 @@ The `workspace/` directory contains markdown files that define the agent's ident
 
 `CLAUDE.md` is a symlink to `AGENTS.md` so Claude Code loads operating procedures automatically.
 
-See the [Workspace guide](/docs/guide/workspace) for full details on each file and the ownership model.
+See the [Workspace guide](/docs/guide/workspace) for full details on each file and the ownership model. For how multiple agents share one sandbox via git worktrees, see [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees).

--- a/docs/content/docs/guide/heartbeats.mdx
+++ b/docs/content/docs/guide/heartbeats.mdx
@@ -5,6 +5,8 @@ title: "Heartbeats"
 
 Heartbeats are cron-scheduled tasks that let agents wake, perform work, and go back to sleep. Each heartbeat is a `.md` file in `workspace/heartbeats/` with YAML frontmatter defining its schedule, agent, and active hours.
 
+A single heartbeat daemon inside the sandbox watches every worktree's `heartbeats/` directory at once — see [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees) for the topology.
+
 ## Managing heartbeats
 
 From the host:
@@ -20,7 +22,7 @@ Inside the sandbox:
 
 ```bash
 heartbeat-daemon sync      # force re-read heartbeat files
-heartbeat-daemon status    # show schedules + recent logs
+heartbeat-daemon status    # show schedules + recent logs, grouped by root
 ```
 
 ## Schedule config
@@ -55,25 +57,73 @@ Use the `/heartbeat` skill inside the sandbox:
 /heartbeat check build health every 30 minutes during business hours
 ```
 
-The daemon auto-detects new files within 500ms — no manual sync needed.
+The daemon auto-detects new files within 500 ms — no manual sync needed.
 
-## How it works
+## Multi-root discovery
 
-1. The `heartbeat-daemon` starts on container boot and watches the `heartbeats/` directory
-2. On each cron tick, the daemon checks active hours (if set), then spawns the agent CLI with the `.md` file content as the prompt
-3. If the file is empty or contains only headers/comments, execution is skipped (saves API costs)
-4. If the agent has nothing to report, it replies `HEARTBEAT_OK` and the response is suppressed
-5. When files change, the daemon performs differential sync — only restarting jobs whose config actually changed
+The daemon runs `git worktree list --porcelain` on startup (and whenever `.git/worktrees/` changes) and treats every worktree whose `workspace/heartbeats/` exists as a **root**. Each root gets:
 
-## Global defaults
+- Its own `fs.watch` on `<root>/workspace/heartbeats/`.
+- Its own log file at `<root>/workspace/heartbeats/heartbeat.log`.
+- A label derived from the branch name (`refs/heads/` stripped, `/` → `-`, lowercased). `agent/sdr-pallet` becomes `agent-sdr-pallet`.
+- Namespaced scheduler keys (`${label}::${slug}`) so two worktrees can ship identically-named heartbeats without colliding.
+
+Each heartbeat is spawned with `cwd = <root>/workspace`, so the agent CLI loads that worktree's `.claude/settings.json`, skills, and relative paths (`memory/YYYY-MM-DD.md`, `crm/leads.csv`) resolve correctly.
+
+Single-root setups continue to work unchanged — the legacy daemon construction path passes no `cwd`, byte-identical to pre-multi-root behavior.
+
+## Global environment variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `HEARTBEAT_AGENT` | `claude` | Default agent CLI for heartbeats without an `agent` frontmatter field |
+| `HEARTBEAT_AGENT` | `claude` | Default CLI for heartbeats without an `agent` frontmatter field |
 | `HEARTBEAT_INTERVAL` | `1800` | Default interval (seconds) for legacy `HEARTBEAT.md` fallback |
+| `HEARTBEAT_MAX_CONCURRENT` | `2` | FIFO daemon-wide cap on concurrent `claude -p` spawns. `0` disables the cap. |
+| `HEARTBEAT_ROOTS` | _(unset)_ | Explicit root overrides: `path1:label1,path2:label2`. Overrides win on path collisions. Auto-discovery still runs for paths not listed. |
 
-Per-heartbeat scheduling and active hours are configured via YAML frontmatter.
+`HEARTBEAT_MAX_CONCURRENT` smooths bursts when multiple worktrees' schedules align (e.g., three `morning-pipeline` clones firing at `0 13 * * 1-5`). Queued spawns wait up to 300 s for a slot, then log `Skipped (concurrency cap reached)`.
+
+## `heartbeat-daemon status` output
+
+Output is grouped by root:
+
+```
+Heartbeat daemon: running (pid 12345)
+
+Roots:
+  parent       → /home/sandbox/harness/workspace (3 schedules)
+  sdr-pallet   → /home/sandbox/harness/.worktrees/agent/sdr-pallet/workspace (5 schedules)
+
+Schedules:
+  parent::nightly-release         50 23 * * *     next: 2026-04-19 23:50 UTC
+  parent::test-sys-metrics        */2 * * * *     next: 2026-04-19 17:14 UTC
+  sdr-pallet::morning-pipeline    0 13 * * 1-5    next: 2026-04-20 13:00 UTC
+  ...
+
+Recent log (parent):
+  ...
+Recent log (sdr-pallet):
+  ...
+```
+
+Scripts that grep the legacy `cronExpr → filePath` format still match — the `Roots:` section is additive.
+
+## How it works
+
+1. The daemon starts on container boot and discovers every worktree root with a `workspace/heartbeats/` directory.
+2. It installs one `fs.watch` per root plus a top-level watcher on `.git/worktrees/` for hot add/remove.
+3. On each cron tick, the daemon checks active hours, then spawns the agent CLI with the `.md` file content as the prompt and `cwd` set to that worktree's workspace.
+4. If the file is empty or contains only headers/comments, execution is skipped (saves API costs).
+5. If the agent has nothing to report, it replies `HEARTBEAT_OK` and the response is suppressed.
+6. When files change, the daemon performs differential sync — only restarting jobs whose config actually changed.
 
 ## Logs
 
-Heartbeat logs are written to `workspace/heartbeats/heartbeat.log` inside the container.
+Each root writes its own log:
+
+```bash
+tail -f /home/sandbox/harness/workspace/heartbeats/heartbeat.log
+tail -f /home/sandbox/harness/.worktrees/agent/<name>/workspace/heartbeats/heartbeat.log
+```
+
+Each per-root logger rotates independently when it exceeds 1000 lines (keeps the last 500). Daemon-level messages (startup, discovery errors) go to the parent root's log.

--- a/workspace/wiki/index.md
+++ b/workspace/wiki/index.md
@@ -1,18 +1,19 @@
 # Wiki Index
 
-> Last updated: —
-> Pages: 0 | Sources: 0
+> Last updated: 2026-04-19
+> Pages: 1 | Sources: 0
 
 ## Pages
 
 | File | Title | Type | Tags | Sources | Updated |
 |------|-------|------|------|---------|---------|
+| [orchestrator-worktree-architecture.md](pages/orchestrator-worktree-architecture.md) | Orchestrator-Worktree Architecture | concept | architecture, harness, worktrees, heartbeats, orchestrator | — | 2026-04-19 |
 
 ## Statistics
 
 - **Entity pages**: 0
-- **Concept pages**: 0
+- **Concept pages**: 1
 - **Synthesis pages**: 0
 - **Total sources**: 0
-- **Last ingest**: never
+- **Last ingest**: 2026-04-19
 - **Last lint**: never

--- a/workspace/wiki/log.md
+++ b/workspace/wiki/log.md
@@ -9,3 +9,8 @@ Rotation: wiki-lint trims to last 200 entries when exceeded.
 - **Sources**: [source filenames referenced]
 - **Summary**: [one sentence]
 -->
+
+## [INGEST] — 2026-04-19 12:45 UTC
+- **Pages**: orchestrator-worktree-architecture.md
+- **Sources**: .claude/specs/orchestrator-worktree-architecture.md, .claude/specs/multi-worktree-heartbeats-spec.md
+- **Summary**: Adapted canonical orchestrator+worktree topology spec into a concept-type wiki page alongside docs-site propagation (issue #83).

--- a/workspace/wiki/pages/orchestrator-worktree-architecture.md
+++ b/workspace/wiki/pages/orchestrator-worktree-architecture.md
@@ -1,0 +1,81 @@
+---
+title: "Orchestrator-Worktree Architecture"
+description: "Canonical shape for running multiple Open Harness agents: one sandbox, N git worktrees, one heartbeat daemon."
+type: concept
+tags: [architecture, harness, worktrees, heartbeats, orchestrator]
+sources: []
+created: 2026-04-19
+updated: 2026-04-19
+---
+
+## Summary
+
+Open Harness runs every agent as a git branch checked out as a worktree under
+`.worktrees/`. A single container (`oh-remote`) bind-mounts the entire repo,
+so all worktrees are visible to one shared toolchain and one shared credential
+set. A single heartbeat daemon inside the sandbox watches every worktree's
+`workspace/heartbeats/` at once, spawning each task with the correct `cwd`.
+
+This is the authoritative topology. "One sandbox per agent" is an escape
+hatch, not the default.
+
+## Key actors
+
+- **Orchestrator** — session at the project root. Owns harness source,
+  git operations, GitHub issues/PRs/releases, and the one-time scaffold
+  of each new agent's `workspace/`. Does not write application code.
+- **Worktree agent** — session inside `.worktrees/<prefix>/<slug>/workspace/`.
+  Owns its workspace subtree (SOUL.md, skills, heartbeats, memory, CRM,
+  wiki, projects) and its branch history.
+- **Sandbox container** — default name `oh-remote`. Bind-mounts
+  `/home/sandbox/harness`, hosts the shared toolchain and credentials.
+- **Heartbeat daemon** — one Node process per sandbox. Discovers roots
+  from `git worktree list --porcelain`; one `fs.watch` per root; each
+  spawn uses `cwd = <worktree>/workspace`.
+
+## Why this shape
+
+1. **Branches have identities.** SOUL.md, skills, CRM, heartbeats all
+   live on a branch — agent identity is files on disk, not runtime
+   config.
+2. **One container per agent is too heavy.** A sandbox is a real OS
+   with its own toolchain, credentials, and dev servers.
+3. **Merging agent work is a git problem.** Git worktrees already solve
+   "multiple branches at once." The natural fit: worktrees on the host,
+   one container for all of them.
+
+## Isolation (thin)
+
+Per-worktree: filesystem under `workspace/`, git history, heartbeat
+schedules + logs, agent identity, memory/CRM/wiki artifacts.
+Shared: credentials (`gh auth`, Anthropic key), container runtime, API
+quotas, OS/kernel. This is enough to keep artifacts clean and
+independently committable, not enough to sandbox a hostile agent. All
+agents in a sandbox must be mutually trusted.
+
+## Heartbeat discovery
+
+The daemon runs `git worktree list --porcelain` and includes every
+worktree whose `workspace/heartbeats/` exists. Labels are derived from
+branch names (`refs/heads/` stripped, `/` → `-`, lowercased). Scheduler
+keys namespace by label (`${label}::${slug}`) so same-named heartbeats
+in two worktrees don't collide. `HEARTBEAT_MAX_CONCURRENT` (default 2)
+caps daemon-wide concurrent spawns to smooth aligned schedules.
+`HEARTBEAT_ROOTS=path1:label1,path2:label2` overrides auto-discovery on
+path collisions.
+
+## When to add a new worktree vs a new sandbox
+
+- **New worktree** — merge-back work, shared stack, shared trust level,
+  shared rate limits. Most agent work.
+- **New sandbox** — kernel-level isolation (untrusted code),
+  conflicting global tooling, isolated API quotas, reproducing a
+  customer environment.
+
+## References
+
+- Docs: [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees)
+- Docs: [Heartbeats guide](/docs/guide/heartbeats) — env vars, multi-root logs
+- Spec: `.claude/specs/orchestrator-worktree-architecture.md` (canonical)
+- Spec: `.claude/specs/multi-worktree-heartbeats-spec.md` (daemon design)
+- Source: `packages/sandbox/src/lib/heartbeat/`


### PR DESCRIPTION
Closes #83

Derives user-facing docs from `.claude/specs/orchestrator-worktree-architecture.md`.

## Summary

- New architecture page `docs/content/docs/architecture/orchestrator-worktrees.mdx` with mermaid topology, lifecycle, and heartbeat firing-flow diagrams.
- `overview.mdx` rewritten to surface the orchestrator-worktree topology + heartbeat daemon as explicit layers (was missing from the "three main layers" framing).
- `meta.json` updated — new page positioned between `structure` and `how-it-works`.
- `guide/heartbeats.mdx` documents multi-root discovery, per-root logs, `HEARTBEAT_MAX_CONCURRENT`, `HEARTBEAT_ROOTS`, and grouped status output.
- `how-it-works.mdx` and `structure.mdx` gain cross-links to the new page.
- `workspace/wiki/pages/orchestrator-worktree-architecture.md` — concept-type wiki entry; `workspace/wiki/{index,log}.md` updated.

## Notes

- `cd docs && pnpm run build` passes. 35 static pages generated (was 33). `/docs/architecture/orchestrator-worktrees` and `/wiki/orchestrator-worktree-architecture` appear in the route table.
- Mermaid fenced blocks follow the existing convention in `docs/content/docs/slack/*.mdx`. The `Mermaid` component exists at `docs/components/Mermaid.tsx` but is not currently registered in `components/mdx.tsx`; wiring that registration is out of scope for this PR (docs-only change).
- Spec files under `.claude/specs/` are unchanged — docs derive from them.
- No `packages/sandbox/` or harness source touched.