### PR TITLE
FROM task/137-brand-cutover TO development

### DIFF
--- a/.claude/rules/docs-site.md
+++ b/.claude/rules/docs-site.md
@@ -7,17 +7,19 @@ Pages are MDX under `docs/pages/**` (Nextra 3.3 Pages Router). Builds
 produce a static export at `docs/out/`, deployed to GitHub Pages by
 `.github/workflows/docs.yml` on pushes to `main`.
 
-## basePath — the thing that breaks local preview
+## basePath
 
-`docs/next.config.mjs` sets `basePath: "/open-harness"` for the GitHub
-Pages URL shape (`https://ryaneggz.github.io/open-harness/...`). Every
-HTML page emitted to `docs/out/` contains absolute asset URLs starting
-with `/open-harness/`.
+`docs/next.config.mjs` sets `basePath: ""` because the docs site is
+served at the apex of a custom domain (`https://oh.mifune.dev/...`)
+via the GitHub Pages `CNAME` file at `docs/public/CNAME`. Every HTML
+page emitted to `docs/out/` references assets at the root
+(`/_next/static/...`), which is what both the deployed apex and a
+local static server expect.
 
-Serving `docs/out/` at the root of a static server produces unstyled
-HTML — CSS and JS 404 because the browser requests
-`/open-harness/_next/static/...` and the server has those files at
-`/_next/static/...`.
+If basePath is ever re-introduced (e.g. `"/open-harness"`), assets
+will 404 in production because the apex `oh.mifune.dev/<path>` will
+not be prefixed. Keep it empty unless the deploy target moves back
+to a subpath URL.
 
 ## Local Preview
 
@@ -31,18 +33,12 @@ Equivalent manually:
 
 ```bash
 pnpm docs:build                            # produces docs/out/
-ln -sfn . docs/out/open-harness            # serves docs/out under the basePath
 cd docs/out && python3 -m http.server 4000
 ```
 
-Then visit `http://localhost:4000/open-harness/` (not `/`).
+Then visit `http://localhost:4000/`.
 
-The symlink is a self-reference (`open-harness → .`). Python's
-`http.server` resolves `/open-harness/<path>` → `docs/out/<path>` in a
-single hop — no infinite loop.
-
-`docs/out/` is gitignored (`docs/.gitignore`), so the symlink never
-enters git history.
+`docs/out/` is gitignored (`docs/.gitignore`).
 
 ## Dev mode (`pnpm docs:dev`) — currently broken
 
@@ -72,6 +68,8 @@ sidebar in the intended position.
 ## Don'ts
 
 - Don't commit `docs/out/` or `docs/.next/` — both gitignored; CI rebuilds.
-- Don't remove `basePath` to make local preview easier — the GitHub
-  Pages deploy depends on it.
+- Don't add a non-empty `basePath` back — the deploy is at the apex
+  `oh.mifune.dev`, so any prefix breaks every asset URL in production.
+- Don't delete `docs/public/CNAME` — GitHub Pages reads it on every
+  build to keep the custom domain bound.
 - Don't publish docs via CI-on-PR — deploy only fires on `main` pushes.

--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -123,7 +123,7 @@ agent-browser close
 
 ### Step 2d — DNS resolution check (tunnel hostnames)
 
-If the URL contains a hostname that routes through a cloudflared tunnel (any `<name>.<your-domain>` served via cloudflared — not the default `ryaneggz.github.io/open-harness/` docs URL, which resolves normally), the container's DNS may not resolve it. Check and fix:
+If the URL contains a hostname that routes through a cloudflared tunnel (any `<name>.<your-domain>` served via cloudflared — not the default `oh.mifune.dev` docs URL, which resolves normally), the container's DNS may not resolve it. Check and fix:
 
 ```bash
 HOSTNAME=$(echo "$URL" | sed 's|https\?://||; s|/.*||; s|:.*||')
@@ -177,7 +177,7 @@ FILENAME=$(echo "$URL" | sed 's|https\?://||; s|/|--|g; s|--$||; s|[^a-zA-Z0-9._
 agent-browser screenshot ".claude/screenshots/${FILENAME}.png"
 ```
 
