### PR TITLE
FROM task/79-arch-rollup TO development

### DIFF
--- a/.claude/specs/orchestrator-worktree-architecture.md
+++ b/.claude/specs/orchestrator-worktree-architecture.md
@@ -45,44 +45,35 @@ without per-agent infrastructure.
 
 ## Topology
 
+```mermaid
+flowchart TB
+  subgraph host["Host filesystem — /home/sandbox/harness"]
+    direction TB
+    gitreg[".git/worktrees/<br/>(git's worktree registry)"]
+    parent["workspace/<br/>(parent-branch workspace)"]
+    pkgs["packages/sandbox/<br/>(harness source)"]
+    subgraph wts[".worktrees/"]
+      direction TB
+      wt1["agent/sdr-pallet/workspace/<br/>• heartbeats/<br/>• crm/<br/>• memory/<br/>• .claude/skills/"]
+      wt2["feat/71-mwh-pr1/workspace/<br/>(ephemeral PR worktree)"]
+      wt3["… more worktrees …"]
+    end
+  end
+  subgraph box["oh-remote container (bind-mounts host at /home/sandbox/harness)"]
+    direction TB
+    daemon["heartbeat-daemon<br/>(single Node process)"]
+    tools["Shared toolchain<br/>claude · codex · pi · pnpm · git · gh · docker"]
+    creds["Shared credentials<br/>~/.claude · ~/.pi · ~/.config/gh"]
+  end
+  daemon -. "top-level watch" .-> gitreg
+  daemon -. "heartbeats watch" .-> parent
+  daemon -. "heartbeats watch" .-> wt1
+  daemon -. "heartbeats watch" .-> wt2
+  box -.->|"bind mount"| host
 ```
-┌────────────────────── host filesystem ───────────────────────┐
-│                                                              │
-│  /home/sandbox/harness/              ← main checkout          │
-│  ├── .git/                                                    │
-│  │   └── worktrees/                  ← git's worktree registry│
-│  │       ├── agent/sdr-pallet/                                │
-│  │       └── feat/71-mwh-pr1/                                 │
-│  ├── workspace/                      ← parent checkout's      │
-│  │   ├── heartbeats/                   workspace (main branch)│
-│  │   ├── memory/                                              │
-│  │   └── .claude/skills/                                      │
-│  ├── packages/sandbox/               ← harness source         │
-│  └── .worktrees/                                              │
-│      ├── agent/                                               │
-│      │   └── sdr-pallet/                                      │
-│      │       └── workspace/          ← sdr-pallet's workspace │
-│      │           ├── heartbeats/                              │
-│      │           ├── crm/                                     │
-│      │           ├── memory/                                  │
-│      │           └── .claude/skills/                          │
-│      └── feat/                                                │
-│          └── 71-mwh-pr1/             ← ephemeral PR worktrees │
-│                                                               │
-│  ┌─── oh-remote container (bind-mounts /home/sandbox/harness)─┐│
-│  │                                                            ││
-│  │   heartbeat-daemon  (one process)                          ││
-│  │     ├── fs.watch .git/worktrees/                           ││
-│  │     ├── fs.watch workspace/heartbeats/        (parent)     ││
-│  │     ├── fs.watch .worktrees/agent/sdr-pallet/…/heartbeats/ ││
-│  │     └── fs.watch …each discovered worktree…                ││
-│  │                                                            ││
-│  │   claude, codex, pi, docker, pnpm, git, gh                 ││
-│  │   (shared toolchain; one credential set)                   ││
-│  │                                                            ││
-│  └────────────────────────────────────────────────────────────┘│
-└──────────────────────────────────────────────────────────────┘
-```
+
+One container. N git worktrees. One daemon watching N+1 directories
+(each root's `heartbeats/` + `.git/worktrees/` itself).
 
 ## Actors
 
@@ -176,45 +167,41 @@ without per-agent infrastructure.
 
 ## Lifecycle of a New Agent
 
-```
- orchestrator session                         sandbox (oh-remote)
- ────────────────────                         ───────────────────
- 1. gh issue create --label agent
-    "agent: pallet-sdr intake"
-        │
-        ▼
- 2. git worktree add -b agent/pallet-sdr \
-    .worktrees/agent/pallet-sdr development
-        │                                     git updates .git/worktrees/
-        ├────────────────────────────────────▶pallet-sdr/ (new dir)
-        ▼
- 3. Scaffold workspace/:
-      SOUL.md, MEMORY.md, USER.md
-      skills/, heartbeats/, crm/, etc.
-        │
-        ▼                                     daemon's top-level watcher
- 4. git commit -m "agent(#N): scaffold …"  ──▶fires, runs
-                                               discoverWorkspaceRoots()
-                                               finds new root
-                                               starts heartbeat-dir watcher
-                                               next sync() picks up
-                                               heartbeat entries
-        │
-        ▼
- 5. git push -u origin agent/pallet-sdr
-        │
-        ▼
- 6. PR against development
-        │
-        ▼
- 7. When heartbeats tick, daemon spawns
-    claude -p (cwd = pallet-sdr workspace)
-    Agent runs, writes to its own memory/,
-    crm/, etc.
+```mermaid
+sequenceDiagram
+  actor Orc as Orchestrator
+  participant Git as Git / Host FS
+  participant Daemon as Heartbeat Daemon<br/>(inside sandbox)
+  participant Agent as Spawned Agent<br/>(claude -p)
+
+  Orc->>Git: gh issue create --label agent
+  Note over Orc,Git: "agent(#N): pallet-sdr intake"
+
+  Orc->>Git: git worktree add -b agent/pallet-sdr<br/>.worktrees/agent/pallet-sdr development
+  Git-->>Git: .git/worktrees/pallet-sdr/ created
+  Git-->>Daemon: top-level watcher fires
+
+  Daemon->>Git: git worktree list --porcelain
+  Daemon->>Daemon: discoverWorkspaceRoots()<br/>start new per-root fs.watch
+
+  Orc->>Git: scaffold workspace/<br/>(SOUL.md, skills/, heartbeats/, crm/)
+  Orc->>Git: git commit + push
+  Git-->>Daemon: heartbeats/ watcher fires
+  Daemon->>Daemon: sync() — schedule new entries
+
+  Orc->>Git: gh pr create --base development
+  Note over Orc,Agent: orchestrator's job ends here
+
+  Note over Daemon,Agent: cron tick arrives
+  Daemon->>Agent: spawn claude -p<br/>(cwd = pallet-sdr workspace)
+  Agent->>Git: writes memory/YYYY-MM-DD.md<br/>crm/attention/YYYY-MM-DD.md
+  Agent-->>Daemon: stdout (HEARTBEAT_OK or body)
+  Daemon->>Daemon: logger.log(per-root log)
 ```
 
-The orchestrator's job ends at step 4. After that the agent is live and
-self-directing (per its heartbeat schedule + manual sessions).
+The orchestrator's job ends once the PR is opened. After that the agent
+is live and self-directing (per its heartbeat schedule + manual sessions
+inside the sandbox).
 
 ## Discovery Mechanism
 
@@ -260,6 +247,100 @@ Consequences:
 > **Back-compat**: single-root daemons (legacy construction path, label
 > `""`) do NOT pass `cwd`. Byte-identical to pre-multi-root behavior so
 > existing deployments don't regress.
+
+## Heartbeat Firing Flow
+
+What actually happens on each cron tick, top to bottom:
+
+```mermaid
+sequenceDiagram
+  participant Cron as Croner (per job)
+  participant Runner as HeartbeatRunner
+  participant Sem as Semaphore<br/>(HEARTBEAT_MAX_CONCURRENT)
+  participant Gates as Gates
+  participant Claude as claude CLI
+  participant Logger as Per-root Logger
+
+  Cron->>Runner: tick(entry)
+  Runner->>Sem: tryAcquireSlot()
+
+  alt slot queued > 300s
+    Runner->>Logger: [label::entry] Skipped<br/>(concurrency cap reached)
+  else slot granted
+    Runner->>Runner: concurrency guard<br/>(root, entryName) already running?
+    opt guard hit
+      Runner->>Logger: Skipping — previous still running
+    end
+
+    Runner->>Gates: isActiveHours(start,end)?
+    alt outside window
+      Runner->>Logger: Outside active hours, skipping
+    else active
+      Runner->>Gates: isHeartbeatEmpty(filePath)?
+      alt empty
+        Runner->>Logger: File effectively empty, skipping
+      else has body
+        Runner->>Runner: build prompt<br/>(SOUL.md + heartbeat body + HEARTBEAT_OK rule)
+        Runner->>Logger: Running heartbeat (agent: claude)
+        Runner->>Claude: spawn(claude, ["-p", prompt, "--dangerously-skip-permissions"],<br/>{ cwd: root.workspacePath, signal: 300s timeout })
+        Claude-->>Runner: stdout (trimmed)
+
+        alt exit 0 and contains HEARTBEAT_OK and <300 chars
+          Runner->>Logger: HEARTBEAT_OK
+        else exit 0 with body
+          Runner->>Logger: Response: <full body>
+        else timeout / non-zero exit
+          Runner->>Logger: Timed out / Failed (exit N)
+        end
+      end
+    end
+
+    Runner->>Sem: releaseSlot()
+    Runner->>Logger: rotate() — trim if >1000 lines
+  end
+```
+
+Key invariants:
+
+- `cwd` is set per entry, never shared across worktrees.
+- The semaphore is daemon-global and FIFO; the concurrency guard is
+  per-`(root, entryName)` composite key.
+- All log writes go to the root's own `heartbeats/heartbeat.log`.
+
+## Module Dependencies
+
+Source layout inside `packages/sandbox/src/lib/heartbeat/` and the CLI entry:
+
+```mermaid
+flowchart LR
+  cli[cli/heartbeat-daemon.ts<br/>CLI entry]
+  discovery[lib/heartbeat/<br/>discovery.ts]
+  daemon[lib/heartbeat/<br/>daemon.ts]
+  config[lib/heartbeat/<br/>config.ts]
+  scheduler[lib/heartbeat/<br/>scheduler.ts]
+  runner[lib/heartbeat/<br/>runner.ts]
+  logger[lib/heartbeat/<br/>logger.ts]
+  gates[lib/heartbeat/<br/>gates.ts]
+
+  cli -->|startup discovery| discovery
+  cli -->|construct + start| daemon
+  discovery -.->|WorkspaceRoot[]| daemon
+  daemon -->|parseHeartbeatConfigAcrossRoots| config
+  daemon -->|sync/start/stop| scheduler
+  daemon -->|own per-root Map| logger
+  scheduler -->|run(entry)| runner
+  runner -->|gate checks| gates
+  runner -->|per-root log line| logger
+  runner -->|spawn claude| Spawn{{"child_process.spawn<br/>cwd=root.workspacePath"}}
+
+  classDef external fill:#eee,stroke-dasharray:3 3
+  class Spawn external
+```
+
+- Types and discovery are "leaf" modules with no dependencies on
+  scheduler/runner — safe to evolve independently.
+- The runner is the only module that actually spawns an agent; all spawn
+  policy (timeout, cwd, arg shape) lives there.
 
 ## Isolation Properties
 
