### PR TITLE
FROM task/140-og-and-theme TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- Per-page OpenGraph + canonical link tags via theme.config.tsx head function ([#140](https://github.com/ryaneggz/open-harness/issues/140)).
 - Root `CHANGELOG.md` and Keep-a-Changelog workflow documented in `.claude/rules/git.md`; `/release` now promotes `[Unreleased]` to the new version section at tag time.
 
 ### Changed

--- a/docs/public/og-card.SPEC.md
+++ b/docs/public/og-card.SPEC.md
@@ -1,0 +1,46 @@
+# OG Card Design Spec — `og-card.png`
+
+**Output path**: `docs/public/og-card.png`
+**Consumed by**: `theme.config.tsx` head function as `https://oh.mifune.dev/og-card.png`
+
+## Dimensions
+
+1200 × 630 px (2× retina export: 2400 × 1260 px, downscaled to 1200 × 630 on delivery)
+
+## Required Elements
+
+1. **Wordmark** — "Open Harness" in the primary display font, left-aligned, large (≥ 72 px equivalent)
+2. **One-liner** — "AI Agent Sandbox Orchestrator" in a lighter weight directly below the wordmark
+3. **Agent icons or wordmarks** — small horizontal row of logos: Claude, Codex, Pi Agent (or generic robot silhouettes if trademarks are a concern); bottom-left quadrant
+4. **Footer URL** — `oh.mifune.dev` in small monospace, bottom-right corner
+5. **Subtle grid or dot pattern** — low-opacity background texture (optional but preferred)
+
+## Color Palette
+
+| Role | Value | Notes |
+|------|-------|-------|
+| Background | `#0a0a0a` | Near-black; reads well on X dark mode |
+| Primary text | `#ffffff` | Wordmark and one-liner |
+| Accent | `#6ee7b7` (emerald-300) or `#38bdf8` (sky-400) | One-liner or underline accent; pick one |
+| Secondary text | `#71717a` (zinc-500) | Footer URL, agent label captions |
+| Border / divider | `#27272a` (zinc-800) | Optional 1 px bottom rule under wordmark |
+
+Aesthetic reference: Vercel, Linear, and Plausible OG cards — clean, minimal, dark, developer-tool.
+
+## Trademark / Imagery Hygiene
+
+- **No Matrix imagery** (falling green characters, Neo silhouette, pill motifs). These are Warner Bros. trademarks and create brand confusion.
+- Do not use the Anthropic "Claude" logo without checking current brand guidelines; a generic robot icon is a safe fallback.
+- "Open Harness" and "oh.mifune.dev" are safe to feature prominently.
+
+## Reference Inspirations
+
+- Vercel OG: https://vercel.com/og-image (dark, wordmark + tagline, minimal)
+- Linear OG: https://linear.app (icon + product name, bold type)
+- Plausible OG: https://plausible.io (clean stats, dark bg, accent color)
+
+## Delivery
+
+Drop the final PNG at `docs/public/og-card.png` and commit.
+Twitter Card Validator: https://cards-dev.twitter.com/validator
+LinkedIn Post Inspector: https://www.linkedin.com/post-inspector/

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -1,5 +1,12 @@
 import React from "react";
+import { useRouter } from "next/router";
+import { useConfig } from "nextra-theme-docs";
 import type { DocsThemeConfig } from "nextra-theme-docs";
+
+const SITE_URL = "https://oh.mifune.dev";
+const DEFAULT_TITLE = "Open Harness";
+const DEFAULT_DESCRIPTION = "AI Agent Sandbox Orchestrator";
+const DEFAULT_OG_IMAGE = `${SITE_URL}/og-card.png`;
 
 const config: DocsThemeConfig = {
   logo: <strong>Open Harness</strong>,
@@ -11,16 +18,63 @@ const config: DocsThemeConfig = {
   footer: {
     content: "Open Harness — AI Agent Sandbox Orchestrator",
   },
-  head: (
-    <>
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <meta property="og:title" content="Open Harness" />
-      <meta
-        property="og:description"
-        content="AI Agent Sandbox Orchestrator"
-      />
-    </>
-  ),
+  head: function Head() {
+    const { asPath } = useRouter();
+    const { frontMatter } = useConfig();
+
+    const title = (frontMatter.title as string | undefined) ?? DEFAULT_TITLE;
+    const description =
+      (frontMatter.description as string | undefined) ?? DEFAULT_DESCRIPTION;
+
+    // Resolve ogImage: if frontMatter provides a relative path, make it absolute.
+    const rawOgImage =
+      (frontMatter.ogImage as string | undefined) ?? DEFAULT_OG_IMAGE;
+    const ogImage = rawOgImage.startsWith("http")
+      ? rawOgImage
+      : `${SITE_URL}${rawOgImage.startsWith("/") ? "" : "/"}${rawOgImage}`;
+
+    // Strip trailing slash from asPath for canonical (Nextra emits trailingSlash pages,
+    // but the canonical should be the canonical URL without the slash, matching the domain root style).
+    const canonicalPath = asPath === "/" ? "" : asPath.replace(/\/$/, "");
+    const canonicalUrl = `${SITE_URL}${canonicalPath}`;
+
+    const isBlogPost =
+      asPath.startsWith("/blog/") && asPath !== "/blog/" && asPath !== "/blog";
+
+    return (
+      <>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+        {/* Canonical */}
+        <link rel="canonical" href={canonicalUrl} />
+
+        {/* Open Graph — base */}
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:image" content={ogImage} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta
+          property="og:type"
+          content={isBlogPost ? "article" : "website"}
+        />
+        <meta property="og:site_name" content={DEFAULT_TITLE} />
+
+        {/* Open Graph — article-specific */}
+        {isBlogPost && frontMatter.date && (
+          <meta
+            property="article:published_time"
+            content={frontMatter.date as string}
+          />
+        )}
+
+        {/* Twitter Card */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={ogImage} />
+      </>
+    );
+  },
 };
 
 export default config;


### PR DESCRIPTION
Closes #140

## Summary
- Added `docs/public/og-card.SPEC.md`: design brief for the OG card PNG (1200×630, required elements, color palette, no Matrix imagery note, reference inspirations).
- Rewrote `docs/theme.config.tsx` `head` as a React function component using `useConfig()` → `frontMatter` and `useRouter()` → `asPath` to emit per-page meta tags.
- Added `CHANGELOG.md` entry under `## [Unreleased] ### Added`.

## New `head` function (for review)

```tsx
head: function Head() {
  const { asPath } = useRouter();
  const { frontMatter } = useConfig();

  const title = (frontMatter.title as string | undefined) ?? DEFAULT_TITLE;
  const description = (frontMatter.description as string | undefined) ?? DEFAULT_DESCRIPTION;

  const rawOgImage = (frontMatter.ogImage as string | undefined) ?? DEFAULT_OG_IMAGE;
  const ogImage = rawOgImage.startsWith("http")
    ? rawOgImage
    : `${SITE_URL}${rawOgImage.startsWith("/") ? "" : "/"}${rawOgImage}`;

  const canonicalPath = asPath === "/" ? "" : asPath.replace(/\/$/, "");
  const canonicalUrl = `${SITE_URL}${canonicalPath}`;

  const isBlogPost = asPath.startsWith("/blog/") && asPath !== "/blog/" && asPath !== "/blog";

  return (
    <>
      <meta name="viewport" content="width=device-width, initial-scale=1" />
      <link rel="canonical" href={canonicalUrl} />
      <meta property="og:title" content={title} />
      <meta property="og:description" content={description} />
      <meta property="og:image" content={ogImage} />
      <meta property="og:url" content={canonicalUrl} />
      <meta property="og:type" content={isBlogPost ? "article" : "website"} />
      <meta property="og:site_name" content={DEFAULT_TITLE} />
      {isBlogPost && frontMatter.date && (
        <meta property="article:published_time" content={frontMatter.date as string} />
      )}
      <meta name="twitter:card" content="summary_large_image" />
      <meta name="twitter:title" content={title} />
      <meta name="twitter:description" content={description} />
      <meta name="twitter:image" content={ogImage} />
    </>
  );
},
```

## Build status

`cd docs && pnpm build` completed successfully — 40 static pages generated, 0 errors.

## Maintainer follow-up

- [ ] Drop the real `og-card.png` (1200×630 px) into `docs/public/og-card.png` and commit. Design spec is at `docs/public/og-card.SPEC.md`.
- [ ] Once deployed to `oh.mifune.dev`, validate with [Twitter Card Validator](https://cards-dev.twitter.com/validator) and [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)