### PR TITLE
FROM task/138-positioning-copy TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - Root `CHANGELOG.md` and Keep-a-Changelog workflow documented in `.claude/rules/git.md`; `/release` now promotes `[Unreleased]` to the new version section at tag time.
 
 ### Changed
+- Adopt Mifune positioning copy across README, docs landing, and About page (#138).
+
 ### Fixed
 - Slack bot no longer drops oversized agent replies with cascading `msg_too_long` errors. Main message is capped at 2,900 chars with a `_message truncated — full response in thread_` footer; full content spills to thread replies; `setWorking(false)` always clears the working indicator. ([#135](https://github.com/ryaneggz/openharness/issues/135))
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# 🏗️ Open Harness
+# Mifune Open Harness
 
-Isolated, pre-configured sandbox containers for AI coding agents — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [OpenAI Codex](https://github.com/openai/codex), [Pi Agent](https://shittycodingagent.ai), and more.
+**Mifune Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
 
-> Spin up a fully-provisioned container where AI coding agents can operate with full permissions, persistent memory, and autonomous background tasks — without touching your host system.
-
-**Only host dependency:** [Docker](https://docs.docker.com/get-docker/).
+- **Worktree-per-agent.** Each agent gets its own branch, its own SOUL, its own schedule.
+- **Agents that work while you sleep.** Cron-driven heartbeats wake them to do real work, autonomously.
+- **One container, every agent.** Claude Code, Codex, Pi, Gemini CLI — same sandbox, same toolchain.
+- **Only host dependency: Docker.** No Node, no Python, no toolchain rot on your laptop.
+- **Composable infra.** Cherry-pick Postgres, Cloudflare tunnels, SSH, Slack, Caddy gateway.
 
 ---
 

--- a/docs/pages/about.mdx
+++ b/docs/pages/about.mdx
@@ -1,0 +1,11 @@
+---
+title: About
+---
+
+# About
+
+Mifune Open Harness lets you run Claude, Codex, Gemini, and Pi side-by-side from a single `docker compose up`. Each agent gets its own git branch, its own SOUL identity, and its own cron schedule, so they can work independently without stepping on each other. Cron-driven heartbeats wake agents to do real work autonomously while you sleep, and the only host dependency is Docker — no Node, no Python, no toolchain rot on your laptop. Composable infra lets you cherry-pick Postgres, Cloudflare tunnels, SSH, Slack, and the Caddy gateway as you need them.
+
+## The name
+
+*Named for Captain Mifune — the one who held the gate open.*

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -1,11 +1,16 @@
 ---
-title: "Open Harness"
+title: "Mifune Open Harness"
 ---
 
+# Mifune Open Harness
 
-Isolated, pre-configured sandbox containers for AI coding agents — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [OpenAI Codex](https://github.com/openai/codex), [Pi Agent](https://shittycodingagent.ai), and more.
+**Mifune Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
 
-> **Spin up a fully-provisioned Dev Container where AI coding agents can operate with full permissions, persistent memory, and autonomous background tasks — without touching your host system.**
+- **Worktree-per-agent.** Each agent gets its own branch, its own SOUL, its own schedule.
+- **Agents that work while you sleep.** Cron-driven heartbeats wake them to do real work, autonomously.
+- **One container, every agent.** Claude Code, Codex, Pi, Gemini CLI — same sandbox, same toolchain.
+- **Only host dependency: Docker.** No Node, no Python, no toolchain rot on your laptop.
+- **Composable infra.** Cherry-pick Postgres, Cloudflare tunnels, SSH, Slack, Caddy gateway.
 
 ## Why Open Harness?
 
@@ -29,3 +34,7 @@ AI coding agents are powerful — but they run with broad system permissions, ex
 - [CLI Commands](/cli/commands) — Full command reference
 - [Compose Overlays](/guide/overlays) — Configure optional services
 - [Slack Bot](/slack/overview) — Connect agents to Slack
+
+---
+
+*Named for Captain Mifune — the one who held the gate open.*


### PR DESCRIPTION
Closes #138

## Summary
- Replace README hero block with the new Mifune one-liner plus five reordered positioning bullets (everything from `## Quickstart` onward untouched).
- Replace the docs landing-page hero in `docs/pages/index.mdx` with the same one-liner and bullets, and add the origin sentence as an italic footer.
- Add `docs/pages/about.mdx` with a 4-sentence expansion of the one-liner and a `## The name` section carrying the origin sentence.

**Conflict with PR #146**: this PR overwrites the stub `docs/pages/about.mdx` created in #146; take this version on merge.