### PR TITLE
FROM bug/117-docs-double-basepath TO development

### DIFF
--- a/docs/pages/architecture/how-it-works.mdx
+++ b/docs/pages/architecture/how-it-works.mdx
@@ -18,7 +18,7 @@ When you start a sandbox (`openharness sandbox` or `docker compose up`), this se
    - Matches the container's Docker group GID to the host socket GID (fixes DinD permissions)
    - Fixes volume ownership (root → sandbox user)
    - Runs conditional SSH server setup if sshd overlay is active
-   - Starts the heartbeat daemon (`heartbeat-daemon start`) to watch every worktree's `heartbeats/` directory for scheduled tasks — see [Orchestrator + Worktrees](/open-harness/architecture/orchestrator-worktrees)
+   - Starts the heartbeat daemon (`heartbeat-daemon start`) to watch every worktree's `heartbeats/` directory for scheduled tasks — see [Orchestrator + Worktrees](/architecture/orchestrator-worktrees)
    - Runs `workspace/startup.sh` as the sandbox user
    - Prints first-boot onboarding message if not yet onboarded
    - Execs the container command (`sleep infinity` by default, or `sshd -D` with the sshd overlay)

--- a/docs/pages/architecture/orchestrator-worktrees.mdx
+++ b/docs/pages/architecture/orchestrator-worktrees.mdx
@@ -64,7 +64,7 @@ Default name `oh-remote`. Bind-mounts `/home/sandbox/harness` into the container
 
 ### Heartbeat daemon
 
-One Node process per sandbox. On startup (and whenever `.git/worktrees/` changes), it runs `git worktree list --porcelain` and includes every worktree whose `workspace/heartbeats/` exists. Each worktree gets its own `fs.watch`, its own log file, and namespaced scheduler keys (`${label}::${slug}`) so two worktrees can ship identically-named heartbeats without collision. Each heartbeat spawn sets `cwd = <worktree>/workspace`, so the agent CLI resolves skills, settings, and relative paths against the correct worktree. See the [heartbeats guide](/open-harness/guide/heartbeats) for env vars and log layout.
+One Node process per sandbox. On startup (and whenever `.git/worktrees/` changes), it runs `git worktree list --porcelain` and includes every worktree whose `workspace/heartbeats/` exists. Each worktree gets its own `fs.watch`, its own log file, and namespaced scheduler keys (`${label}::${slug}`) so two worktrees can ship identically-named heartbeats without collision. Each heartbeat spawn sets `cwd = <worktree>/workspace`, so the agent CLI resolves skills, settings, and relative paths against the correct worktree. See the [heartbeats guide](/guide/heartbeats) for env vars and log layout.
 
 ## Lifecycle of a new agent
 
@@ -255,8 +255,8 @@ git worktree remove .worktrees/agent/<name>
 
 ## Further reading
 
