### PR TITLE
FROM feat/130-deepagents-cli-optional TO development

### DIFF
--- a/.devcontainer/.example.env
+++ b/.devcontainer/.example.env
@@ -48,6 +48,36 @@ HEARTBEAT_AGENT=claude
 # Disabled by default — only enable if you need headless browser automation.
 INSTALL_AGENT_BROWSER=true
 
+# ─── Deep Agents CLI (optional) ─────────────────────────────────────
+# Set to true to install LangChain's deepagents-cli on container startup.
+# Disabled by default. Installs via `uv tool install deepagents-cli` on
+# first boot; binary lands at /usr/local/bin/deepagents. Auth is via
+# provider API keys (see the next section) — no OAuth step.
+# See: https://github.com/langchain-ai/deepagents
+# INSTALL_DEEPAGENTS_CLI=true
+
+# ─── Provider API Keys ─────────────────────────────────────────────
+# The default coding agents — claude, codex, pi — authenticate via
+# OAuth subscriptions on first run. Log in once with `claude`, `codex`,
+# or `pi` and the host bind-mounts (~/.claude, ~/.codex, ~/.pi)
+# persist the session across container rebuilds. No API keys required.
+#
+# Raw provider API keys below are for tools that DON'T use OAuth —
+# primarily deepagents-cli, and any custom scripts that call a
+# provider SDK directly. Uncomment and fill in only what you need.
+
+# Anthropic (Claude models via API)
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI (GPT models via API)
+# OPENAI_API_KEY=sk-...
+
+# Google (Gemini via API)
+# GOOGLE_API_KEY=...
+
+# Groq
+# GROQ_API_KEY=...
+
 # ─── Slack bot (only with slack.yml overlay) ─────────────────────────
 # The Slack bot (Mom) connects to a Slack workspace and responds to
 # messages using an AI agent. Requires a Slack app with Socket Mode.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,6 +18,10 @@
 #   - GIT_USER_NAME, GIT_USER_EMAIL: Git commit author
 #   - GH_TOKEN: GitHub token for `gh auth` automation
 #   - INSTALL_AGENT_BROWSER: Set to "true" to install Chromium (opt-in)
+#   - INSTALL_DEEPAGENTS_CLI: Set to "true" to install deepagents-cli (opt-in)
+#   - ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY / GROQ_API_KEY:
+#     Provider API keys — used by deepagents-cli and any direct-SDK scripts.
+#     claude / codex / pi use OAuth subscriptions and do NOT need these.
 #   - SANDBOX_PASSWORD: SSH password if using docker-compose.sshd.yml
 #
 # Entrypoint: /usr/local/bin/entrypoint.sh — Initializes git config, installs tools, runs onboarding
@@ -62,6 +66,11 @@ services:
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GH_TOKEN=${GH_TOKEN:-}
       - INSTALL_AGENT_BROWSER=${INSTALL_AGENT_BROWSER:-false}
+      - INSTALL_DEEPAGENTS_CLI=${INSTALL_DEEPAGENTS_CLI:-false}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
     stdin_open: true
     tty: true
     init: true

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -261,6 +261,19 @@ if [ "${INSTALL_AGENT_BROWSER:-false}" = "true" ] && ! command -v agent-browser 
     || echo "[entrypoint] agent-browser install failed — skipping"
 fi
 
+# ─── Optional: deepagents-cli (opt-in via INSTALL_DEEPAGENTS_CLI=true) ──
+# LangChain's deepagents-cli (PyPI: deepagents-cli, binary: deepagents).
+# Installed via `uv tool install`; UV_TOOL_BIN_DIR=/usr/local/bin puts the
+# launcher on PATH for the sandbox user without further plumbing. uv
+# fetches Python 3.13 on demand. Idempotent via the command -v guard.
+if [ "${INSTALL_DEEPAGENTS_CLI:-false}" = "true" ] && ! command -v deepagents &>/dev/null; then
+  echo "[entrypoint] Installing deepagents-cli (INSTALL_DEEPAGENTS_CLI=true)..."
+  UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/usr/local/share/uv-tools \
+    uv tool install --python 3.13 deepagents-cli 2>&1 | tail -5 \
+    && echo "[entrypoint] deepagents-cli installed" \
+    || echo "[entrypoint] deepagents-cli install failed — skipping"
+fi
+
 # Run workspace startup (dev server + tunnel) as sandbox user
 STARTUP="/home/sandbox/harness/workspace/startup.sh"
 if [ -f "$STARTUP" ]; then

--- a/workspace/TOOLS.md
+++ b/workspace/TOOLS.md
@@ -24,13 +24,12 @@
 
 ### Optional Agents
 
-| Agent | Command | Notes |
-|-------|---------|-------|
-| Claude Code | `claude` | Installed by default |
-| OpenAI Codex | `codex` | Installed by default |
-| Pi Agent | `pi` | Installed by default |
-| Deep Agents | `deepagents` | Opt-in via `INSTALL_DEEPAGENTS_CLI=true` |
-| AgentMail | `agentmail` | Opt-in via setup.sh |
+| Agent | Command |
+|-------|---------|
+| Claude Code | `claude` |
+| OpenAI Codex | `codex` |
+| Pi Agent | `pi` |
+| AgentMail | `agentmail` |
 
 ## Principles
 

--- a/workspace/TOOLS.md
+++ b/workspace/TOOLS.md
@@ -24,12 +24,13 @@
 
 ### Optional Agents
 
-| Agent | Command |
-|-------|---------|
-| Claude Code | `claude` |
-| OpenAI Codex | `codex` |
-| Pi Agent | `pi` |
-| AgentMail | `agentmail` |
+| Agent | Command | Notes |
+|-------|---------|-------|
+| Claude Code | `claude` | Installed by default |
+| OpenAI Codex | `codex` | Installed by default |
+| Pi Agent | `pi` | Installed by default |
+| Deep Agents | `deepagents` | Opt-in via `INSTALL_DEEPAGENTS_CLI=true` |
+| AgentMail | `agentmail` | Opt-in via setup.sh |
 
 ## Principles
 


### PR DESCRIPTION
## Summary

- Adds LangChain's [deepagents-cli](https://github.com/langchain-ai/deepagents) as an opt-in sandbox agent, off by default, using the same entrypoint-time pattern as `INSTALL_AGENT_BROWSER`.
- Documents a new "Provider API Keys" section in `.devcontainer/.example.env` that frames raw API keys as the exception — `claude` / `codex` / `pi` continue to authenticate via OAuth subscriptions on first run.
- Wires common provider keys through `docker-compose.yml` so values set locally reach the container.

## Changes

| File | Change |
|------|--------|
| `.devcontainer/docker-compose.yml` | Pass `INSTALL_DEEPAGENTS_CLI` + provider API-key env vars (all empty defaults) |
| `.devcontainer/.example.env` | New Deep Agents CLI toggle + Provider API Keys section (all commented out) |
| `.devcontainer/entrypoint.sh` | Opt-in `uv tool install --python 3.13 deepagents-cli` with `command -v` idempotency guard |
| `workspace/TOOLS.md` | Optional Agents table updated with opt-in notes |

## Test plan

- [ ] Default sandbox build still boots with no new tooling installed.
- [ ] Setting `INSTALL_DEEPAGENTS_CLI=true` in `.devcontainer/.env` causes `deepagents` to install on next boot; binary resolves from `/usr/local/bin/deepagents`.
- [ ] Re-booting with the toggle still on skips the install (idempotent via `command -v deepagents`).
- [ ] Provider key env vars set locally are visible to processes inside the container.

Closes #130