@@ -365,6 +446,71 @@ git worktree remove .worktrees/agent/<name>
 # Daemon auto-drops it on next .git/worktrees/ mutation event
 # PR merge (or abandon) on the branch is a separate concern
 ```
+
+## Where to Change What
+
+Concrete change targets for common modifications. Paths are relative to
+the harness repo root (`/home/sandbox/harness`). If you add something
+here, keep the table alphabetical within each section.
+
+### Adding or modifying agents
+
+| Change | Touch | Notes |
+|--------|-------|-------|
+| Add a new worktree agent | `git worktree add -b agent/<name> .worktrees/agent/<name> development` then scaffold `workspace/` | Daemon auto-discovers within ~500 ms of commit |
+| Retire a worktree agent | `git worktree remove .worktrees/agent/<name>` | Daemon drops it; branch lifecycle separate |
+| Rename an agent's branch | `git branch -m agent/<old> agent/<new>` then `git worktree move` | Changes the daemon label; heartbeats re-namespace under the new label |
+| Scaffold content for a new agent | `workspace/` inside the new worktree — seed SOUL.md, skills/, heartbeats/, CRM data, etc. | Orchestrator writes this once, agent owns it afterward |
+| Share a skill across all agents | Write to each worktree's `workspace/.claude/skills/<name>/` (or add to a template under the parent workspace that new agents copy from) | There is no central "shared skills" dir today — by design, for isolation |
+
+### Heartbeat daemon behavior
+
+| Change | Touch | Notes |
+|--------|-------|-------|
+| Frontmatter schema (add/remove a field) | `packages/sandbox/src/lib/heartbeat/config.ts` — `parseFrontmatter`, `buildEntry`, `HeartbeatEntry` | Update `src/__tests__/heartbeat-config.test.ts` |
+| Discovery rule (include a different subdir than `workspace/`) | `packages/sandbox/src/lib/heartbeat/discovery.ts` — `discoverWorkspaceRoots` | Update `src/__tests__/heartbeat-discovery.test.ts` |
+| Label format / sanitization | `packages/sandbox/src/lib/heartbeat/discovery.ts` — `sanitizeBranch` | Keep `""` empty label back-compat for legacy single-root |
+| Default concurrency cap | `packages/sandbox/src/lib/heartbeat/runner.ts` — `HEARTBEAT_MAX_CONCURRENT` default (or set env in `install/entrypoint.sh`) | `0` disables the cap |
+| Per-spawn timeout (currently 300 s) | `packages/sandbox/src/lib/heartbeat/runner.ts` — `AbortSignal.timeout(300_000)` | Applies to every spawn |
+| Active-hours / empty-file gates | `packages/sandbox/src/lib/heartbeat/gates.ts` | Covered by `heartbeat-gates.test.ts` |
+| Log file name or path per root | `packages/sandbox/src/lib/heartbeat/logger.ts` + call site in `daemon.ts` | Current: `<root.heartbeatDir>/heartbeat.log` |
+| Log rotation threshold | `packages/sandbox/src/lib/heartbeat/logger.ts` — `rotate()` constants (1000 keep 500) | |
+| Add a new agent CLI (beyond `claude`/`codex`) | `packages/sandbox/src/lib/heartbeat/runner.ts` — `spawnAgent` switch | Register the new arg shape |
+| Watcher debounce window (currently 500 ms) | `packages/sandbox/src/lib/heartbeat/daemon.ts` — `startWatching` setTimeout | |
+| `.git/worktrees/` hot add/remove behavior | `packages/sandbox/src/lib/heartbeat/daemon.ts` — `startTopLevelWatcher`, `rediscoverRoots` | |
+| Status CLI output format | `packages/sandbox/src/lib/heartbeat/daemon.ts` — `status()` | Single-root legacy format is load-bearing for scripts |
+| CLI entry (env-var surface) | `packages/sandbox/src/cli/heartbeat-daemon.ts` | Reads `HEARTBEAT_ROOTS`, `HEARTBEAT_AGENT`, `HEARTBEAT_INTERVAL`, `HEARTBEAT_MAX_CONCURRENT` |
+
+### Sandbox / container
+
+| Change | Touch | Notes |
+|--------|-------|-------|
+| Bind mounts | `.devcontainer/docker-compose.yml` + overlays (`docker-compose.cloudflared.yml`, `docker-compose.slack.yml`) | Daemon discovery picks up new paths automatically if they're worktrees |
+| Base image / toolchain | `.devcontainer/Dockerfile` | Rebuild via `/provision` |
+| Boot sequence (daemon watchdog, other services) | `install/entrypoint.sh` | |
+| Onboarding script | `install/onboard.sh` | Runs `gh auth` + `pi` OAuth once at first shell |
+| Default env vars | `.devcontainer/.example.env` → copied to `.env` at `/provision` time | |
+| Sandbox lifecycle skills | `.claude/skills/{provision,destroy,repair}/SKILL.md` | Orchestrator-only |
+
+### Orchestrator surface
+
+| Change | Touch | Notes |
+|--------|-------|-------|
+| Orchestrator-only skill | `/home/sandbox/harness/.claude/skills/<name>/SKILL.md` on `development` | Not loaded by agent sessions inside workspaces |
+| Orchestrator-wide coding rule | `/home/sandbox/harness/.claude/rules/<name>.md` | Auto-loaded |
+| Git workflow conventions | `.claude/rules/git.md` | Source of truth for branch/issue/PR format |
+| Advisor-model briefing template | `.claude/rules/advisor-model.md` | Used by `/delegate` |
+| Project-root playbook | `/home/sandbox/harness/CLAUDE.md` | Auto-loaded at orchestrator session start |
+| Issue templates | `.github/ISSUE_TEMPLATE/*.md` | Prefixes must match `.claude/rules/git.md` |
+
+### Specs and decision records
+
+| Change | Touch | Notes |
+|--------|-------|-------|
+| This architecture spec | `.claude/specs/orchestrator-worktree-architecture.md` | Update `Historical Note` if the topology itself changes |
+| Heartbeat daemon spec | `.claude/specs/multi-worktree-heartbeats-spec.md` | |
+| Slack package spec | `.claude/specs/slack-package-spec.md` | Vendored fork of pi-mom |
+| New architecture decision | Add a new file under `.claude/specs/<topic>.md` | Keep one topic per file |
 
 ## Failure Modes and Mitigations
 

--- a/.claude/specs/orchestrator-worktree-architecture.md
+++ b/.claude/specs/orchestrator-worktree-architecture.md
@@ -1,0 +1,425 @@
+# Orchestrator + Worktree Agents in a Shared Sandbox
+
+**Status:** canonical · **Date:** 2026-04-19 · **Owner:** harness-orchestrator
+
+> This is the primary configuration pattern for Open Harness. If you're here
+> to understand "where does this code run, and who owns what," read this
+> document first. It supersedes anything implicit in `CLAUDE.md` or
+> agent-level docs.
+
+## TL;DR
+
+- **One parent sandbox** (container) is the shared runtime. Provisioned once.
+- **N git worktrees** live under `.worktrees/` on the host. Each tracks a
+  branch (usually `agent/<name>`). Each ships its own `workspace/`
+  (skills, CRM, SOUL.md, heartbeats, memory, wiki, projects).
+- **One heartbeat daemon** inside the sandbox watches all worktree
+  workspaces. Discovered automatically from `git worktree list`. Spawns
+  each heartbeat with `cwd` inside that worktree's workspace, so skills
+  and relative paths resolve against the correct agent.
+- **The orchestrator** (the session running at the project root) scaffolds
+  new agents, manages git/issues/PRs, and runs sandbox lifecycle skills
+  (`/provision`, `/destroy`, `/repair`). It does NOT write application
+  code — that happens inside agent workspaces.
+- **Thin isolation** between agents: each has its own filesystem subtree
+  and schedule, all sharing one container, one credential set, one daemon.
+
+## Why this shape
+
+Three forces drove this topology:
+
+1. **Branches have identities**, not just code. An `agent/sdr-pallet`
+   branch has its own CRM schema, templates, skills, heartbeats, SOUL.md.
+   Agent identity is files on disk, not runtime config.
+2. **Running N containers per N agents is too heavy.** Each sandbox is a
+   real OS with its own toolchain, credentials, dev server. Duplicating
+   that per agent explodes resource use and onboarding friction.
+3. **Merging agent work back to main is a git problem**, not a
+   container problem. Git worktrees already solve "multiple branches
+   checked out simultaneously." The natural fit is: worktrees on the
+   host, one container for all of them.
+
+The resulting pattern — **one sandbox, N worktrees, one daemon** — gives
+each agent a stable identity, shared tooling, and independent schedules
+without per-agent infrastructure.
+
+## Topology
+
+```
+┌────────────────────── host filesystem ───────────────────────┐
+│                                                              │
+│  /home/sandbox/harness/              ← main checkout          │
+│  ├── .git/                                                    │
+│  │   └── worktrees/                  ← git's worktree registry│
+│  │       ├── agent/sdr-pallet/                                │
+│  │       └── feat/71-mwh-pr1/                                 │
+│  ├── workspace/                      ← parent checkout's      │
+│  │   ├── heartbeats/                   workspace (main branch)│
+│  │   ├── memory/                                              │
+│  │   └── .claude/skills/                                      │
+│  ├── packages/sandbox/               ← harness source         │
+│  └── .worktrees/                                              │
+│      ├── agent/                                               │
+│      │   └── sdr-pallet/                                      │
+│      │       └── workspace/          ← sdr-pallet's workspace │
+│      │           ├── heartbeats/                              │
+│      │           ├── crm/                                     │
+│      │           ├── memory/                                  │
+│      │           └── .claude/skills/                          │
+│      └── feat/                                                │
+│          └── 71-mwh-pr1/             ← ephemeral PR worktrees │
+│                                                               │
+│  ┌─── oh-remote container (bind-mounts /home/sandbox/harness)─┐│
+│  │                                                            ││
+│  │   heartbeat-daemon  (one process)                          ││
+│  │     ├── fs.watch .git/worktrees/                           ││
+│  │     ├── fs.watch workspace/heartbeats/        (parent)     ││
+│  │     ├── fs.watch .worktrees/agent/sdr-pallet/…/heartbeats/ ││
+│  │     └── fs.watch …each discovered worktree…                ││
+│  │                                                            ││
+│  │   claude, codex, pi, docker, pnpm, git, gh                 ││
+│  │   (shared toolchain; one credential set)                   ││
+│  │                                                            ││
+│  └────────────────────────────────────────────────────────────┘│
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Actors
+
+### 1. Orchestrator
+
+- **Where it runs**: project root (`/home/sandbox/harness`), usually in a
+  Claude Code session outside or attached to the sandbox. Also runs in
+  the current session you're reading this in.
+- **What it owns**:
+  - Harness infrastructure: `.devcontainer/`, `install/`, `packages/`
+  - Agent scaffolding: writing the initial `workspace/` for a new agent
+  - Git operations: branches, worktrees, commits, PRs, releases
+  - Sandbox lifecycle: `/provision`, `/destroy`, `/repair`
+  - GitHub issues, labels, milestones
+- **What it does NOT own**:
+  - Agent business logic (CRM updates, outreach emails, domain code)
+  - Ongoing edits to `workspace/` files once an agent is running
+  - Anything inside `workspace/projects/` after the initial scaffold
+- **Authoritative docs**: `/home/sandbox/harness/CLAUDE.md` (this file's
+  parent orchestrator playbook).
+
+### 2. Worktree Agent
+
+- **Where it runs**: normally inside the sandbox, as a `claude` or `codex`
+  session whose CWD is the worktree's `workspace/`. For heartbeats, as a
+  short-lived `claude -p …` spawn from the daemon with the same CWD.
+- **What it owns**:
+  - Its `workspace/` subtree: `heartbeats/`, `skills/`, `memory/`,
+    `SOUL.md`, `MEMORY.md`, `USER.md`, `IDENTITY.md`, `projects/*`,
+    domain-specific dirs (`crm/`, `wiki/`, etc.)
+  - Its agent-side rules and skills (`workspace/.claude/`)
+  - Its branch's commit history
+- **What it does NOT own**:
+  - Harness source (`packages/sandbox/`, `.devcontainer/`, `install/`)
+  - Other agents' workspaces
+  - The daemon itself
+- **Authoritative docs**: `workspace/CLAUDE.md` (agent-level) inside its
+  worktree.
+
+### 3. Sandbox (container)
+
+- **Identity**: single Docker container, default name `oh-remote`.
+- **Bind mounts**: `/home/sandbox/harness` → host's project root. This
+  single mount gives the container visibility into all worktrees under
+  `.worktrees/` automatically.
+- **Shared resources**: credentials (`gh auth`, `~/.claude`, `~/.pi`),
+  toolchain (Node, pnpm, Docker socket, `claude` / `codex` / `pi`),
+  network, /tmp.
+- **Boot**: `install/entrypoint.sh` starts the heartbeat daemon under a
+  watchdog and optionally starts `pi` + Slack bot.
+
+### 4. Heartbeat Daemon
+
+- **Where it runs**: single Node process inside the sandbox.
+- **Discovery**: on startup (and on `.git/worktrees/` mutations), calls
+  `git worktree list --porcelain` and includes every worktree whose
+  `<path>/workspace/heartbeats/` exists. Parent checkout is included
+  the same way.
+- **Per-root**: one `fs.watch` for each discovered `heartbeats/`, one
+  `HeartbeatLogger` writing to `<root>/workspace/heartbeats/heartbeat.log`.
+- **Scheduling**: single `HeartbeatScheduler` with per-root namespaced
+  keys (`${label}::${slug}`) so two worktrees can ship identically-named
+  heartbeats without collision.
+- **Runner**: spawns `claude -p …` with `cwd: entry.root.workspacePath`.
+  The agent CLI therefore loads that worktree's `.claude/settings.json`,
+  skills, and relative paths. Global semaphore
+  (`HEARTBEAT_MAX_CONCURRENT`, default `2`) prevents N worktrees from
+  saturating the Anthropic API when their schedules align.
+- **Canonical spec**: `.claude/specs/multi-worktree-heartbeats-spec.md`.
+- **Source**: `packages/sandbox/src/lib/heartbeat/`.
+
+## Filesystem Contract
+
+| Path | Owner | Notes |
+|------|-------|-------|
+| `/home/sandbox/harness/` | orchestrator | Project root, main git checkout |
+| `/home/sandbox/harness/.git/worktrees/` | git | Git's worktree registry. Daemon watches this for hot add/remove. |
+| `/home/sandbox/harness/workspace/` | parent-branch agent | Parent checkout's workspace (when on a branch with one) |
+| `/home/sandbox/harness/packages/` | orchestrator | Harness source (sandbox CLI, daemon, slack bot) |
+| `/home/sandbox/harness/.worktrees/<prefix>/<slug>/` | worktree-branch agent | A single worktree on the host |
+| `/home/sandbox/harness/.worktrees/<prefix>/<slug>/workspace/` | that agent | Its files |
+| `/home/sandbox/harness/.claude/specs/` | orchestrator | Harness architecture specs |
+| `/home/sandbox/harness/.claude/rules/` | orchestrator | Harness-wide coding rules |
+| `/home/sandbox/harness/.claude/skills/` | orchestrator | Orchestrator-level skills (`/provision`, `/delegate`, …) |
+| `.worktrees/<…>/workspace/.claude/rules/` | that agent | Agent-specific rules |
+| `.worktrees/<…>/workspace/.claude/skills/` | that agent | Agent-specific skills |
+
+> **Rule**: files under `.worktrees/<…>/workspace/` are agent-owned.
+> The orchestrator writes them once during scaffolding, then does not
+> modify them. Agents evolve their own workspaces.
+
+## Lifecycle of a New Agent
+
+```
+ orchestrator session                         sandbox (oh-remote)
+ ────────────────────                         ───────────────────
+ 1. gh issue create --label agent
+    "agent: pallet-sdr intake"
+        │
+        ▼
+ 2. git worktree add -b agent/pallet-sdr \
+    .worktrees/agent/pallet-sdr development
+        │                                     git updates .git/worktrees/
+        ├────────────────────────────────────▶pallet-sdr/ (new dir)
+        ▼
+ 3. Scaffold workspace/:
+      SOUL.md, MEMORY.md, USER.md
+      skills/, heartbeats/, crm/, etc.
+        │
+        ▼                                     daemon's top-level watcher
+ 4. git commit -m "agent(#N): scaffold …"  ──▶fires, runs
+                                               discoverWorkspaceRoots()
+                                               finds new root
+                                               starts heartbeat-dir watcher
+                                               next sync() picks up
+                                               heartbeat entries
+        │
+        ▼
+ 5. git push -u origin agent/pallet-sdr
+        │
+        ▼
+ 6. PR against development
+        │
+        ▼
+ 7. When heartbeats tick, daemon spawns
+    claude -p (cwd = pallet-sdr workspace)
+    Agent runs, writes to its own memory/,
+    crm/, etc.
+```
+
+The orchestrator's job ends at step 4. After that the agent is live and
+self-directing (per its heartbeat schedule + manual sessions).
+
+## Discovery Mechanism
+
+`discoverWorkspaceRoots(home, overrides?)` (see
+`packages/sandbox/src/lib/heartbeat/discovery.ts`):
+
+1. Run `git -C <home>/harness worktree list --porcelain`. Parse
+   `worktree <path>` + `branch refs/heads/<name>` pairs.
+2. For each pair, include as a root if `<path>/workspace/heartbeats/`
+   exists.
+3. `label = sanitizeBranch(branch)` — `refs/heads/` stripped, `/` → `-`,
+   lowercased. Detached HEAD → `detached-<shortsha>`.
+4. Merge overrides from `HEARTBEAT_ROOTS=path1:label1,path2:label2`.
+   Overrides win on path collision.
+5. Warn if discovered root count exceeds 32 (inotify sanity check).
+
+`.git/worktrees/` is the authoritative source because git maintains it
+directly. Filesystem layout under `.worktrees/` can be nested, flat, or
+symlinked — discovery doesn't care.
+
+## Spawn Semantics
+
+When a heartbeat fires:
+
+```ts
+spawn("claude", ["-p", prompt, "--dangerously-skip-permissions"], {
+  cwd: entry.root.workspacePath,        // e.g. .../sdr-pallet/workspace
+  signal: AbortSignal.timeout(300_000),
+});
+```
+
+Consequences:
+
+- `claude` loads that worktree's `workspace/.claude/settings.json`
+  (model, permissions, hooks).
+- Slash-skills resolve against `workspace/.claude/skills/`.
+- Relative paths in the prompt (`memory/YYYY-MM-DD.md`, `crm/leads.csv`,
+  `workspace/.claude/skills/attention-list/`) resolve correctly.
+- Memory and CRM writes land in the correct worktree's subtree.
+- Credentials come from the container's shared user home
+  (`~/.claude`, `~/.pi`, `~/.config/gh`) — shared across all agents.
+
+> **Back-compat**: single-root daemons (legacy construction path, label
+> `""`) do NOT pass `cwd`. Byte-identical to pre-multi-root behavior so
+> existing deployments don't regress.
+
+## Isolation Properties
+
+| Dimension | Isolated? | Notes |
+|-----------|-----------|-------|
+| Filesystem under `workspace/` | Yes | Each worktree owns its subtree |
+| Git history / branch state | Yes | Git worktrees are fully independent |
+| Heartbeat schedules + logs | Yes | Per-root logger, per-root watcher |
+| Agent identity (SOUL.md, skills) | Yes | Per-root, loaded via spawn cwd |
+| Memory + CRM + wiki artifacts | Yes | Per-root directories |
+| Credentials | **No** (shared) | One `gh auth`, one Anthropic key |
+| Container runtime | **No** (shared) | Same processes, /tmp, network |
+| Docker socket | **No** (shared) | Any agent can drive Docker |
+| API quotas | **No** (shared) | `HEARTBEAT_MAX_CONCURRENT` smooths bursts |
+| OS / kernel | **No** (shared) | One container |
+
+This is "thin isolation" — enough to keep agent artifacts clean and
+independently committable, not enough to sandbox a hostile agent. All
+agents in a sandbox must be mutually trusted.
+
+## When to Add a New Worktree vs a New Sandbox
+
+**Add a new worktree agent when**:
+- The work lives on a branch you'd eventually merge back
+- The agent shares the same stack, credentials, and trust level
+- You want shared tooling, shared rate limits, and independent identity
+- You want the daemon to schedule it alongside other agents
+
+**Add a new sandbox when**:
+- You need kernel-level isolation (untrusted code, tenant separation)
+- The agent needs a different OS, different base image, or conflicting
+  global tooling (two clashing Node versions, different language
+  runtimes)
+- You need isolated rate limits (separate Anthropic account, separate
+  API quota)
+- You're reproducing a customer environment for debugging
+
+Most "I want to add an agent" cases are the first bucket. New sandboxes
+are rare and expensive.
+
+## Trust Boundary
+
+All worktrees discovered from the main checkout's `.git/worktrees/` are
+treated as trusted. This is the same trust model as the rest of the
+sandbox: if you can `git commit` to a branch in this repo, you can make
+the daemon run code on your behalf. The `--dangerously-skip-permissions`
+flag on the `claude` spawn makes this explicit.
+
+Do NOT point `HEARTBEAT_ROOTS` at untrusted paths. Do NOT provision a
+sandbox from a repo you don't own.
+
+## Operational Playbook
+
+### Adding an agent
+
+```bash
+# From the orchestrator session (project root)
+gh issue create --label agent --title "agent(#N): <name> — <role>"
+git worktree add -b agent/<name> .worktrees/agent/<name> development
+# Scaffold workspace/ per the agent's role
+git commit -m "agent(#N): scaffold <name>"
+git push -u origin agent/<name>
+# Daemon auto-discovers within 500ms after commit (if .git/worktrees/ watcher is active)
+```
+
+### Verifying a worktree agent is live
+
+```bash
+# Inside the sandbox
+heartbeat-daemon status
+# Look for: "Roots:" section includes your agent, and per-root schedules
+```
+
+### Diagnosing a stuck heartbeat
+
+1. `heartbeat-daemon status` — is the schedule listed?
+2. `tail -f <worktree>/workspace/heartbeats/heartbeat.log` — per-root log
+3. If "Skipped (concurrency cap reached)" — raise `HEARTBEAT_MAX_CONCURRENT`
+4. If "Outside active hours" — check frontmatter `active:` range
+5. If "File is effectively empty" — the heartbeat body needs tasks
+6. If timing out — the prompt is too heavy; trim it or raise spawn timeout
+
+### Force rediscovery
+
+```bash
+# Sandbox-side
+heartbeat-daemon sync      # re-parses, does not re-run discovery
+# Trigger discovery by touching .git/worktrees/ (or restart the daemon)
+```
+
+### Reading per-root logs
+
+```bash
+# Each worktree has its own log
+tail -f /home/sandbox/harness/workspace/heartbeats/heartbeat.log
+tail -f /home/sandbox/harness/.worktrees/agent/sdr-pallet/workspace/heartbeats/heartbeat.log
+```
+
+### Retiring a worktree agent
+
+```bash
+git worktree remove .worktrees/agent/<name>
+# Daemon auto-drops it on next .git/worktrees/ mutation event
+# PR merge (or abandon) on the branch is a separate concern
+```
+
+## Failure Modes and Mitigations
+
+| Failure | Cause | Mitigation |
+|---------|-------|------------|
+| Heartbeats from a worktree don't fire | Daemon can't see the worktree | Check `heartbeat-daemon status` for the root; verify `.git/worktrees/` watcher alive |
+| Skills not found in spawned run | Spawn CWD wrong | Verify `entry.root.workspacePath` points at `<worktree>/workspace` not `<worktree>` |
+| Two agents step on each other's memory | Same workspace path or symlink | Never share `workspace/` between worktrees |
+| Anthropic rate-limit errors in heartbeats | Multiple roots firing concurrently | Tune `HEARTBEAT_MAX_CONCURRENT` down |
+| `.git/worktrees/` watcher misses a mutation | Rapid add/remove under the 500ms debounce | Run `heartbeat-daemon sync` once |
+| Worktree on detached HEAD | Label becomes `detached-<sha>` | Functional but noisy — check out a branch |
+| inotify watcher exhaustion | >8k watchers (unrealistic but possible) | Raise `fs.inotify.max_user_watches` |
+
+## Related Specs & Source
+
+- `.claude/specs/multi-worktree-heartbeats-spec.md` — daemon design
+- `packages/sandbox/src/lib/heartbeat/` — daemon implementation
+- `packages/sandbox/src/lib/heartbeat/discovery.ts` — root discovery
+- `install/entrypoint.sh` — sandbox boot, daemon watchdog
+- `.devcontainer/docker-compose.yml` — sandbox bind mounts
+- `CLAUDE.md` (project root) — orchestrator playbook
+- `workspace/CLAUDE.md` (per worktree) — agent playbook
+- `.claude/rules/git.md` — branch/worktree/PR conventions
+- `.claude/rules/advisor-model.md` — pattern used by orchestrator to brief agents
+
+## Open Questions & Future Work
+
+1. **Per-agent credential rotation** — currently all agents share one
+   Anthropic key. Splitting by agent would give per-agent rate budgets
+   and per-agent audit trails, at the cost of credential management.
+2. **Worktree quotas** — no hard cap on worktrees or per-worktree disk
+   use. Inotify is the first thing to strain (~8k default).
+3. **Cross-worktree coordination primitives** — agents today don't know
+   about each other. If agent A produces output that agent B consumes,
+   they coordinate through git (commits on a shared branch) or through
+   the filesystem. A formal pub/sub has not been needed yet.
+4. **Sandbox-per-branch escape hatch** — for the rare case where thin
+   isolation is insufficient (untrusted code, conflicting tooling),
+   document the "one sandbox per agent" alternative so operators know
+   it exists. Tradeoffs captured above but not yet operationalized.
+5. **Daemon observability** — today: log tails + `status`. Future:
+   structured event stream, optional Slack delivery of heartbeat
+   outputs (tracked in `docs/plans/event-heartbeat-delivery-plan.md`).
+
+## Historical Note
+
+This architecture was crystallized on 2026-04-19 after attempting to
+demo the sdr-pallet agent's heartbeats and discovering that the daemon
+was single-rooted. The fix (PRs #72, #74, #76, #78) made the daemon
+multi-root and validated the pattern end-to-end. Before that, the
+orchestrator + worktree + sandbox pattern was implicit in the harness
+design but not documented; agent heartbeats from worktree branches
+would silently never fire.
+
+If you're reading this because you're about to add an agent or change
+how sandboxes are provisioned, the answer to "how should this interact
+with the rest of the system" is almost certainly in the tables above.
+If it isn't, update this document.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,49 @@ docker compose -f .devcontainer/docker-compose.yml down -v
 
 ---
 
+## Architecture
+
+Open Harness runs **one sandbox container, N git worktrees, one heartbeat daemon**. The container is the shared runtime (toolchain, credentials, processes). Each agent lives on its own branch under `.worktrees/`, shipping its own `workspace/` (SOUL.md, skills, heartbeats, memory, projects). A single Node daemon inside the sandbox watches every worktree's `heartbeats/` directory and spawns scheduled agent runs with the correct `cwd`, so each agent's skills and relative paths resolve to its own subtree. This gives every agent a stable identity and independent schedule without duplicating containers, credentials, or toolchains.
+
+### Topology
+
+```mermaid
+flowchart TB
+  subgraph host["Host filesystem — /home/sandbox/harness"]
+    direction TB
+    parent["workspace/<br/>(parent-branch workspace)"]
+    gitreg[".git/worktrees/<br/>(git's worktree registry)"]
+    subgraph wts[".worktrees/"]
+      direction TB
+      wt1["agent/sdr-pallet/workspace/<br/>• heartbeats/ • skills/ • memory/"]
+      wt2["feat/71-…/workspace/<br/>(ephemeral PR worktree)"]
+      wt3["… more worktrees …"]
+    end
+  end
+  subgraph box["sandbox container (bind-mounts host root)"]
+    direction TB
+    daemon["heartbeat-daemon<br/>(single Node process)"]
+    tools["Shared toolchain<br/>claude · codex · pi · git · gh"]
+    creds["Shared credentials<br/>~/.claude · ~/.pi · ~/.config/gh"]
+  end
+  daemon -. "top-level watch" .-> gitreg
+  daemon -. "heartbeats watch" .-> parent
+  daemon -. "heartbeats watch" .-> wt1
+  daemon -. "heartbeats watch" .-> wt2
+  box -.->|"bind mount"| host
+```
+
+### Actors
+
+- **Orchestrator** — the session at the project root. Scaffolds agents, manages git/issues/PRs, runs sandbox lifecycle skills (`/provision`, `/destroy`, `/repair`). Does not write application code.
+- **Worktree agent** — a `claude`/`codex` session (or heartbeat spawn) with `cwd` inside a worktree's `workspace/`. Owns its subtree: SOUL.md, skills, heartbeats, memory, branch history.
+- **Sandbox** — one Docker container with the host's project root bind-mounted in. All worktrees are visible automatically; toolchain and credentials are shared.
+- **Heartbeat daemon** — single Node process inside the sandbox. Discovers worktrees via `git worktree list`, watches each `heartbeats/` directory, and spawns scheduled runs with per-root `cwd` and per-root logs.
+
+For the deep reference, see [`.claude/specs/orchestrator-worktree-architecture.md`](./.claude/specs/orchestrator-worktree-architecture.md) and the docs-site architecture page: [`/docs/architecture/orchestrator-worktrees`](https://ryaneggz.github.io/open-harness/architecture/orchestrator-worktrees).
+
+---
+
 ## What's in the box
 
 The sandbox image (Debian bookworm-slim) comes pre-installed with:

--- a/docs/components/Mermaid.tsx
+++ b/docs/components/Mermaid.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef, useState } from "react";
 
 export default function Mermaid({ chart }: { chart: string }) {

--- a/docs/components/mdx.tsx
+++ b/docs/components/mdx.tsx
@@ -1,9 +1,40 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import type { ComponentProps, ComponentType, ReactNode } from "react";
+import Mermaid from "./Mermaid";
+
+type CodeElement = { props?: { className?: string; children?: ReactNode } };
+
+function isMermaidCodeBlock(node: unknown): node is CodeElement {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    "props" in node &&
+    (node as CodeElement).props?.className === "language-mermaid"
+  );
+}
+
+function toText(node: ReactNode): string {
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(toText).join("");
+  if (node && typeof node === "object" && "props" in node) {
+    const child = (node as { props?: { children?: ReactNode } }).props?.children;
+    return child !== undefined ? toText(child) : "";
+  }
+  return "";
+}
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    pre: (props: ComponentProps<"pre">) => {
+      if (isMermaidCodeBlock(props.children)) {
+        return <Mermaid chart={toText(props.children.props?.children)} />;
+      }
+      const DefaultPre = defaultMdxComponents.pre as ComponentType<ComponentProps<"pre">>;
+      return <DefaultPre {...props} />;
+    },
     ...components,
   } satisfies MDXComponents;
 }

--- a/docs/components/mdx.tsx
+++ b/docs/components/mdx.tsx
@@ -1,40 +1,11 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
-import type { ComponentProps, ComponentType, ReactNode } from "react";
 import Mermaid from "./Mermaid";
-
-type CodeElement = { props?: { className?: string; children?: ReactNode } };
-
-function isMermaidCodeBlock(node: unknown): node is CodeElement {
-  return (
-    typeof node === "object" &&
-    node !== null &&
-    "props" in node &&
-    (node as CodeElement).props?.className === "language-mermaid"
-  );
-}
-
-function toText(node: ReactNode): string {
-  if (typeof node === "string") return node;
-  if (typeof node === "number") return String(node);
-  if (Array.isArray(node)) return node.map(toText).join("");
-  if (node && typeof node === "object" && "props" in node) {
-    const child = (node as { props?: { children?: ReactNode } }).props?.children;
-    return child !== undefined ? toText(child) : "";
-  }
-  return "";
-}
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
-    pre: (props: ComponentProps<"pre">) => {
-      if (isMermaidCodeBlock(props.children)) {
-        return <Mermaid chart={toText(props.children.props?.children)} />;
-      }
-      const DefaultPre = defaultMdxComponents.pre as ComponentType<ComponentProps<"pre">>;
-      return <DefaultPre {...props} />;
-    },
+    Mermaid,
     ...components,
   } satisfies MDXComponents;
 }

--- a/docs/content/docs/architecture/how-it-works.mdx
+++ b/docs/content/docs/architecture/how-it-works.mdx
@@ -18,7 +18,7 @@ When you start a sandbox (`openharness sandbox` or `docker compose up`), this se
    - Matches the container's Docker group GID to the host socket GID (fixes DinD permissions)
    - Fixes volume ownership (root → sandbox user)
    - Runs conditional SSH server setup if sshd overlay is active
-   - Starts the heartbeat daemon (`heartbeat-daemon start`) to watch `heartbeats/` for scheduled tasks
+   - Starts the heartbeat daemon (`heartbeat-daemon start`) to watch every worktree's `heartbeats/` directory for scheduled tasks — see [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees)
    - Runs `workspace/startup.sh` as the sandbox user
    - Prints first-boot onboarding message if not yet onboarded
    - Execs the container command (`sleep infinity` by default, or `sshd -D` with the sshd overlay)

--- a/docs/content/docs/architecture/meta.json
+++ b/docs/content/docs/architecture/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Architecture",
-  "pages": ["overview", "structure", "how-it-works"]
+  "pages": ["overview", "structure", "orchestrator-worktrees", "how-it-works"]
 }

--- a/docs/content/docs/architecture/orchestrator-worktrees.mdx
+++ b/docs/content/docs/architecture/orchestrator-worktrees.mdx
@@ -1,0 +1,262 @@
+---
+title: "Orchestrator + Worktrees"
+description: "One sandbox, N git worktrees, one heartbeat daemon — the canonical shape for running multiple agents together."
+---
+
+
+Open Harness runs on a single pattern: **one parent sandbox, N git worktrees, one heartbeat daemon**. Every agent is a git branch checked out as a worktree under `.worktrees/`. The sandbox container bind-mounts the entire repo, so all worktrees are visible to one shared toolchain and one shared credential set. A single heartbeat daemon inside the sandbox watches all of them at once.
+
+This page explains the topology, who owns what, and how a new agent comes online. For implementation detail (file paths, scheduler keys, change targets), see the [canonical spec](https://github.com/ryaneggz/open-harness/blob/development/.claude/specs/orchestrator-worktree-architecture.md).
+
+## At a glance
+
+```mermaid
+flowchart TB
+  subgraph host["Host — /home/sandbox/harness"]
+    direction TB
+    gitreg[".git/worktrees/<br/>(git's worktree registry)"]
+    parent["workspace/<br/>(parent-branch workspace)"]
+    subgraph wts[".worktrees/"]
+      direction TB
+      wt1["agent/sdr-pallet/workspace/<br/>heartbeats · crm · memory · .claude/skills"]
+      wt2["feat/71-mwh-pr1/workspace/<br/>(ephemeral PR worktree)"]
+      wt3["… more worktrees …"]
+    end
+  end
+  subgraph box["oh-remote container (bind-mount of host)"]
+    direction TB
+    daemon["heartbeat-daemon<br/>(single Node process)"]
+    tools["Shared toolchain<br/>claude · codex · pi · pnpm · git · gh"]
+    creds["Shared credentials<br/>~/.claude · ~/.pi · ~/.config/gh"]
+  end
+  daemon -. "top-level watch" .-> gitreg
+  daemon -. "heartbeats watch" .-> parent
+  daemon -. "heartbeats watch" .-> wt1
+  daemon -. "heartbeats watch" .-> wt2
+  box -.->|"bind mount"| host
+```
+
+One container. N git worktrees. One daemon watching every worktree's `heartbeats/` directory at once.
+
+## Why this shape
+
+- **Branches have identities.** An `agent/<name>` branch owns a whole workspace — SOUL.md, skills, CRM, heartbeats, memory. Agent identity is files on disk, not runtime config.
+- **One container per agent is too heavy.** A sandbox is a real OS with its own toolchain, credentials, and dev servers. Duplicating that per agent explodes resource use.
+- **Merging agent work back is a git problem.** Git worktrees already solve "multiple branches checked out at once." The natural fit: worktrees on the host, one container for all of them.
+
+## Actors
+
+### Orchestrator
+
+- **Runs at:** the project root (`/home/sandbox/harness`) — usually a Claude Code session attached to the sandbox.
+- **Owns:** harness source (`packages/sandbox/`, `.devcontainer/`, `install/`), git operations, GitHub issues/PRs/releases, sandbox lifecycle skills (`/provision`, `/destroy`, `/repair`), and the one-time scaffold of each new agent's `workspace/`.
+- **Does not write application code.** Agents do that inside their workspaces.
+
+### Worktree agent
+
+- **Runs at:** `.worktrees/<prefix>/<slug>/workspace/` — either as an interactive `claude` session or as a short-lived heartbeat spawn.
+- **Owns:** its `workspace/` subtree (SOUL.md, MEMORY.md, skills, heartbeats, memory, crm, wiki, projects) and its branch history.
+- **Does not touch:** harness source, other worktrees, or the daemon.
+
+### Sandbox container
+
+Default name `oh-remote`. Bind-mounts `/home/sandbox/harness` into the container so all worktrees are visible automatically. Hosts the shared toolchain (`claude`, `codex`, `pi`, `pnpm`, `git`, `gh`, Docker socket) and shared credentials (`~/.claude`, `~/.pi`, `~/.config/gh`). Boots via `install/entrypoint.sh`, which starts the heartbeat daemon under a watchdog.
+
+### Heartbeat daemon
+
+One Node process per sandbox. On startup (and whenever `.git/worktrees/` changes), it runs `git worktree list --porcelain` and includes every worktree whose `workspace/heartbeats/` exists. Each worktree gets its own `fs.watch`, its own log file, and namespaced scheduler keys (`${label}::${slug}`) so two worktrees can ship identically-named heartbeats without collision. Each heartbeat spawn sets `cwd = <worktree>/workspace`, so the agent CLI resolves skills, settings, and relative paths against the correct worktree. See the [heartbeats guide](/docs/guide/heartbeats) for env vars and log layout.
+
+## Lifecycle of a new agent
+
+```mermaid
+sequenceDiagram
+  actor Orc as Orchestrator
+  participant Git as Git / Host FS
+  participant Daemon as Heartbeat Daemon<br/>(inside sandbox)
+  participant Agent as Spawned Agent<br/>(claude -p)
+
+  Orc->>Git: gh issue create --label agent
+  Orc->>Git: git worktree add -b agent/<name><br/>.worktrees/agent/<name> development
+  Git-->>Git: .git/worktrees/<name>/ created
+  Git-->>Daemon: top-level watcher fires
+
+  Daemon->>Git: git worktree list --porcelain
+  Daemon->>Daemon: discoverWorkspaceRoots()<br/>start new per-root fs.watch
+
+  Orc->>Git: scaffold workspace/<br/>(SOUL.md, skills/, heartbeats/, crm/)
+  Orc->>Git: git commit + push
+  Git-->>Daemon: heartbeats/ watcher fires
+  Daemon->>Daemon: sync() — schedule new entries
+
+  Orc->>Git: gh pr create --base development
+  Note over Orc,Agent: orchestrator's job ends here
+
+  Note over Daemon,Agent: cron tick arrives
+  Daemon->>Agent: spawn claude -p<br/>(cwd = <worktree>/workspace)
+  Agent->>Git: writes memory/YYYY-MM-DD.md, crm/...
+  Agent-->>Daemon: stdout (HEARTBEAT_OK or body)
+  Daemon->>Daemon: logger.log(per-root log)
+```
+
+The orchestrator's job ends once the PR is opened. After that, the agent is self-directing on its heartbeat schedule (plus interactive sessions inside the sandbox).
+
+## Discovery
+
+The daemon discovers worktrees from `.git/worktrees/` — git's own authoritative registry — not from walking the filesystem. Rules:
+
+1. Run `git -C <home>/harness worktree list --porcelain`.
+2. Include any worktree whose `<path>/workspace/heartbeats/` exists.
+3. Compute a label: strip `refs/heads/`, replace `/` with `-`, lowercase. `agent/sdr-pallet` → `agent-sdr-pallet`. Detached HEAD → `detached-<shortsha>`.
+4. Honor `HEARTBEAT_ROOTS=path1:label1,path2:label2` overrides. Overrides win on path collisions.
+5. Warn if the discovered root count exceeds 32 (inotify sanity check).
+
+Layout under `.worktrees/` can be nested, flat, or symlinked — discovery doesn't care.
+
+## Spawn semantics
+
+Every heartbeat spawn sets `cwd` to its worktree's `workspace/`:
+
+```ts
+spawn("claude", ["-p", prompt, "--dangerously-skip-permissions"], {
+  cwd: entry.root.workspacePath,        // e.g. .../sdr-pallet/workspace
+  signal: AbortSignal.timeout(300_000),
+});
+```
+
+Consequences:
+
+- `claude` loads that worktree's `workspace/.claude/settings.json` (model, permissions, hooks).
+- Slash-skills resolve against `workspace/.claude/skills/`.
+- Relative paths in prompts (`memory/YYYY-MM-DD.md`, `crm/leads.csv`) land in the right worktree.
+- Credentials are shared — one `gh auth`, one Anthropic key across all agents.
+
+## Isolation properties
+
+| Dimension | Isolated? | Notes |
+|-----------|-----------|-------|
+| Filesystem under `workspace/` | Yes | Each worktree owns its subtree |
+| Git history / branch state | Yes | Worktrees are fully independent |
+| Heartbeat schedules + logs | Yes | Per-root logger, per-root watcher |
+| Agent identity (SOUL.md, skills) | Yes | Per-root, loaded via spawn cwd |
+| Memory + CRM + wiki artifacts | Yes | Per-root directories |
+| Credentials | **No** | One `gh auth`, one Anthropic key |
+| Container runtime | **No** | Same processes, /tmp, network |
+| API quotas | **No** | `HEARTBEAT_MAX_CONCURRENT` smooths bursts |
+| OS / kernel | **No** | One container |
+
+This is **thin isolation** — enough to keep agent artifacts clean and independently committable, not enough to sandbox a hostile agent. All agents in a sandbox must be mutually trusted.
+
+## Worktree vs new sandbox
+
+**Add a new worktree agent when:**
+
+- The work lives on a branch you'd eventually merge back.
+- The agent shares the same stack, credentials, and trust level.
+- You want shared tooling and independent identity.
+- The daemon should schedule it alongside other agents.
+
+**Add a new sandbox when:**
+
+- You need kernel-level isolation (untrusted code, tenant separation).
+- The agent needs a different OS, different base image, or conflicting global tooling.
+- You need isolated rate limits (separate Anthropic account, separate API quota).
+- You're reproducing a customer environment for debugging.
+
+Most "I want to add an agent" cases are the first bucket. New sandboxes are rare.
+
+## Heartbeat firing flow
+
+```mermaid
+sequenceDiagram
+  participant Cron as Croner (per job)
+  participant Runner as HeartbeatRunner
+  participant Sem as Semaphore<br/>(HEARTBEAT_MAX_CONCURRENT)
+  participant Gates as Gates
+  participant Claude as claude CLI
+  participant Logger as Per-root Logger
+
+  Cron->>Runner: tick(entry)
+  Runner->>Sem: tryAcquireSlot()
+
+  alt slot queued > 300s
+    Runner->>Logger: [label::entry] Skipped<br/>(concurrency cap reached)
+  else slot granted
+    Runner->>Runner: concurrency guard<br/>(root, entryName) already running?
+    opt guard hit
+      Runner->>Logger: Skipping — previous still running
+    end
+
+    Runner->>Gates: isActiveHours(start,end)?
+    alt outside window
+      Runner->>Logger: Outside active hours, skipping
+    else active
+      Runner->>Gates: isHeartbeatEmpty(filePath)?
+      alt empty
+        Runner->>Logger: File effectively empty, skipping
+      else has body
+        Runner->>Runner: build prompt<br/>(SOUL.md + heartbeat body + HEARTBEAT_OK rule)
+        Runner->>Claude: spawn(claude, ..., { cwd, signal: 300s })
+        Claude-->>Runner: stdout
+        alt exit 0, contains HEARTBEAT_OK, <300 chars
+          Runner->>Logger: HEARTBEAT_OK
+        else exit 0 with body
+          Runner->>Logger: Response: <body>
+        else timeout / non-zero
+          Runner->>Logger: Timed out / Failed (exit N)
+        end
+      end
+    end
+
+    Runner->>Sem: releaseSlot()
+  end
+```
+
+Key invariants: `cwd` is set per entry, never shared across worktrees. The semaphore is daemon-global and FIFO. Each worktree writes to its own `heartbeats/heartbeat.log`.
+
+## Trust boundary
+
+All worktrees discovered from the main checkout's `.git/worktrees/` are treated as trusted. This is the same trust model as the rest of the sandbox: if you can `git commit` to a branch in this repo, you can make the daemon run code on your behalf. The `--dangerously-skip-permissions` flag on the `claude` spawn makes this explicit. Do not point `HEARTBEAT_ROOTS` at untrusted paths; do not provision a sandbox from a repo you don't own.
+
+## Operational snippets
+
+Add an agent:
+
+```bash
+# From the orchestrator session (project root)
+gh issue create --label agent --title "agent(#N): <name> — <role>"
+git worktree add -b agent/<name> .worktrees/agent/<name> development
+# Scaffold workspace/ for the agent's role
+git commit -m "agent(#N): scaffold <name>"
+git push -u origin agent/<name>
+# Daemon auto-discovers within ~500 ms
+```
+
+Verify it's live:
+
+```bash
+# Inside the sandbox
+heartbeat-daemon status
+# Look for: "Roots:" section includes the agent, per-root schedules listed
+```
+
+Read per-root logs:
+
+```bash
+tail -f /home/sandbox/harness/workspace/heartbeats/heartbeat.log
+tail -f /home/sandbox/harness/.worktrees/agent/<name>/workspace/heartbeats/heartbeat.log
+```
+
+Retire an agent:
+
+```bash
+git worktree remove .worktrees/agent/<name>
+# Daemon drops it on the next .git/worktrees/ mutation
+```
+
+## Further reading
+
+- [How It Works](/docs/architecture/how-it-works) — boot sequence and container environment.
+- [Project Structure](/docs/architecture/structure) — repo layout.
+- [Heartbeats guide](/docs/guide/heartbeats) — multi-root discovery, env vars, log layout.
+- **Canonical spec** — [`.claude/specs/orchestrator-worktree-architecture.md`](https://github.com/ryaneggz/open-harness/blob/development/.claude/specs/orchestrator-worktree-architecture.md) — file-path tables, change-target matrices, failure modes.
+- **Daemon spec** — [`.claude/specs/multi-worktree-heartbeats-spec.md`](https://github.com/ryaneggz/open-harness/blob/development/.claude/specs/multi-worktree-heartbeats-spec.md) — internal daemon design.

--- a/docs/content/docs/architecture/overview.mdx
+++ b/docs/content/docs/architecture/overview.mdx
@@ -3,23 +3,38 @@ title: "Architecture Overview"
 ---
 
 
-Open Harness is a monorepo that provides isolated Docker sandboxes for AI coding agents. The system has three main layers:
+Open Harness is a monorepo that provides isolated Docker sandboxes for AI coding agents, with a shared runtime pattern that lets multiple agents co-exist in one container. The system has four layers:
 
-## CLI & Sandbox Package (`packages/sandbox/`)
+## 1. CLI & Sandbox Package (`packages/sandbox/`)
 
 `@openharness/sandbox` is the core of the system. The `openharness` binary lives in `src/cli/` and handles all user-facing commands: starting, stopping, entering, and cleaning up sandboxes. Container lifecycle operations — Docker Compose command builders and tool definitions — live in `src/tools/` and `src/lib/`. Each tool (sandbox, run, stop, clean, shell, etc.) constructs and executes Docker commands against the `.devcontainer/` configuration.
 
 The package also serves as a Pi Agent extension, registering all tools as both LLM-callable functions and slash commands.
 
-## Container Infrastructure (`.devcontainer/`)
+## 2. Container Infrastructure (`.devcontainer/`)
 
 The Dockerfile and Compose files define the sandbox environment:
 
 - **Dockerfile**: Debian Bookworm with Node.js 22, pnpm, agent CLIs, Docker CLI, GitHub CLI, and dev tools
 - **docker-compose.yml**: Base service with SSH, workspace mount, named volumes for auth persistence
 - **Compose overlays**: Optional services (PostgreSQL, Cloudflare, Docker-in-Docker, SSH) toggled via `.openharness/config.json`
-- **entrypoint.sh**: Container startup logic (Docker GID matching, cron, heartbeat sync)
+- **entrypoint.sh**: Container startup logic (Docker GID matching, cron, heartbeat daemon, onboarding)
+
+## 3. Orchestrator + Worktree Topology
+
+The running configuration is not "one sandbox per agent" — it's **one parent sandbox, N git worktrees, one heartbeat daemon**. Every agent is a git branch checked out as a worktree under `.worktrees/`, each shipping its own `workspace/` (SOUL.md, skills, heartbeats, memory, CRM, wiki). The container bind-mounts the entire repo, so all worktrees are visible to one shared toolchain and one shared credential set.
+
+Ownership splits cleanly:
+
+- **Orchestrator** (session at the project root): owns harness source, git operations, GitHub issues/PRs/releases, and the one-time scaffold of each new agent's workspace.
+- **Worktree agent** (session inside `.worktrees/<prefix>/<slug>/workspace/`): owns its workspace subtree and its branch history.
+
+See [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees) for the full topology, lifecycle, and isolation properties.
+
+## 4. Heartbeat Daemon
+
+A single Node process inside the sandbox watches every worktree's `workspace/heartbeats/` directory at once. It discovers roots from `git worktree list --porcelain` (the authoritative registry), spawns each heartbeat with `cwd` inside the correct worktree, and writes per-root logs. A global semaphore (`HEARTBEAT_MAX_CONCURRENT`, default 2) prevents aligned schedules from saturating shared API quotas. See the [Heartbeats guide](/docs/guide/heartbeats) for configuration detail.
 
 ## Workspace Template (`workspace/`)
 
-The workspace template provides agent identity (SOUL.md, MEMORY.md), operating procedures (AGENTS.md), coding standards (`.claude/rules/`), skills (`.claude/skills/`), and heartbeat schedules. Bind-mounted into the container at `/home/sandbox/harness/workspace/`.
+The workspace template provides agent identity (SOUL.md, MEMORY.md), operating procedures (AGENTS.md), coding standards (`.claude/rules/`), skills (`.claude/skills/`), and heartbeat schedules. Bind-mounted into the container; each worktree carries its own copy, evolved independently on its branch.

--- a/docs/content/docs/architecture/structure.mdx
+++ b/docs/content/docs/architecture/structure.mdx
@@ -75,4 +75,4 @@ The `workspace/` directory contains markdown files that define the agent's ident
 
 `CLAUDE.md` is a symlink to `AGENTS.md` so Claude Code loads operating procedures automatically.
 
-See the [Workspace guide](/docs/guide/workspace) for full details on each file and the ownership model.
+See the [Workspace guide](/docs/guide/workspace) for full details on each file and the ownership model. For how multiple agents share one sandbox via git worktrees, see [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees).

--- a/docs/content/docs/guide/heartbeats.mdx
+++ b/docs/content/docs/guide/heartbeats.mdx
@@ -5,6 +5,8 @@ title: "Heartbeats"
 
 Heartbeats are cron-scheduled tasks that let agents wake, perform work, and go back to sleep. Each heartbeat is a `.md` file in `workspace/heartbeats/` with YAML frontmatter defining its schedule, agent, and active hours.
 
+A single heartbeat daemon inside the sandbox watches every worktree's `heartbeats/` directory at once — see [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees) for the topology.
+
 ## Managing heartbeats
 
 From the host:
@@ -20,7 +22,7 @@ Inside the sandbox:
 
 ```bash
 heartbeat-daemon sync      # force re-read heartbeat files
-heartbeat-daemon status    # show schedules + recent logs
+heartbeat-daemon status    # show schedules + recent logs, grouped by root
 ```
 
 ## Schedule config
@@ -55,25 +57,73 @@ Use the `/heartbeat` skill inside the sandbox:
 /heartbeat check build health every 30 minutes during business hours
 ```
 
-The daemon auto-detects new files within 500ms — no manual sync needed.
+The daemon auto-detects new files within 500 ms — no manual sync needed.
 
-## How it works
+## Multi-root discovery
 
-1. The `heartbeat-daemon` starts on container boot and watches the `heartbeats/` directory
-2. On each cron tick, the daemon checks active hours (if set), then spawns the agent CLI with the `.md` file content as the prompt
-3. If the file is empty or contains only headers/comments, execution is skipped (saves API costs)
-4. If the agent has nothing to report, it replies `HEARTBEAT_OK` and the response is suppressed
-5. When files change, the daemon performs differential sync — only restarting jobs whose config actually changed
+The daemon runs `git worktree list --porcelain` on startup (and whenever `.git/worktrees/` changes) and treats every worktree whose `workspace/heartbeats/` exists as a **root**. Each root gets:
 
-## Global defaults
+- Its own `fs.watch` on `<root>/workspace/heartbeats/`.
+- Its own log file at `<root>/workspace/heartbeats/heartbeat.log`.
+- A label derived from the branch name (`refs/heads/` stripped, `/` → `-`, lowercased). `agent/sdr-pallet` becomes `agent-sdr-pallet`.
+- Namespaced scheduler keys (`${label}::${slug}`) so two worktrees can ship identically-named heartbeats without colliding.
+
+Each heartbeat is spawned with `cwd = <root>/workspace`, so the agent CLI loads that worktree's `.claude/settings.json`, skills, and relative paths (`memory/YYYY-MM-DD.md`, `crm/leads.csv`) resolve correctly.
+
+Single-root setups continue to work unchanged — the legacy daemon construction path passes no `cwd`, byte-identical to pre-multi-root behavior.
+
+## Global environment variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `HEARTBEAT_AGENT` | `claude` | Default agent CLI for heartbeats without an `agent` frontmatter field |
+| `HEARTBEAT_AGENT` | `claude` | Default CLI for heartbeats without an `agent` frontmatter field |
 | `HEARTBEAT_INTERVAL` | `1800` | Default interval (seconds) for legacy `HEARTBEAT.md` fallback |
+| `HEARTBEAT_MAX_CONCURRENT` | `2` | FIFO daemon-wide cap on concurrent `claude -p` spawns. `0` disables the cap. |
+| `HEARTBEAT_ROOTS` | _(unset)_ | Explicit root overrides: `path1:label1,path2:label2`. Overrides win on path collisions. Auto-discovery still runs for paths not listed. |
 
-Per-heartbeat scheduling and active hours are configured via YAML frontmatter.
+`HEARTBEAT_MAX_CONCURRENT` smooths bursts when multiple worktrees' schedules align (e.g., three `morning-pipeline` clones firing at `0 13 * * 1-5`). Queued spawns wait up to 300 s for a slot, then log `Skipped (concurrency cap reached)`.
+
+## `heartbeat-daemon status` output
+
+Output is grouped by root:
+
+```
+Heartbeat daemon: running (pid 12345)
+
+Roots:
+  parent       → /home/sandbox/harness/workspace (3 schedules)
+  sdr-pallet   → /home/sandbox/harness/.worktrees/agent/sdr-pallet/workspace (5 schedules)
+
+Schedules:
+  parent::nightly-release         50 23 * * *     next: 2026-04-19 23:50 UTC
+  parent::test-sys-metrics        */2 * * * *     next: 2026-04-19 17:14 UTC
+  sdr-pallet::morning-pipeline    0 13 * * 1-5    next: 2026-04-20 13:00 UTC
+  ...
+
+Recent log (parent):
+  ...
+Recent log (sdr-pallet):
+  ...
+```
+
+Scripts that grep the legacy `cronExpr → filePath` format still match — the `Roots:` section is additive.
+
+## How it works
+
+1. The daemon starts on container boot and discovers every worktree root with a `workspace/heartbeats/` directory.
+2. It installs one `fs.watch` per root plus a top-level watcher on `.git/worktrees/` for hot add/remove.
+3. On each cron tick, the daemon checks active hours, then spawns the agent CLI with the `.md` file content as the prompt and `cwd` set to that worktree's workspace.
+4. If the file is empty or contains only headers/comments, execution is skipped (saves API costs).
+5. If the agent has nothing to report, it replies `HEARTBEAT_OK` and the response is suppressed.
+6. When files change, the daemon performs differential sync — only restarting jobs whose config actually changed.
 
 ## Logs
 
-Heartbeat logs are written to `workspace/heartbeats/heartbeat.log` inside the container.
+Each root writes its own log:
+
+```bash
+tail -f /home/sandbox/harness/workspace/heartbeats/heartbeat.log
+tail -f /home/sandbox/harness/.worktrees/agent/<name>/workspace/heartbeats/heartbeat.log
+```
+
+Each per-root logger rotates independently when it exceeds 1000 lines (keeps the last 500). Daemon-level messages (startup, discovery errors) go to the parent root's log.

--- a/docs/lib/remark-mermaid.mjs
+++ b/docs/lib/remark-mermaid.mjs
@@ -1,0 +1,18 @@
+import { visit } from "unist-util-visit";
+
+export default function remarkMermaid() {
+  return (tree) => {
+    visit(tree, "code", (node, index, parent) => {
+      if (node.lang !== "mermaid") return;
+      if (!parent || typeof index !== "number") return;
+      parent.children[index] = {
+        type: "mdxJsxFlowElement",
+        name: "Mermaid",
+        attributes: [
+          { type: "mdxJsxAttribute", name: "chart", value: node.value },
+        ],
+        children: [],
+      };
+    });
+  };
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,19 +8,20 @@
     "start": "next start -p 3001"
   },
   "dependencies": {
+    "@tailwindcss/postcss": "^4",
     "fumadocs-core": "latest",
     "fumadocs-mdx": "latest",
     "fumadocs-ui": "latest",
+    "mermaid": "^11.14.0",
     "next": "^16",
     "react": "^19",
     "react-dom": "^19",
-    "tailwindcss": "^4",
-    "@tailwindcss/postcss": "^4"
+    "tailwindcss": "^4"
   },
   "devDependencies": {
     "@types/mdx": "^2",
     "@types/react": "^19",
-    "typescript": "^5",
-    "postcss": "^8"
+    "postcss": "^8",
+    "typescript": "^5"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,8 @@
     "next": "^16",
     "react": "^19",
     "react-dom": "^19",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@types/mdx": "^2",

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,4 +1,5 @@
 import { defineDocs, defineConfig } from "fumadocs-mdx/config";
+import remarkMermaid from "./lib/remark-mermaid.mjs";
 
 export const docs = defineDocs({
   dir: "content/docs",
@@ -8,4 +9,8 @@ export const wiki = defineDocs({
   dir: "content/wiki",
 });
 
-export default defineConfig();
+export default defineConfig({
+  mdxOptions: {
+    remarkPlugins: [remarkMermaid],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,13 +23,16 @@ importers:
         version: 4.2.2
       fumadocs-core:
         specifier: latest
-        version: 16.7.16(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+        version: 16.8.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
       fumadocs-mdx:
         specifier: latest
-        version: 14.3.0(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+        version: 14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
       fumadocs-ui:
         specifier: latest
-        version: 16.7.16(@tailwindcss/oxide@4.2.2)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2)
+        version: 16.8.0(@tailwindcss/oxide@4.2.2)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2)
+      mermaid:
+        specifier: ^11.14.0
+        version: 11.14.0
       next:
         specifier: ^16
         version: 16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1741,10 +1744,6 @@ packages:
     resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
     engines: {node: '>=20'}
 
-  '@shikijs/transformers@4.0.2':
-    resolution: {integrity: sha512-1+L0gf9v+SdDXs08vjaLb3mBFa8U7u37cwcBQIv/HCocLwX69Tt6LpUCjtB+UUTvQxI7BnjZKhN/wMjhHBcJGg==}
-    engines: {node: '>=20'}
-
   '@shikijs/types@4.0.2':
     resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
     engines: {node: '>=20'}
@@ -3214,8 +3213,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  fumadocs-core@16.7.16:
-    resolution: {integrity: sha512-OXZMJPS/HVAfCw8/VEgsOEQNWUXq7+U2v1A/DbKmI0Vbb08uPCUpbIqVSj4kmGr46L+Pa/PZgG596Z7iPhlbCg==}
+  fumadocs-core@16.8.0:
+    resolution: {integrity: sha512-kO9DnhJ/8E2DNtsyDlvMFDBNH0A5V+OFJEFiGNNb/jM/zs7YdSszQ3LOPL66AnyUQ5aou7BmFyPvzJvyiDMyjg==}
     peerDependencies:
       '@mdx-js/mdx': '*'
       '@mixedbread/sdk': ^0.46.0
@@ -3273,8 +3272,8 @@ packages:
       zod:
         optional: true
 
-  fumadocs-mdx@14.3.0:
-    resolution: {integrity: sha512-OsllpIpdk6Mu595MpX1hFFXrBq7cFpFBEkKNAFgO7aKZ/ux4e4pavTesDd5xKhuOfC0J9CZSUJ8RMlad9j5yTA==}
+  fumadocs-mdx@14.3.1:
+    resolution: {integrity: sha512-0u2eXvYrZtrJB14y6fDhP0hhxLgmH8JOmRv6IVHALt5MqR9JIJxV5LJYlho8g8CJXRE8w12rVNFZN0rtUVAqGw==}
     hasBin: true
     peerDependencies:
       '@types/mdast': '*'
@@ -3301,13 +3300,13 @@ packages:
       vite:
         optional: true
 
-  fumadocs-ui@16.7.16:
-    resolution: {integrity: sha512-NFWH8GuVV0O6OQnGb0TCS6jsdgyB7/5phQm8YjtIkyjkxAkERwA76N5RYCpS27p41NdtWdQw4eFIEve1Aq9Siw==}
+  fumadocs-ui@16.8.0:
+    resolution: {integrity: sha512-om9bQBUcy/1Dt4+VCJIN4SplF8KLpwT+lOaqOmUzQjHl6l/YgYULBm9dukuA7wxDBXaFCawvwBWfx0TjrC+UuA==}
     peerDependencies:
       '@takumi-rs/image-response': '*'
       '@types/mdx': '*'
       '@types/react': '*'
-      fumadocs-core: 16.7.16
+      fumadocs-core: 16.8.0
       next: 16.x.x
       react: ^19.2.0
       react-dom: ^19.2.0
@@ -6833,11 +6832,6 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.0.2
 
-  '@shikijs/transformers@4.0.2':
-    dependencies:
-      '@shikijs/core': 4.0.2
-      '@shikijs/types': 4.0.2
-
   '@shikijs/types@4.0.2':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
@@ -8613,14 +8607,14 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6):
+  fumadocs-core@16.8.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6):
     dependencies:
       '@orama/orama': 3.1.18
-      '@shikijs/transformers': 4.0.2
       estree-util-value-to-estree: 3.5.0
       github-slugger: 2.0.0
       hast-util-to-estree: 3.1.3
       hast-util-to-jsx-runtime: 2.3.6
+      js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
       remark: 15.0.1
@@ -8647,14 +8641,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.3.0(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
+  fumadocs-mdx@14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.7.16(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+      fumadocs-core: 16.8.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -8677,7 +8671,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.7.16(@tailwindcss/oxide@4.2.2)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2):
+  fumadocs-ui@16.8.0(@tailwindcss/oxide@4.2.2)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2):
     dependencies:
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.2.2)(tailwindcss@4.2.2)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -8691,7 +8685,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.7.16(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+      fumadocs-core: 16.8.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.7.43)(lucide-react@1.8.0(react@19.2.5))(next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
       lucide-react: 1.8.0(react@19.2.5)
       motion: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.2
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@types/mdx':
         specifier: ^2
@@ -834,89 +837,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1017,30 +1036,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
     resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
     resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
     resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
@@ -1141,24 +1165,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.4':
     resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.4':
     resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.4':
     resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.4':
     resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
@@ -1629,66 +1657,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2005,24 +2046,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -3684,24 +3729,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/workspace/wiki/index.md
+++ b/workspace/wiki/index.md
@@ -1,18 +1,19 @@
 # Wiki Index
 
-> Last updated: —
-> Pages: 0 | Sources: 0
+> Last updated: 2026-04-19
+> Pages: 1 | Sources: 0
 
 ## Pages
 
 | File | Title | Type | Tags | Sources | Updated |
 |------|-------|------|------|---------|---------|
+| [orchestrator-worktree-architecture.md](pages/orchestrator-worktree-architecture.md) | Orchestrator-Worktree Architecture | concept | architecture, harness, worktrees, heartbeats, orchestrator | — | 2026-04-19 |
 
 ## Statistics
 
 - **Entity pages**: 0
-- **Concept pages**: 0
+- **Concept pages**: 1
 - **Synthesis pages**: 0
 - **Total sources**: 0
-- **Last ingest**: never
+- **Last ingest**: 2026-04-19
 - **Last lint**: never

--- a/workspace/wiki/log.md
+++ b/workspace/wiki/log.md
@@ -9,3 +9,8 @@ Rotation: wiki-lint trims to last 200 entries when exceeded.
 - **Sources**: [source filenames referenced]
 - **Summary**: [one sentence]
 -->
+
+## [INGEST] — 2026-04-19 12:45 UTC
+- **Pages**: orchestrator-worktree-architecture.md
+- **Sources**: .claude/specs/orchestrator-worktree-architecture.md, .claude/specs/multi-worktree-heartbeats-spec.md
+- **Summary**: Adapted canonical orchestrator+worktree topology spec into a concept-type wiki page alongside docs-site propagation (issue #83).

--- a/workspace/wiki/pages/orchestrator-worktree-architecture.md
+++ b/workspace/wiki/pages/orchestrator-worktree-architecture.md
@@ -1,0 +1,81 @@
+---
+title: "Orchestrator-Worktree Architecture"
+description: "Canonical shape for running multiple Open Harness agents: one sandbox, N git worktrees, one heartbeat daemon."
+type: concept
+tags: [architecture, harness, worktrees, heartbeats, orchestrator]
+sources: []
+created: 2026-04-19
+updated: 2026-04-19
+---
+
+## Summary
+
+Open Harness runs every agent as a git branch checked out as a worktree under
+`.worktrees/`. A single container (`oh-remote`) bind-mounts the entire repo,
+so all worktrees are visible to one shared toolchain and one shared credential
+set. A single heartbeat daemon inside the sandbox watches every worktree's
+`workspace/heartbeats/` at once, spawning each task with the correct `cwd`.
+
+This is the authoritative topology. "One sandbox per agent" is an escape
+hatch, not the default.
+
+## Key actors
+
+- **Orchestrator** — session at the project root. Owns harness source,
+  git operations, GitHub issues/PRs/releases, and the one-time scaffold
+  of each new agent's `workspace/`. Does not write application code.
+- **Worktree agent** — session inside `.worktrees/<prefix>/<slug>/workspace/`.
+  Owns its workspace subtree (SOUL.md, skills, heartbeats, memory, CRM,
+  wiki, projects) and its branch history.
+- **Sandbox container** — default name `oh-remote`. Bind-mounts
+  `/home/sandbox/harness`, hosts the shared toolchain and credentials.
+- **Heartbeat daemon** — one Node process per sandbox. Discovers roots
+  from `git worktree list --porcelain`; one `fs.watch` per root; each
+  spawn uses `cwd = <worktree>/workspace`.
+
+## Why this shape
+
+1. **Branches have identities.** SOUL.md, skills, CRM, heartbeats all
+   live on a branch — agent identity is files on disk, not runtime
+   config.
+2. **One container per agent is too heavy.** A sandbox is a real OS
+   with its own toolchain, credentials, and dev servers.
+3. **Merging agent work is a git problem.** Git worktrees already solve
+   "multiple branches at once." The natural fit: worktrees on the host,
+   one container for all of them.
+
+## Isolation (thin)
+
+Per-worktree: filesystem under `workspace/`, git history, heartbeat
+schedules + logs, agent identity, memory/CRM/wiki artifacts.
+Shared: credentials (`gh auth`, Anthropic key), container runtime, API
+quotas, OS/kernel. This is enough to keep artifacts clean and
+independently committable, not enough to sandbox a hostile agent. All
+agents in a sandbox must be mutually trusted.
+
+## Heartbeat discovery
+
+The daemon runs `git worktree list --porcelain` and includes every
+worktree whose `workspace/heartbeats/` exists. Labels are derived from
+branch names (`refs/heads/` stripped, `/` → `-`, lowercased). Scheduler
+keys namespace by label (`${label}::${slug}`) so same-named heartbeats
+in two worktrees don't collide. `HEARTBEAT_MAX_CONCURRENT` (default 2)
+caps daemon-wide concurrent spawns to smooth aligned schedules.
+`HEARTBEAT_ROOTS=path1:label1,path2:label2` overrides auto-discovery on
+path collisions.
+
+## When to add a new worktree vs a new sandbox
+
+- **New worktree** — merge-back work, shared stack, shared trust level,
+  shared rate limits. Most agent work.
+- **New sandbox** — kernel-level isolation (untrusted code),
+  conflicting global tooling, isolated API quotas, reproducing a
+  customer environment.
+
+## References
+
+- Docs: [Orchestrator + Worktrees](/docs/architecture/orchestrator-worktrees)
+- Docs: [Heartbeats guide](/docs/guide/heartbeats) — env vars, multi-root logs
+- Spec: `.claude/specs/orchestrator-worktree-architecture.md` (canonical)
+- Spec: `.claude/specs/multi-worktree-heartbeats-spec.md` (daemon design)
+- Source: `packages/sandbox/src/lib/heartbeat/`


### PR DESCRIPTION
Rollup of the orchestrator-worktree architecture docs rollout. Replaces PRs #80, #82, #84, #86.

Closes #79
Closes #81
Closes #83
Closes #85

## Summary

- **#79** — new canonical spec `.claude/specs/orchestrator-worktree-architecture.md` (+571).
- **#83** — derives user-facing docs from the spec: new `docs/content/docs/architecture/orchestrator-worktrees.mdx`, rewritten `overview.mdx`, updated `guide/heartbeats.mdx`, cross-links, and `workspace/wiki/pages/orchestrator-worktree-architecture.md` (+438/-24).
- **#85** — wires mermaid rendering via a remark plugin (`docs/lib/remark-mermaid.mjs`) that rewrites ```` ```mermaid ```` fences into `<Mermaid>` JSX before Shiki runs. The original `pre`-override approach never fired because Fumadocs runs Shiki before MDX components render.
- **#81** — adds Architecture section to `README.md` linking to the spec and docs-site page.

## QA

- `pnpm run build` in `docs/` — 35 static pages (was 33), `/docs/architecture/orchestrator-worktrees` + `/wiki/orchestrator-worktree-architecture` in route table.
- Live inspection via trycloudflare tunnel: all 3 mermaid diagrams on the new architecture page render as SVGs (topology flowchart + 2 sequence diagrams). Screenshots at `.claude/screenshots/orchestrator-worktrees-mermaid-*.png`.

## Notes

- No `packages/sandbox/`, `.devcontainer/`, or harness source touched.
- Supersedes #80, #82, #84, #86 — those PRs can be closed after this one merges.