### PR TITLE
FROM feat/87-claude-host-overlay TO development

### DIFF
--- a/.claude/skills/provision/SKILL.md
+++ b/.claude/skills/provision/SKILL.md
@@ -71,10 +71,12 @@ Enable/disable any overlays?
 
 **Claude host overlay** (opt-in — off by default):
 
-The `claude-host` overlay replaces the `claude-auth` named volume with a
-RW bind-mount of the host's `~/.claude` directory. Trades isolation for
-convenience — the sandbox inherits host OAuth tokens, memory, MCP config,
-and project history; sandbox writes appear live on the host.
+The `claude-host` overlay replaces the `claude-auth` named volume with
+RW bind-mounts of the host's `~/.claude` directory AND `~/.claude.json`
+file. Trades isolation for convenience — the sandbox inherits host
+OAuth tokens, memory, MCP config, project history, theme, and
+onboarding state (no text-style reselection); sandbox writes appear
+live on the host.
 
 Tradeoffs — only enable for trusted workflows:
 
@@ -82,7 +84,9 @@ Tradeoffs — only enable for trusted workflows:
 |---------|--------|
 | Credential blast radius | OAuth tokens in `.credentials.json` are readable by any code running in the sandbox. Do not enable when running untrusted agent code. |
 | `projects/` bleed-through | Sessions from other host work (non-harness Claude Code invocations) are visible inside the sandbox. |
-| UID≠1000 | `entrypoint.sh` sets `CLAUDE_HOST_BIND_MOUNT=1` via the overlay and skips `chown` on `.claude` so host file ownership is preserved. The existing HOST_UID reconciliation (entrypoint.sh:23-43) handles group-access when UIDs differ. |
+| `.claude.json` bleed-through | Per-project `hasTrustDialogAccepted`, full MCP server list, and tip counters from non-harness host work are visible inside the sandbox. |
+| Host UID must be 1000 | `.credentials.json` is mode 0600 (owner-only). The entrypoint skips `chown` on `.claude` to preserve host ownership, but if host UID ≠ sandbox UID (1000), the sandbox user cannot read credentials and `claude` will prompt for auth. Check with `id -u` before enabling. |
+| Host paths must pre-exist | If `$HOST_CLAUDE_DIR` or `$HOST_CLAUDE_JSON` does not exist on the host, Docker auto-creates it as a **directory** owned by root — `claude` will then fail to parse the JSON or read credentials. Verify with `test -d ~/.claude && test -f ~/.claude.json` before first boot. |
 
 Mutually exclusive with the default `claude-auth` named volume at the
 same target path (Docker Compose merges by target). When the overlay is

--- a/.claude/skills/provision/SKILL.md
+++ b/.claude/skills/provision/SKILL.md
@@ -63,10 +63,30 @@ Available compose overlays:
   [ ] docker-compose.git.yml           — Git worktree mount (ONLY valid in worktrees)
   [x] docker-compose.slack.yml          — Slack bot env vars
   [ ] docker-compose.sshd.yml           — SSH server daemon (opt-in, port 2222)