-Example: `https://ryaneggz.github.io/open-harness/guide/exposure/` → `.claude/screenshots/ryaneggz.github.io--open-harness--guide--exposure.png`
+Example: `https://oh.mifune.dev/guide/exposure/` → `.claude/screenshots/oh.mifune.dev--guide--exposure.png`
 
 ### Step 5 — Report
 

--- a/.claude/skills/provision/SKILL.md
+++ b/.claude/skills/provision/SKILL.md
@@ -233,7 +233,7 @@ If no keypair exists, skip this step — git auth via `gh auth setup-git` is the
 Sandbox 'orchestrator' is ready!
 
   Branch:  agent/orchestrator
-  Docs:    https://ryaneggz.github.io/open-harness/
+  Docs:    https://oh.mifune.dev/
   Tests:   8/8 passed
 
   Finish setup (one-time, inside the sandbox):

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -42,6 +42,6 @@ assignees: ""
 - [ ] Bug is fixed and no longer reproducible
 - [ ] Regression test added (Vitest or Playwright)
 - [ ] Lint + format + type-check pass
-- [ ] Verified via agent-browser at the deployed URL (docs default: `https://ryaneggz.github.io/open-harness/`)
+- [ ] Verified via agent-browser at the deployed URL (docs default: `https://oh.mifune.dev/`)
 - [ ] No regressions introduced
 - [ ] PR targets the default target branch (see `.claude/rules/git.md`)

--- a/.github/ISSUE_TEMPLATE/feat.md
+++ b/.github/ISSUE_TEMPLATE/feat.md
@@ -40,6 +40,6 @@ assignees: ""
 - [ ] Vitest tests added for new logic
 - [ ] Playwright E2E test covers the happy path
 - [ ] Lint + format + type-check pass (`pnpm run lint && pnpm run format:check && pnpm run type-check`)
