### PR TITLE
FROM feat/110-default-tmux-conf TO development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,6 +66,9 @@ RUN useradd -m -s /bin/bash sandbox \
  && chmod 0440 /etc/sudoers.d/sandbox \
  && groupadd -f docker && usermod -aG docker sandbox
 
+# Default tmux config for sandbox user
+COPY --chown=sandbox:sandbox install/.tmux.conf /home/sandbox/.tmux.conf
+
 # Ensure PNPM_HOME is on PATH for login shells (SSH, openharness shell)
 RUN echo 'export PNPM_HOME="/usr/local/share/pnpm"' >> /home/sandbox/.profile \
  && echo 'export PATH="$PNPM_HOME:$PATH"' >> /home/sandbox/.profile

--- a/install/.tmux.conf
+++ b/install/.tmux.conf
@@ -1,0 +1,40 @@
+# Set prefix to Ctrl-a
+unbind C-b
+set -g prefix C-b
+bind C-b send-prefix
+
+# Enable mouse
+set -g mouse on
+
+# Pane border color
+set -g pane-border-style fg=cyan
+set -g pane-active-border-style fg=yellow
+
+# Status bar (black background and white text)
+set -g status-bg black          # Black background
+set -g status-fg white          # White text
+set -g status-interval 5
+
+# Window title colors
+set-window-option -g window-status-current-style fg=yellow,bg=black
+set-window-option -g window-status-style fg=cyan,bg=black
+
+# Show Git branch in status bar
+set -g status-left-length 50
+set -g status-left '#[fg=cyan]#S #[fg=white]#(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "no branch") '
+
+# Highlight active pane
+set -g pane-active-border-style fg=yellow
+
+# Key bindings for better navigation
+bind -n C-Left select-pane -L
+bind -n C-Right select-pane -R
+bind -n C-Up select-pane -U
+bind -n C-Down select-pane -D
+
+# Enable color for tmux in terminal
+set -g default-terminal "screen-256color"
+
+# Agent Long Living Sessions
+#set -g remain-on-exit on
+#set -g history-limit 50000


### PR DESCRIPTION
## Summary

- Vendor a default tmux config at `install/.tmux.conf` (mouse on, styled status bar with git branch, Ctrl+arrow pane nav, `screen-256color`).
- `COPY` it into the sandbox image at `/home/sandbox/.tmux.conf` via `.devcontainer/Dockerfile` (right after the `useradd sandbox` block).
- No runtime changes — tmux reads `~/.tmux.conf` automatically when sessions start (including the auto-launched `slack` session in `.devcontainer/entrypoint.sh:217` and `install/tmux-agent.sh` agent wrappers).

## Test plan

- [ ] `docker compose -f .devcontainer/docker-compose.yml build sandbox` succeeds.
- [ ] `docker exec openharness ls -la /home/sandbox/.tmux.conf` → owned by `sandbox:sandbox`.
- [ ] `docker exec -u sandbox openharness tmux new-session -d -s test && docker exec -u sandbox openharness tmux show-options -g | grep -E 'mouse|status-bg'` → mouse on, status-bg black.
- [ ] CI green.

Closes #110