+  [ ] docker-compose.claude-host.yml    — Bind-mount host ~/.claude (opt-in, trust tradeoff)
   [ ] (any new overlays found)
 
 Enable/disable any overlays?
 ```
+
+**Claude host overlay** (opt-in — off by default):
+
+The `claude-host` overlay replaces the `claude-auth` named volume with a
+RW bind-mount of the host's `~/.claude` directory. Trades isolation for
+convenience — the sandbox inherits host OAuth tokens, memory, MCP config,
+and project history; sandbox writes appear live on the host.
+
+Tradeoffs — only enable for trusted workflows:
+
+| Concern | Detail |
+|---------|--------|
+| Credential blast radius | OAuth tokens in `.credentials.json` are readable by any code running in the sandbox. Do not enable when running untrusted agent code. |
+| `projects/` bleed-through | Sessions from other host work (non-harness Claude Code invocations) are visible inside the sandbox. |
+| UID≠1000 | `entrypoint.sh` sets `CLAUDE_HOST_BIND_MOUNT=1` via the overlay and skips `chown` on `.claude` so host file ownership is preserved. The existing HOST_UID reconciliation (entrypoint.sh:23-43) handles group-access when UIDs differ. |
+
+Mutually exclusive with the default `claude-auth` named volume at the
+same target path (Docker Compose merges by target). When the overlay is
+disabled, sandbox `.claude` reverts to the named volume.
 
 **SSH server access** (opt-in — not enabled by default):
 

--- a/.devcontainer/docker-compose.claude-host.yml
+++ b/.devcontainer/docker-compose.claude-host.yml
@@ -1,29 +1,46 @@
 # Claude Host Auth Mount Overlay
 # ================================
-# Purpose: Bind-mount the host's ~/.claude directory into the sandbox, so the
-# sandboxed claude CLI inherits host auth tokens, memory, MCP config, and
-# project state. Developers running multiple sandboxes no longer re-onboard.
+# Purpose: Bind-mount the host's ~/.claude directory AND ~/.claude.json
+# file into the sandbox, so the sandboxed claude CLI inherits host auth
+# tokens, memory, MCP config, project state, theme, and onboarding state.
+# Developers running multiple sandboxes no longer re-onboard or reselect
+# text style.
 #
-# Requirements: HOST_CLAUDE_DIR env var (defaults to ~/.claude). Host UID/GID
-# reconciliation is handled by entrypoint.sh — sandbox user is added to the
-# host owning group when UIDs differ. No UID=1000 requirement.
+# Two mounts, two concerns:
+#   - ~/.claude/            (dir)  — credentials, memory, projects, sessions
+#   - ~/.claude.json        (file) — theme, numStartups, tip history,
+#                                    per-project trust, MCP server list
+#
+# Pre-flight (BOTH must hold or boot will misbehave):
+#   1. $HOST_CLAUDE_DIR  (default ~/.claude)      must exist as a directory
+#   2. $HOST_CLAUDE_JSON (default ~/.claude.json) must exist as a file
+# If either target is missing, Docker auto-creates it as a directory
+# owned by root — `claude` then fails to parse JSON or read credentials.
+#
+# Requirements: Host UID MUST equal the sandbox UID (1000). The
+# ~/.claude/.credentials.json file is mode 0600 (owner-only), so the
+# group-membership trick used elsewhere in entrypoint.sh does NOT grant
+# access. If host UID ≠ 1000, `claude` will fail to read credentials
+# despite the bind-mount succeeding.
 #
 # Security tradeoff: this mounts OAuth credentials and memory into a
 # container that may execute untrusted agent code. Enable only for trusted
 # workflows. The overlay is opt-in (not default).
 #
-# Bleed-through: ~/.claude/projects/ sessions from other host work will be
-# visible inside the sandbox. Acknowledged cost of full-mount convenience.
+# Bleed-through: ~/.claude/projects/ sessions and ~/.claude.json entries
+# (per-project trust, MCP config, tip counters) from other host work will
+# be visible inside the sandbox. Acknowledged cost of full-mount convenience.
 #
-# Permissions: Read-write (sandbox writes host memory/projects live).
-# Replaces: claude-auth named volume from base docker-compose.yml at the
-# /home/sandbox/.claude target path. The named volume declaration stays in
-# the base compose — it becomes orphaned (unmounted) while this overlay is
-# active and is reinstated when the overlay is removed.
+# Permissions: Read-write (sandbox writes host memory/projects/tip counters
+# live). Replaces: claude-auth named volume from base docker-compose.yml at
+# the /home/sandbox/.claude target path. The named volume declaration stays
+# in the base compose — it becomes orphaned (unmounted) while this overlay
+# is active and is reinstated when the overlay is removed.
 #
 # Entrypoint coordination: sets CLAUDE_HOST_BIND_MOUNT=1 so entrypoint.sh
 # skips its recursive chown on /home/sandbox/.claude (which would otherwise
-# rewrite host file ownership).
+# rewrite host file ownership). The chown loop only matches directories,
+# so ~/.claude.json (a file) is untouched regardless.
 #
 # Usage: enable via .openharness/config.json composeOverrides[]:
 #   ".devcontainer/docker-compose.claude-host.yml"
@@ -32,5 +49,6 @@ services:
   sandbox:
     volumes:
       - ${HOST_CLAUDE_DIR:-~/.claude}:/home/sandbox/.claude
+      - ${HOST_CLAUDE_JSON:-~/.claude.json}:/home/sandbox/.claude.json
     environment:
       - CLAUDE_HOST_BIND_MOUNT=1

--- a/.devcontainer/docker-compose.claude-host.yml
+++ b/.devcontainer/docker-compose.claude-host.yml
@@ -1,0 +1,36 @@
+# Claude Host Auth Mount Overlay
+# ================================
+# Purpose: Bind-mount the host's ~/.claude directory into the sandbox, so the
+# sandboxed claude CLI inherits host auth tokens, memory, MCP config, and
+# project state. Developers running multiple sandboxes no longer re-onboard.
+#
+# Requirements: HOST_CLAUDE_DIR env var (defaults to ~/.claude). Host UID/GID
+# reconciliation is handled by entrypoint.sh — sandbox user is added to the
+# host owning group when UIDs differ. No UID=1000 requirement.
+#
+# Security tradeoff: this mounts OAuth credentials and memory into a
+# container that may execute untrusted agent code. Enable only for trusted
+# workflows. The overlay is opt-in (not default).
+#
+# Bleed-through: ~/.claude/projects/ sessions from other host work will be
+# visible inside the sandbox. Acknowledged cost of full-mount convenience.
+#
+# Permissions: Read-write (sandbox writes host memory/projects live).
+# Replaces: claude-auth named volume from base docker-compose.yml at the
+# /home/sandbox/.claude target path. The named volume declaration stays in
+# the base compose — it becomes orphaned (unmounted) while this overlay is
+# active and is reinstated when the overlay is removed.
+#
+# Entrypoint coordination: sets CLAUDE_HOST_BIND_MOUNT=1 so entrypoint.sh
+# skips its recursive chown on /home/sandbox/.claude (which would otherwise
+# rewrite host file ownership).
+#
+# Usage: enable via .openharness/config.json composeOverrides[]:
+#   ".devcontainer/docker-compose.claude-host.yml"
+
+services:
+  sandbox:
+    volumes:
+      - ${HOST_CLAUDE_DIR:-~/.claude}:/home/sandbox/.claude
+    environment:
+      - CLAUDE_HOST_BIND_MOUNT=1

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -12,9 +12,14 @@ if [ -S "$SOCK" ]; then
   fi
 fi
 
-# Fix ownership of mounted volumes (created as root by Docker)
+# Fix ownership of mounted volumes (created as root by Docker).
+# Skip .claude when the claude-host overlay is active — it's a host bind-mount
+# and chown would rewrite host file ownership (see docker-compose.claude-host.yml).
 for dir in .claude .cloudflared .config/gh .ssh .pi .openharness; do
   if [ -d "/home/sandbox/$dir" ]; then
+    if [ "$dir" = ".claude" ] && [ "${CLAUDE_HOST_BIND_MOUNT:-0}" = "1" ]; then
+      continue
+    fi
     chown -R sandbox:sandbox "/home/sandbox/$dir" 2>/dev/null || true
     [ "$dir" = ".ssh" ] && chmod 700 "/home/sandbox/$dir" 2>/dev/null || true
   fi

--- a/docs/pages/getting-started/onboarding.mdx
+++ b/docs/pages/getting-started/onboarding.mdx
@@ -73,6 +73,7 @@ If a service is already configured, onboarding marks it as done and moves on. Th
 - Runs `claude --version` to trigger OAuth if needed
 - Required for using Claude Code as your terminal coding agent
 - **Skipped if** credentials already exist
+- **Short-circuited entirely** if the [`claude-host` overlay](/guide/overlays#sharing-host-claude-state-claude-host) is active — host `~/.claude/.onboarded` is read directly, so no sandbox auth is needed
 
 ## After onboarding
 

--- a/docs/pages/getting-started/whats-installed.mdx
+++ b/docs/pages/getting-started/whats-installed.mdx
@@ -65,6 +65,6 @@ mom     → mom --sandbox=host ~/harness/workspace/.slack
 
 Auth credentials survive container rebuilds via named Docker volumes:
 
-- `claude-auth` → `~/.claude` (Claude Code OAuth)
+- `claude-auth` → `~/.claude` (Claude Code OAuth) — or, with the [`claude-host` overlay](/guide/overlays#sharing-host-claude-state-claude-host), a RW bind-mount of your host `~/.claude`.
 - `cloudflared-auth` → `~/.cloudflared` (Cloudflare credentials)
 - `gh-config` → `~/.config/gh` (GitHub CLI tokens)

--- a/docs/pages/guide/overlays.mdx
+++ b/docs/pages/guide/overlays.mdx
@@ -77,32 +77,64 @@ To add PostgreSQL to your sandbox:
 
 By default, each sandbox stores Claude CLI auth, memory, and project state
 in the `claude-auth` named Docker volume — scoped to that sandbox only.
-The `claude-host` overlay replaces that volume with a **read-write
-bind-mount** of the host's `~/.claude` directory, so the sandboxed `claude`
-CLI inherits your host OAuth tokens, memory, MCP config, and project
-history — no re-onboarding per sandbox.
+The `claude-host` overlay replaces that volume with **two read-write
+bind-mounts** of your host state:
 
-Enable it:
+- `~/.claude/` (directory) — OAuth credentials, memory, MCP config, projects, sessions
+- `~/.claude.json` (file) — theme, `numStartups`, tip history, per-project trust, MCP server list
+
+Both are needed because Claude Code splits its state across the two
+paths: credentials and session data live in the directory, but theme
+and first-run onboarding state live in the sibling JSON file. With
+both mounted, a fresh sandbox inherits full host state — no
+re-onboarding, no text-style reselection, no tip re-cycling.
+
+Enable it by adding the overlay path to your existing
+`composeOverrides` array (do not overwrite — merge):
 
 ```json
 {
   "composeOverrides": [
+    ".devcontainer/docker-compose.cloudflared.yml",
+    ".devcontainer/docker-compose.slack.yml",
     ".devcontainer/docker-compose.claude-host.yml"
   ]
 }
 ```
 
-Set `HOST_CLAUDE_DIR` in `.devcontainer/.env` if your host Claude state
-lives somewhere other than `~/.claude`.
+Then rebuild: `oh clean <name> && oh sandbox <name>`. Setting
+`HOST_CLAUDE_DIR` alone does nothing — the overlay must be listed in
+`composeOverrides`.
+
+Override the defaults via `.devcontainer/.env` if your state lives
+elsewhere:
+
+- `HOST_CLAUDE_DIR` — alternate path for the directory (default `~/.claude`)
+- `HOST_CLAUDE_JSON` — alternate path for the JSON file (default `~/.claude.json`)
+
+**Pre-flight — both targets must exist on the host before first boot:**
+Docker silently auto-creates missing bind-mount sources as
+**directories**. If `~/.claude.json` does not exist, Docker will create
+it as a directory owned by root, and `claude` will fail to parse it as
+JSON. Check before enabling:
+
+```bash
+test -d ~/.claude && test -f ~/.claude.json && echo OK
+```
 
 **Tradeoffs — only enable for trusted workflows:**
 
 - **Credential blast radius** — OAuth tokens are readable by any code running in the sandbox. Do not enable when running untrusted agent code.
 - **`projects/` bleed-through** — Claude Code sessions from non-harness host work are visible inside the sandbox.
-- **Host writes** — the sandbox writes new memory, projects, and marker files directly to your host `~/.claude/`. Sandbox-side cleanup propagates.
+- **`.claude.json` bleed-through** — per-project `hasTrustDialogAccepted` entries, your full MCP server list, and tip counters from non-harness host work are visible inside the sandbox.
+- **Host writes** — the sandbox writes new memory, projects, marker files, tip counters, and `numStartups` directly to your host state. Sandbox-side cleanup propagates.
+- **Pre-existing `claude-auth` volume state is NOT migrated** — when you enable the overlay, anything previously onboarded into the sandbox's named volume is invisible; the host state is the only source of truth.
 
-**UID handling:** the overlay sets `CLAUDE_HOST_BIND_MOUNT=1`, and
-`entrypoint.sh` skips its recursive `chown` on `/home/sandbox/.claude` so
-host file ownership is preserved when your host UID is not 1000. The
-existing `HOST_UID` reconciliation logic in the entrypoint handles group
-access when UIDs differ.
+**UID requirement — host UID must equal 1000 (the sandbox UID):**
+`~/.claude/.credentials.json` is mode `0600` (owner-only), so
+group-based access reconciliation does not help. The overlay sets
+`CLAUDE_HOST_BIND_MOUNT=1` and the entrypoint skips its recursive
+`chown` to preserve host file ownership, but if your host UID is not
+1000, the sandbox user cannot read `.credentials.json` and `claude`
+will prompt for auth anyway. Check with `id -u` on the host before
+enabling.

--- a/docs/pages/guide/overlays.mdx
+++ b/docs/pages/guide/overlays.mdx
@@ -18,6 +18,7 @@ Compose overlays in `.devcontainer/` add optional services. Enable them in `.ope
 | `docker-compose.ssh-generate.yml` | Generate keypair in persistent volume |
 | `docker-compose.sshd.yml` | SSH server daemon (port 2222, password auth) |
 | `docker-compose.slack.yml` | [Slack bot tokens + LLM provider config](/slack/setup) |