-- [ ] Verified via agent-browser at the deployed URL (docs default: `https://ryaneggz.github.io/open-harness/`)
+- [ ] Verified via agent-browser at the deployed URL (docs default: `https://oh.mifune.dev/`)
 - [ ] Prisma migration included if schema changed
 - [ ] PR targets the default target branch (see `.claude/rules/git.md`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - Root `CHANGELOG.md` and Keep-a-Changelog workflow documented in `.claude/rules/git.md`; `/release` now promotes `[Unreleased]` to the new version section at tag time.
 
 ### Changed
+- Rebrand docs domain from `https://ryaneggz.github.io/open-harness/` to `https://oh.mifune.dev/`; default cloudflared tunnel hostname updated from `*.ruska.dev` to `*.mifune.dev`. ([#137](https://github.com/ryaneggz/openharness/issues/137))
+
 ### Fixed
 - Slack bot no longer drops oversized agent replies with cascading `msg_too_long` errors. Main message is capped at 2,900 chars with a `_message truncated — full response in thread_` footer; full content spills to thread replies; `setWorking(false)` always clears the working indicator. ([#135](https://github.com/ryaneggz/openharness/issues/135))
 

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -10,7 +10,7 @@ const withNextra = nextra({
 export default withNextra({
   output: "export",
   images: { unoptimized: true },
-  basePath: "/open-harness",
+  basePath: "",
   trailingSlash: true,
   experimental: { externalDir: true },
   transpilePackages: [

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+oh.mifune.dev

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "pnpm --filter @openharness/docs dev & cd workspace/projects/next-app && pnpm dev",
     "docs:dev": "pnpm --filter @openharness/docs dev",
     "docs:build": "pnpm --filter @openharness/docs build",
-    "docs:preview": "pnpm docs:build && ln -sfn . docs/out/open-harness && cd docs/out && python3 -m http.server ${DOCS_PREVIEW_PORT:-4000}"
+    "docs:preview": "pnpm docs:build && cd docs/out && python3 -m http.server ${DOCS_PREVIEW_PORT:-4000}"
   },
   "devDependencies": {
     "vitest": "^3.0.0"

--- a/packages/sandbox/src/__tests__/onboard-cloudflare.test.ts
+++ b/packages/sandbox/src/__tests__/onboard-cloudflare.test.ts
@@ -84,7 +84,7 @@ describe("cloudflare step", () => {
           cmd[0] === "bash" &&
           cmd[1].endsWith("/install/cloudflared-tunnel.sh") &&
           cmd[2] === "my-tun" &&
-          cmd[3] === "my-tun.ruska.dev" &&
+          cmd[3] === "my-tun.mifune.dev" &&
           cmd[4] === "3000",
       ),
     ).toBe(true);

--- a/packages/sandbox/src/onboard/steps/cloudflare.ts
+++ b/packages/sandbox/src/onboard/steps/cloudflare.ts
@@ -55,8 +55,8 @@ export const cloudflareStep: Step = {
 
     const tunnelName = (await io.ask("Tunnel name (default: open-harness):")) || "open-harness";
     const tunnelHost =
-      (await io.ask(`Public hostname (default: ${tunnelName}.ruska.dev):`)) ||
-      `${tunnelName}.ruska.dev`;
+      (await io.ask(`Public hostname (default: ${tunnelName}.mifune.dev):`)) ||
+      `${tunnelName}.mifune.dev`;
     const tunnelPort = (await io.ask("Local port (default: 3000):")) || DEFAULT_PORT;
 
     io.raw("\n");


### PR DESCRIPTION
Closes #137

## Summary

Repo-side execution of the Mifune brand cutover.

- `docs/next.config.mjs`: `basePath: ""` (deploy moves from `ryaneggz.github.io/open-harness/` subpath to apex `oh.mifune.dev`).
- `docs/public/CNAME`: new file with `oh.mifune.dev` so GitHub Pages keeps the custom domain bound on every build.
- `packages/sandbox/src/onboard/steps/cloudflare.ts` + matching test: default tunnel hostname `*.ruska.dev` -> `*.mifune.dev`.
- Sweep of stale strings (`oh.ruska.dev`, `ruska.dev`, `ryaneggz.github.io/open-harness`) in `.github/ISSUE_TEMPLATE/{bug,feat}.md`, `.claude/skills/{agent-browser,provision}/SKILL.md`, `.claude/rules/docs-site.md`, root `package.json` `docs:preview` script.
- `.claude/rules/docs-site.md`: rewrote basePath section, dropped the symlink workaround from Local Preview (now visit `http://localhost:4000/`), inverted the "don't remove basePath" rule to "don't add a non-empty basePath back" plus a new "don't delete `docs/public/CNAME`" rule.
- `CHANGELOG.md` `[Unreleased] -> Changed` entry.

`README.md` is intentionally NOT touched (owned by issues #138/#139). `docs/theme.config.tsx`, landing/about/blog pages, and `docs/package.json` are out of scope (other in-flight PRs).

Verification grep returned zero hits across `docs/`, `packages/`, `.github/`, `.claude/`:

```
grep -rn "oh\.ruska\.dev\|ryaneggz\.github\.io/open-harness\|ruska\.dev" \
  --exclude-dir=.worktrees --exclude-dir=workspace --exclude-dir=node_modules --exclude=README.md \
  docs/ packages/ .github/ .claude/
```

All 396 sandbox-package tests pass under the pre-commit hook.

## Manual steps remaining (launch runbook)

These are the operator/manual steps NOT in this PR — to flip the live site after merge:

- [ ] **DNS** — Add `CNAME oh -> ryaneggz.github.io.` at the `mifune.dev` zone (Cloudflare or current registrar).
- [ ] **Cloudflare 301** — Configure a Page Rule (or Worker) on `ryaneggz.github.io/open-harness/*` -> `https://oh.mifune.dev/$1` (301) so old links keep working.
- [ ] **GitHub repo edit** — `gh repo edit ryaneggz/open-harness --description "..."` and update the homepage URL to `https://oh.mifune.dev` so the repo card shows the new domain.
- [ ] **GH Pages settings** — In repo Settings -> Pages, confirm the custom domain reads `oh.mifune.dev` (the `CNAME` file in this PR auto-populates it on first build, but a one-time HTTPS-enforce checkbox toggle is manual) and "Enforce HTTPS" is on once the Let's Encrypt cert provisions.
- [ ] **DNS snapshot** — Capture `dig oh.mifune.dev +short` and `curl -sI https://oh.mifune.dev/` output; attach to issue #137 as the post-cutover proof.