### PR TITLE
FROM fix/98-entrypoint-slack-link TO development

### DIFF
--- a/install/entrypoint.sh
+++ b/install/entrypoint.sh
@@ -73,14 +73,17 @@ if [ -f "$STARTUP" ]; then
   gosu sandbox bash "$STARTUP" 2>&1 | sed 's/^/  /' || true
 fi
 
-# Build and link Slack bot from bind-mount (replaces /opt/slack image copy)
-if [ -f "$HOME/harness/packages/slack/package.json" ]; then
-  echo "Building and linking Slack bot package..."
-  cd "$HOME/harness/packages/slack"
-  pnpm install 2>/dev/null
-  pnpm run build 2>/dev/null
-  pnpm link --global 2>/dev/null
-  cd "$HOME/harness"
+# Build and link Slack bot from bind-mount (replaces /opt/slack image copy).
+# Entrypoint runs as root, so $HOME is /root — use the sandbox user's absolute
+# path and run pnpm as that user so the global link lands on their PATH.
+SLACK_PKG="/home/sandbox/harness/packages/slack"
+if [ -f "$SLACK_PKG/package.json" ]; then
+  echo "[entrypoint] Building and linking Slack bot package..."
+  if gosu sandbox bash -c "cd '$SLACK_PKG' && pnpm install && pnpm run build && pnpm link --global"; then
+    echo "[entrypoint] Slack bot linked ($(gosu sandbox bash -lc 'command -v mom || echo missing'))"
+  else
+    echo "[entrypoint] WARNING: Slack bot build/link failed — mom CLI will be unavailable"
+  fi
 fi
 
 exec gosu sandbox "$@"

--- a/packages/sandbox/src/__tests__/heartbeat-discovery.test.ts
+++ b/packages/sandbox/src/__tests__/heartbeat-discovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -10,6 +10,16 @@ import { discoverWorkspaceRoots, sanitizeBranch } from "../lib/heartbeat/discove
 // Helpers: build a real, throwaway multi-worktree git repo on disk so we can
 // exercise `git worktree list --porcelain` end-to-end (no parsing mocks).
 // ---------------------------------------------------------------------------
+
+// Husky pre-commit hooks export GIT_DIR/GIT_INDEX_FILE, which leak into every
+// child `git` process — both the test helper below and the production
+// `discoverWorkspaceRoots` call — and silently retarget them at the real repo.
+// Strip them once for the whole file so the tests are hermetic.
+beforeAll(() => {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("GIT_")) delete process.env[key];
+  }
+});
 
 function run(cwd: string, ...args: string[]): string {
   return execFileSync("git", ["-C", cwd, ...args], {


### PR DESCRIPTION
## Summary

- **`install/entrypoint.sh`**: the Slack-bot build/link step ran as root where `$HOME=/root`, so its guard on `$HOME/harness/packages/slack/package.json` was always false. Silent `2>/dev/null` redirections hid the skip. Result: `mom` CLI absent from the sandbox PATH on every fresh container, and onboard's Slack step silently no-ops. Fixed by using the absolute sandbox path, running via `gosu sandbox`, and surfacing success/failure.
- **`packages/sandbox/src/__tests__/heartbeat-discovery.test.ts`**: husky exports `GIT_DIR`/`GIT_INDEX_FILE` when it runs the pre-commit hook; those leaked into the test's child `git` processes and retargeted them at the real repo, so `git worktree add -b agent/sdr-pallet` failed (that branch already exists from #73). Strip `GIT_*` from `process.env` in a `beforeAll`.

Closes #98

## Test plan

- [x] `pnpm run test` in `packages/sandbox` passes (260/260)
- [x] Same test suite passes with `GIT_DIR=…` exported (simulates husky)
- [ ] After rebuilding `oh-local` (`docker compose ... up -d --build`), `which mom` resolves inside the container and entrypoint log shows `[entrypoint] Slack bot linked (/...path-to-mom)`
- [ ] Fresh `openharness onboard` flow sees `mom` on PATH and starts the bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)