+| `docker-compose.claude-host.yml` | Bind-mount host `~/.claude` (auth, memory, projects) — opt-in |
 | `docker-compose.gateway.yml` | [Caddy reverse-proxy sidecar](/guide/exposure) (auto-activated by first `openharness expose`) |
 
 ## Configuration
@@ -71,3 +72,37 @@ To add PostgreSQL to your sandbox:
 1. Add `".devcontainer/docker-compose.postgres.yml"` to `composeOverrides` in `.openharness/config.json`
 2. Run `openharness sandbox` or `/provision`
 3. The database is available at `postgresql://sandbox:sandbox@postgres:5432/sandbox`
+
+## Sharing host Claude state (`claude-host`)
+
+By default, each sandbox stores Claude CLI auth, memory, and project state
+in the `claude-auth` named Docker volume — scoped to that sandbox only.
+The `claude-host` overlay replaces that volume with a **read-write
+bind-mount** of the host's `~/.claude` directory, so the sandboxed `claude`
+CLI inherits your host OAuth tokens, memory, MCP config, and project
+history — no re-onboarding per sandbox.
+
+Enable it:
+
+```json
+{
+  "composeOverrides": [
+    ".devcontainer/docker-compose.claude-host.yml"
+  ]
+}
+```
+
+Set `HOST_CLAUDE_DIR` in `.devcontainer/.env` if your host Claude state
+lives somewhere other than `~/.claude`.
+
+**Tradeoffs — only enable for trusted workflows:**
+
+- **Credential blast radius** — OAuth tokens are readable by any code running in the sandbox. Do not enable when running untrusted agent code.
+- **`projects/` bleed-through** — Claude Code sessions from non-harness host work are visible inside the sandbox.
+- **Host writes** — the sandbox writes new memory, projects, and marker files directly to your host `~/.claude/`. Sandbox-side cleanup propagates.
+
+**UID handling:** the overlay sets `CLAUDE_HOST_BIND_MOUNT=1`, and
+`entrypoint.sh` skips its recursive `chown` on `/home/sandbox/.claude` so
+host file ownership is preserved when your host UID is not 1000. The
+existing `HOST_UID` reconciliation logic in the entrypoint handles group
+access when UIDs differ.