-- [How It Works](/open-harness/architecture/how-it-works) — boot sequence and container environment.
-- [Project Structure](/open-harness/architecture/structure) — repo layout.
-- [Heartbeats guide](/open-harness/guide/heartbeats) — multi-root discovery, env vars, log layout.
+- [How It Works](/architecture/how-it-works) — boot sequence and container environment.
+- [Project Structure](/architecture/structure) — repo layout.
+- [Heartbeats guide](/guide/heartbeats) — multi-root discovery, env vars, log layout.
 - **Canonical spec** — [`.claude/specs/orchestrator-worktree-architecture.md`](https://github.com/ryaneggz/open-harness/blob/development/.claude/specs/orchestrator-worktree-architecture.md) — file-path tables, change-target matrices, failure modes.
 - **Daemon spec** — [`.claude/specs/multi-worktree-heartbeats-spec.md`](https://github.com/ryaneggz/open-harness/blob/development/.claude/specs/multi-worktree-heartbeats-spec.md) — internal daemon design.

--- a/docs/pages/architecture/overview.mdx
+++ b/docs/pages/architecture/overview.mdx
@@ -29,11 +29,11 @@ Ownership splits cleanly:
 - **Orchestrator** (session at the project root): owns harness source, git operations, GitHub issues/PRs/releases, and the one-time scaffold of each new agent's workspace.
 - **Worktree agent** (session inside `.worktrees/<prefix>/<slug>/workspace/`): owns its workspace subtree and its branch history.
 
-See [Orchestrator + Worktrees](/open-harness/architecture/orchestrator-worktrees) for the full topology, lifecycle, and isolation properties.
+See [Orchestrator + Worktrees](/architecture/orchestrator-worktrees) for the full topology, lifecycle, and isolation properties.
 
 ## 4. Heartbeat Daemon
 
-A single Node process inside the sandbox watches every worktree's `workspace/heartbeats/` directory at once. It discovers roots from `git worktree list --porcelain` (the authoritative registry), spawns each heartbeat with `cwd` inside the correct worktree, and writes per-root logs. A global semaphore (`HEARTBEAT_MAX_CONCURRENT`, default 2) prevents aligned schedules from saturating shared API quotas. See the [Heartbeats guide](/open-harness/guide/heartbeats) for configuration detail.
+A single Node process inside the sandbox watches every worktree's `workspace/heartbeats/` directory at once. It discovers roots from `git worktree list --porcelain` (the authoritative registry), spawns each heartbeat with `cwd` inside the correct worktree, and writes per-root logs. A global semaphore (`HEARTBEAT_MAX_CONCURRENT`, default 2) prevents aligned schedules from saturating shared API quotas. See the [Heartbeats guide](/guide/heartbeats) for configuration detail.
 
 ## Workspace Template (`workspace/`)
 

--- a/docs/pages/architecture/structure.mdx
+++ b/docs/pages/architecture/structure.mdx
@@ -75,4 +75,4 @@ The `workspace/` directory contains markdown files that define the agent's ident
 
 `CLAUDE.md` is a symlink to `AGENTS.md` so Claude Code loads operating procedures automatically.
 
-See the [Workspace guide](/open-harness/guide/workspace) for full details on each file and the ownership model. For how multiple agents share one sandbox via git worktrees, see [Orchestrator + Worktrees](/open-harness/architecture/orchestrator-worktrees).
+See the [Workspace guide](/guide/workspace) for full details on each file and the ownership model. For how multiple agents share one sandbox via git worktrees, see [Orchestrator + Worktrees](/architecture/orchestrator-worktrees).

--- a/docs/pages/cli/commands.mdx
+++ b/docs/pages/cli/commands.mdx
@@ -32,7 +32,7 @@ title: "CLI Commands"
 
 ## Exposure commands
 
-Route sandbox apps through a Caddy reverse proxy. See [Exposing apps](/open-harness/guide/exposure) for the full walkthrough.
+Route sandbox apps through a Caddy reverse proxy. See [Exposing apps](/guide/exposure) for the full walkthrough.
 
 | Command | Description |
 |---------|-------------|

--- a/docs/pages/getting-started/installation.mdx
+++ b/docs/pages/getting-started/installation.mdx
@@ -45,4 +45,4 @@ Or [fork the repo](https://github.com/ryaneggz/open-harness/fork) first for your
 
 ## Next step
 
-Once installed, [configure your environment](/open-harness/guide/configuration) or jump straight to the [quickstart](/open-harness/getting-started/quickstart).
+Once installed, [configure your environment](/guide/configuration) or jump straight to the [quickstart](/getting-started/quickstart).

--- a/docs/pages/getting-started/quickstart.mdx
+++ b/docs/pages/getting-started/quickstart.mdx
@@ -12,7 +12,7 @@ git clone https://github.com/ryaneggz/open-harness.git && cd open-harness
 cp .devcontainer/.example.env .devcontainer/.env   # configure name, password, etc.
 ```
 
-See [Configuration](/open-harness/guide/configuration) for all available environment variables.
+See [Configuration](/guide/configuration) for all available environment variables.
 
 ## 2. Start the sandbox
 
@@ -56,7 +56,7 @@ If Docker is running on a remote host, SSH into the host first, then attach to t
 
 Enable the `sshd` overlay and SSH straight into any sandbox on a unique port. This also enables sandbox-to-sandbox communication and CI/CD integration.
 
-See the [Multi-Sandbox SSH guide](/open-harness/guide/multi-sandbox-ssh) for full setup.
+See the [Multi-Sandbox SSH guide](/guide/multi-sandbox-ssh) for full setup.
 
 ## 4. Onboard (one-time)
 
@@ -68,7 +68,7 @@ gh auth setup-git                # git credential helper (no SSH keys needed)
 pi                               # Pi Agent OAuth — powers Slack, heartbeats, extensions
 ```
 
-See [Onboarding](/open-harness/getting-started/onboarding) for the full walkthrough.
+See [Onboarding](/getting-started/onboarding) for the full walkthrough.
 
 ## 5. Start working
 
@@ -87,7 +87,7 @@ Omit `-v` to keep auth volumes (Claude Code, GitHub CLI, Cloudflare tokens) acro
 
 ## Next steps
 
-- [What's installed](/open-harness/getting-started/whats-installed) — full inventory of pre-installed tools
-- [Compose overlays](/open-harness/guide/overlays) — add Postgres, Slack, Docker-in-Docker, SSH
-- [Workspace structure](/open-harness/guide/workspace) — identity files, memory, heartbeats
-- [Permissions & security](/open-harness/guide/permissions) — what agents can and can't do
+- [What's installed](/getting-started/whats-installed) — full inventory of pre-installed tools
+- [Compose overlays](/guide/overlays) — add Postgres, Slack, Docker-in-Docker, SSH
+- [Workspace structure](/guide/workspace) — identity files, memory, heartbeats
+- [Permissions & security](/guide/permissions) — what agents can and can't do

--- a/docs/pages/guide/configuration.mdx
+++ b/docs/pages/guide/configuration.mdx
@@ -22,7 +22,7 @@ The `.example.env` file contains all available variables with comments explainin
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SANDBOX_NAME` | `openharness` | Name used for the Docker container, compose project, and CLI commands (e.g. `openharness shell $SANDBOX_NAME`) |
-| `SANDBOX_PASSWORD` | `changeme` | Password for the `sandbox` Linux user. Only takes effect when the [sshd overlay](/open-harness/guide/overlays#ssh-server-access) is active — used for SSH login. Without the overlay, no password is set. |
+| `SANDBOX_PASSWORD` | `changeme` | Password for the `sandbox` Linux user. Only takes effect when the [sshd overlay](/guide/overlays#ssh-server-access) is active — used for SSH login. Without the overlay, no password is set. |
 
 ### Timezone
 
@@ -32,7 +32,7 @@ The `.example.env` file contains all available variables with comments explainin
 
 ### Heartbeats
 
-Heartbeats are cron-scheduled tasks that run an AI agent CLI inside the sandbox on a recurring schedule (e.g., hourly issue triage). Each heartbeat is a `.md` file in `workspace/heartbeats/` with YAML frontmatter defining its schedule, agent, and active hours. See the [heartbeats guide](/open-harness/guide/heartbeats) for details.
+Heartbeats are cron-scheduled tasks that run an AI agent CLI inside the sandbox on a recurring schedule (e.g., hourly issue triage). Each heartbeat is a `.md` file in `workspace/heartbeats/` with YAML frontmatter defining its schedule, agent, and active hours. See the [heartbeats guide](/guide/heartbeats) for details.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -41,7 +41,7 @@ Heartbeats are cron-scheduled tasks that run an AI agent CLI inside the sandbox 
 
 ### SSH (overlay)
 
-Only applies when an SSH overlay is enabled. See [overlays](/open-harness/guide/overlays#ssh-key-strategy).
+Only applies when an SSH overlay is enabled. See [overlays](/guide/overlays#ssh-key-strategy).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -49,7 +49,7 @@ Only applies when an SSH overlay is enabled. See [overlays](/open-harness/guide/
 
 ### Slack bot (overlay)
 
-Only applies when the `slack.yml` overlay is enabled. The Slack bot (Mom) connects to a Slack workspace via Socket Mode and responds to messages using an AI agent. See [Slack setup](/open-harness/slack/setup).
+Only applies when the `slack.yml` overlay is enabled. The Slack bot (Mom) connects to a Slack workspace via Socket Mode and responds to messages using an AI agent. See [Slack setup](/slack/setup).
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/docs/pages/guide/heartbeats.mdx
+++ b/docs/pages/guide/heartbeats.mdx
@@ -5,7 +5,7 @@ title: "Heartbeats"
 
 Heartbeats are cron-scheduled tasks that let agents wake, perform work, and go back to sleep. Each heartbeat is a `.md` file in `workspace/heartbeats/` with YAML frontmatter defining its schedule, agent, and active hours.
 
-A single heartbeat daemon inside the sandbox watches every worktree's `heartbeats/` directory at once — see [Orchestrator + Worktrees](/open-harness/architecture/orchestrator-worktrees) for the topology.
+A single heartbeat daemon inside the sandbox watches every worktree's `heartbeats/` directory at once — see [Orchestrator + Worktrees](/architecture/orchestrator-worktrees) for the topology.
 
 ## Managing heartbeats
 

--- a/docs/pages/guide/identity.mdx
+++ b/docs/pages/guide/identity.mdx
@@ -25,9 +25,9 @@ Defines the agent's persona and boundaries. The agent may evolve it over time bu
 
 ## MEMORY.md
 
-Curated, durable memory distilled from daily logs. Contains decisions, lessons learned, recurring patterns, and triage history. Symlinked to `.slack/MEMORY.md` so all agent interfaces share the same memory. See [Slack Bot Memory](/open-harness/slack/memory) for how the bot uses these files.
+Curated, durable memory distilled from daily logs. Contains decisions, lessons learned, recurring patterns, and triage history. Symlinked to `.slack/MEMORY.md` so all agent interfaces share the same memory. See [Slack Bot Memory](/slack/memory) for how the bot uses these files.
 
-Memory stores **operational self-awareness** — what the agent learned from doing work. For **structured domain knowledge** extracted from external documents, see the [Wiki](/open-harness/guide/wiki) system instead.
+Memory stores **operational self-awareness** — what the agent learned from doing work. For **structured domain knowledge** extracted from external documents, see the [Wiki](/guide/wiki) system instead.
 
 ## Memory protocol
 

--- a/docs/pages/guide/overlays.mdx
+++ b/docs/pages/guide/overlays.mdx
@@ -17,8 +17,8 @@ Compose overlays in `.devcontainer/` add optional services. Enable them in `.ope
 | `docker-compose.ssh.yml` | Mount host `~/.ssh` read-only |
 | `docker-compose.ssh-generate.yml` | Generate keypair in persistent volume |
 | `docker-compose.sshd.yml` | SSH server daemon (port 2222, password auth) |
-| `docker-compose.slack.yml` | [Slack bot tokens + LLM provider config](/open-harness/slack/setup) |
-| `docker-compose.gateway.yml` | [Caddy reverse-proxy sidecar](/open-harness/guide/exposure) (auto-activated by first `openharness expose`) |
+| `docker-compose.slack.yml` | [Slack bot tokens + LLM provider config](/slack/setup) |
+| `docker-compose.gateway.yml` | [Caddy reverse-proxy sidecar](/guide/exposure) (auto-activated by first `openharness expose`) |
 
 ## Configuration
 

--- a/docs/pages/guide/permissions.mdx
+++ b/docs/pages/guide/permissions.mdx
@@ -71,7 +71,7 @@ When the `sshd` overlay is enabled:
 - Password auth uses `SANDBOX_PASSWORD` from `.env` (default: `changeme`)
 - **Change the default password** for any internet-facing or shared server
 - SSH keys from the host can be forwarded via `ForwardAgent yes` in `~/.ssh/config`
-- See [Multi-Sandbox SSH](/open-harness/guide/multi-sandbox-ssh) for port allocation
+- See [Multi-Sandbox SSH](/guide/multi-sandbox-ssh) for port allocation
 
 ## Recommendations
 

--- a/docs/pages/guide/wiki.mdx
+++ b/docs/pages/guide/wiki.mdx
@@ -3,7 +3,7 @@ title: "Wiki"
 ---
 
 
-The wiki is a persistent, LLM-maintained knowledge base that lives in `workspace/wiki/`. Unlike the [memory system](/open-harness/guide/identity), which tracks operational decisions and lessons learned from doing work, the wiki stores **structured domain knowledge** extracted from external source documents — articles, papers, transcripts, notes.
+The wiki is a persistent, LLM-maintained knowledge base that lives in `workspace/wiki/`. Unlike the [memory system](/guide/identity), which tracks operational decisions and lessons learned from doing work, the wiki stores **structured domain knowledge** extracted from external source documents — articles, papers, transcripts, notes.
 
 The agent incrementally builds and maintains the wiki. You curate sources and ask questions; the agent does the summarizing, cross-referencing, and bookkeeping.
 

--- a/docs/pages/guide/workspace.mdx
+++ b/docs/pages/guide/workspace.mdx
@@ -82,7 +82,7 @@ Logs are append-only. Agents distill durable lessons from them into `MEMORY.md` 
 
 ## Heartbeats
 
-The `heartbeats/` directory contains heartbeat task definitions — markdown files with YAML frontmatter (`schedule`, `agent`, `active` fields). See the [Heartbeats guide](/open-harness/guide/heartbeats) for details.
+The `heartbeats/` directory contains heartbeat task definitions — markdown files with YAML frontmatter (`schedule`, `agent`, `active` fields). See the [Heartbeats guide](/guide/heartbeats) for details.
 
 ## Application code
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -24,8 +24,8 @@ AI coding agents are powerful — but they run with broad system permissions, ex
 
 ## Quick Links
 
-- [Installation](/open-harness/getting-started/installation) — Install the CLI
-- [Quickstart](/open-harness/getting-started/quickstart) — Start a sandbox in 3 steps
-- [CLI Commands](/open-harness/cli/commands) — Full command reference
-- [Compose Overlays](/open-harness/guide/overlays) — Configure optional services
-- [Slack Bot](/open-harness/slack/overview) — Connect agents to Slack
+- [Installation](/getting-started/installation) — Install the CLI
+- [Quickstart](/getting-started/quickstart) — Start a sandbox in 3 steps
+- [CLI Commands](/cli/commands) — Full command reference
+- [Compose Overlays](/guide/overlays) — Configure optional services
+- [Slack Bot](/slack/overview) — Connect agents to Slack

--- a/docs/pages/slack/events.mdx
+++ b/docs/pages/slack/events.mdx
@@ -82,4 +82,4 @@ Example: a periodic event checks for new emails every 15 minutes. If there are n
 
 ## Events vs Heartbeats
 
-> Events and [Heartbeats](/open-harness/guide/heartbeats) are different scheduling systems. Events are Slack-bot-specific -- JSON files that target a Slack channel. Heartbeats are sandbox-level -- cron schedules that invoke an agent CLI on a `.md` file. Use events for Slack-channel tasks; use heartbeats for general sandbox automation.
+> Events and [Heartbeats](/guide/heartbeats) are different scheduling systems. Events are Slack-bot-specific -- JSON files that target a Slack channel. Heartbeats are sandbox-level -- cron schedules that invoke an agent CLI on a `.md` file. Use events for Slack-channel tasks; use heartbeats for general sandbox automation.

--- a/docs/pages/slack/memory.mdx
+++ b/docs/pages/slack/memory.mdx
@@ -21,4 +21,4 @@ The Slack bot uses `MEMORY.md` files to persist context across sessions. Memory 
 
 ## Shared memory
 
-The Slack bot's global `MEMORY.md` is symlinked to the workspace `MEMORY.md`, so all agent interfaces (Claude Code, Codex, Pi Agent) share the same memory. See [Identity & Memory](/open-harness/guide/identity) for details on the broader memory system.
+The Slack bot's global `MEMORY.md` is symlinked to the workspace `MEMORY.md`, so all agent interfaces (Claude Code, Codex, Pi Agent) share the same memory. See [Identity & Memory](/guide/identity) for details on the broader memory system.

--- a/docs/pages/slack/overview.mdx
+++ b/docs/pages/slack/overview.mdx
@@ -31,7 +31,7 @@ flowchart LR
 
 ## Quick links
 
-- [Setup](/open-harness/slack/setup) — Configure your Slack app and connect the bot
-- [How It Works](/open-harness/slack/how-it-works) — Message flow and workspace layout
-- [Events](/open-harness/slack/events) — Schedule tasks and reminders
-- [Security](/open-harness/slack/security) — Prompt injection, isolation, access control
+- [Setup](/slack/setup) — Configure your Slack app and connect the bot
+- [How It Works](/slack/how-it-works) — Message flow and workspace layout
+- [Events](/slack/events) — Schedule tasks and reminders
+- [Security](/slack/security) — Prompt injection, isolation, access control

--- a/docs/pages/slack/setup.mdx
+++ b/docs/pages/slack/setup.mdx
@@ -77,7 +77,7 @@ The Slack overlay is enabled by default. Verify it is listed in `.openharness/co
 }
 ```
 
-See [Compose Overlays](/open-harness/guide/overlays) for the full list of available overlays and how to combine them.
+See [Compose Overlays](/guide/overlays) for the full list of available overlays and how to combine them.
 
 ## Configure the provider
 


### PR DESCRIPTION
Closes #117

Strip `/open-harness/` prefix from 41 internal MDX link refs across 19 docs pages. Next's `basePath` auto-prepends the prefix, so hand-written prefixes produced `/open-harness/open-harness/…` on GitHub Pages.

Verified via `pnpm docs:build` — every internal `href` has a single `/open-harness/` prefix.