### PR TITLE
FROM skill/cloudflared-0.0.0.0 TO development

### DIFF
--- a/.claude/skills/cloudflared-tunnel/SKILL.md
+++ b/.claude/skills/cloudflared-tunnel/SKILL.md
@@ -95,7 +95,7 @@ CONFIG_FILE="$HOME/.cloudflared/config-${TUNNEL_NAME}.yml"
     hostname="${pair%%:*}"
     port="${pair##*:}"
     echo "  - hostname: $hostname"
-    echo "    service: http://localhost:$port"
+    echo "    service: http://0.0.0.0:$port"
   done
   echo "  - service: http_status:404"
 } > "$CONFIG_FILE"
@@ -135,7 +135,7 @@ Tunnel '$TUNNEL_NAME' is configured!
   Creds:      $CREDS_FILE
 
   Ingress rules:
-    <hostname> → localhost:<port>    (for each pair)
+    <hostname> → 0.0.0.0:<port>    (for each pair)
 
   To run:
     cloudflared tunnel --config $CONFIG_FILE run $TUNNEL_NAME


### PR DESCRIPTION
## Summary
- Route cloudflared tunnel ingress to `http://0.0.0.0:$port` instead of `http://localhost:$port`.
- Fixes 502/530 when the tunnel runs in-container against Next dev servers bound to `-H 0.0.0.0`.

## Test plan
- [x] Tunnel `openharness` with `oh.ruska.dev:3000` + `oh-docs.ruska.dev:3001` both return 200 after the change.
- [x] QA'd via agent-browser (screenshots in `.claude/screenshots/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)