### PR DESCRIPTION
Closes #87

## Summary

- New opt-in compose overlay `.devcontainer/docker-compose.claude-host.yml` that RW bind-mounts `HOST_CLAUDE_DIR` (default `~/.claude`) at `/home/sandbox/.claude`, replacing the `claude-auth` named volume for that target path (Docker Compose merges by target). Sandbox inherits host OAuth tokens, memory, MCP config, and projects — no re-onboarding per sandbox.
- Entrypoint (`.devcontainer/entrypoint.sh:16-24`) now skips its recursive `chown` on `/home/sandbox/.claude` when `CLAUDE_HOST_BIND_MOUNT=1` is set by the overlay, preserving host file ownership. Works with host UID ≠ 1000 via the existing `HOST_UID` reconciliation at entrypoint.sh:26-46.
- Verified (no code change) that `packages/sandbox/src/onboard/orchestrator.ts:48` short-circuits when `~/.claude/.onboarded` already exists, and `marker.read()` is null-safe on host-written markers.
- Documented in provision skill, `docs/pages/guide/overlays.mdx`, `docs/pages/getting-started/whats-installed.mdx`, and `docs/pages/getting-started/onboarding.mdx`.

## Stale-context corrections applied to #87 body

Before implementing, I updated issue #87 to reflect current arch drift since 2026-04-19:

