### PR TITLE
FROM task/143-blog-scaffold TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- Blog section at /blog and About page nav entry (#143).
 - Root `CHANGELOG.md` and Keep-a-Changelog workflow documented in `.claude/rules/git.md`; `/release` now promotes `[Unreleased]` to the new version section at tag time.
 
 ### Changed

--- a/docs/pages/_meta.js
+++ b/docs/pages/_meta.js
@@ -6,4 +6,6 @@ export default {
   cli: "CLI Reference",
   architecture: "Architecture",
   wiki: "Wiki",
+  about: "About",
+  blog: "Blog",
 };

--- a/docs/pages/about.mdx
+++ b/docs/pages/about.mdx
@@ -1,0 +1,7 @@
+---
+title: "About"
+---
+
+# About
+
+{/* Content for this page is being drafted — see issue #138. */}

--- a/docs/pages/blog/_meta.js
+++ b/docs/pages/blog/_meta.js
@@ -1,0 +1,6 @@
+export default {
+  index: "Blog",
+  // Future posts — add slugs here as they ship, newest first:
+  // "worktree-per-agent": "One Worktree Per Agent",
+  // "byoh": "Bring Your Own Harness",
+};

--- a/docs/pages/blog/index.mdx
+++ b/docs/pages/blog/index.mdx
@@ -1,0 +1,14 @@
+---
+title: "Blog"
+---
+
+# Blog
+
+Engineering notes, release walkthroughs, and deep-dives from the Open Harness team.
+
+First posts shipping Tuesday — subscribe via RSS or follow the repo for updates.
+
+{/* TODO: As posts land, add links here, newest first. Example:
+- [One Worktree Per Agent](/blog/worktree-per-agent) — 2026-04-29
+- [Bring Your Own Harness](/blog/byoh) — 2026-04-29
+*/}


### PR DESCRIPTION
## Summary
- Scaffolds `docs/pages/blog/` with `_meta.js` and `index.mdx` landing page (placeholder content, ready for posts)
- Adds both `about` and `blog` entries to `docs/pages/_meta.js` top nav
- Creates stub `docs/pages/about.mdx` so Nextra `_meta` validation passes until #138 lands its content

## Test plan
- [x] `pnpm build` inside `docs/` passes cleanly (396 sandbox tests pass, 42 static pages rendered including `/blog`)
- [ ] Verify `/blog` route renders after merge and deploy to GitHub Pages
- [ ] Verify `about` nav entry links correctly once #138 merges

Closes #143