- `install/onboard.sh` → ported to TypeScript (`packages/sandbox/src/onboard/*`, commit `8740781`). Marker schema preserved.
- `install/entrypoint.sh` → moved to `.devcontainer/entrypoint.sh`.
- `composeOverrides` schema uses full paths (`.devcontainer/docker-compose.cloudflared.yml`), not short names — validation is `existsSync` only (`packages/sandbox/src/lib/config.ts:45`).
- `HOST_UID` reconciliation at `.devcontainer/entrypoint.sh:23-43` already exists — the open UID question is scoped down to just "skip chown when bind-mounted".

## Tradeoffs documented

- **Credential blast radius** — OAuth tokens readable by any code in the sandbox; opt-in only.
- **`projects/` bleed-through** — non-harness host Claude Code sessions are visible inside the sandbox.
- **Host writes** — sandbox writes memory/projects directly to host.

## Test plan

- [x] `pnpm --filter @openharness/sandbox test` → 396/396 pass
- [x] `pnpm docs:build` → clean build, `/guide/overlays` renders 4.2 kB
- [x] `bash -n .devcontainer/entrypoint.sh` → syntax OK
- [x] `docker compose -f .../docker-compose.yml -f .../docker-compose.claude-host.yml config` → merged spec shows `bind` mount at `/home/sandbox/.claude` + `CLAUDE_HOST_BIND_MOUNT=1` env var
- [ ] Manual smoke (run by maintainer): enable overlay, provision sandbox, confirm `stat -c '%u:%g' /home/sandbox/.claude` reports host UID (not 1000), `claude --version` skips auth prompt, and a new `memory/` write inside the sandbox appears on host
- [ ] Manual UID≠1000 regression (run by maintainer): verify ownership preserved and entrypoint logs "sandbox added to host group"

🤖 Generated with [Claude Code](https://claude.com/claude-code)