### PR TITLE
FROM task/144-blog-byoh TO task/143-blog-scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 
 ### Added
 - Blog section at /blog and About page nav entry (#143).
+- Blog post: BYOH — stop installing agent CLIs on your laptop (#144).
 - Root `CHANGELOG.md` and Keep-a-Changelog workflow documented in `.claude/rules/git.md`; `/release` now promotes `[Unreleased]` to the new version section at tag time.
 
 ### Changed

--- a/docs/pages/blog/byoh.mdx
+++ b/docs/pages/blog/byoh.mdx
@@ -1,0 +1,73 @@
+---
+title: "BYOH — stop installing agent CLIs on your laptop"
+description: "My laptop had 14 Node versions, 3 Pythons, and a Rust toolchain I never asked for. Here's the one Docker command that replaced all of it — and let me run Claude, Codex, and Gemini in parallel."
+date: 2026-04-28
+ogImage: /blog/byoh-og.png
+canonical: https://oh.mifune.dev/blog/byoh
+---
+
+# BYOH — stop installing agent CLIs on your laptop
+
+I ran `ls ~/.nvm/versions/node` last week and counted **14 Node versions**. Three Pythons in `pyenv`. A Rust toolchain I'm pretty sure I installed for one Tauri experiment in 2023. A `~/.local/share/pnpm/global` directory that npm wouldn't admit existed. My laptop was a museum of dependency archaeology.
+
+The trigger was Codex. I wanted to try OpenAI's CLI alongside Claude Code. Step one of the install was "make sure you're on Node 20." Step two of the Gemini CLI was "make sure you're on Node 22." Step three of Pi (the agent runtime I actually wanted to glue everything together) was "we recommend a clean Python 3.11 venv." Each agent CLI was a fresh archaeology dig and a fresh chance to break the other two.
+
+I gave up. I containerized the whole thing. Now my laptop runs Docker and one binary, and **every** agent CLI lives inside a sandbox I can blow away in a second.
+
+It's called Open Harness. The pattern is BYOH — Bring Your Own Harness. Here's the part that actually changed my workflow.
+
+## The aha — three commands, every agent
+
+```bash
+oh sandbox my-agent     # build + start sandbox
+oh shell my-agent       # drop into a zsh inside it
+oh clean my-agent       # blow it away
+```
+
+That's it. The sandbox is a Debian container with Claude Code, Codex, the Gemini CLI, and Pi all preinstalled, on the right Node, on the right Python, with `gh`, `tmux`, `docker` (mounted socket), and the rest of the toolchain already wired. First run prompts `oh onboard` for OAuth flows — Slack, GitHub, Cloudflare, your LLM keys — once, then never again.
+
+No more "let me just upgrade brew first." No more "this CLI needs Node 22 and breaks on 24." The host stays clean. The sandbox does the work.
+
+## What you get out of the box
+
+Inside the container, on day one:
+
+- **Four agent CLIs**: `claude`, `codex`, `gemini`, `pi` — all current, all isolated.
+- **Identity files**: `SOUL.md` (persona), `MEMORY.md` (long-term notes), `AGENTS.md` (in-sandbox instructions). Every agent reads them; you edit them once.
+- **Heartbeats**: cron-style YAML in `workspace/heartbeats/*.md`. The Pi daemon fires them on schedule — daily wiki lints, hourly PR babysitting, whatever you want.
+- **A Slack bot** (`pi-mom`) that proxies the agent into a channel. Mention it, get a thread reply, work from your phone.
+- **Cloudflare tunnel exposure**: `oh expose docs 3000` puts a dev server on the public internet at `https://docs.<sandbox>.<your-domain>` with real TLS. No port forwarding, no `ngrok` tab.
+- **A docker socket** the agent can use — so the agent inside the sandbox can spin up _its own_ throwaway containers for tests, builds, browsers.
+
+The sandbox is the unit. You can have one for work, one for a weekend project, one for the AI side-quest you don't want polluting the others.
+
+## The unlock — agents racing each other
+
+Here's the part I didn't expect.
+
+Once every CLI lives inside one sandbox, **running them in parallel is trivial**. I open three tmux panes:
+
+```bash
+tmux new-session  -d -s race 'cd .worktrees/feat-x-claude  && claude'
+tmux split-window -t race    'cd .worktrees/feat-x-codex   && codex'
+tmux split-window -t race    'cd .worktrees/feat-x-gemini  && gemini'
+```
+
+Three worktrees, three branches, three agents, same prompt. Twenty minutes later I `git diff` the branches and pick the implementation I like best — or cherry-pick the good ideas across all three. Claude usually wins on architecture, Codex usually wins on test coverage, Gemini occasionally surprises me on a corner case. The point isn't which one wins; it's that **comparison is now cheap**.
+
+You can't do this when each CLI demands a different Node version on the host. You _can_ do it when they all share one well-tuned container. That's the actual product.
+
+## Try it
+
+```bash
+git clone https://github.com/ryaneggz/open-harness.git
+cd open-harness
+docker compose -f .devcontainer/docker-compose.yml up -d --build
+docker exec -it -u sandbox openharness zsh
+```
+
+Or, after the first sandbox: `oh sandbox <name>` from anywhere.
+
+Full docs at **[oh.mifune.dev](https://oh.mifune.dev)**. Source at [github.com/ryaneggz/open-harness](https://github.com/ryaneggz/open-harness). Issues and PRs welcome — the fastest way to make BYOH better is to bring _your_ harness rules and tell me what's missing.
+
+Wednesday's post: **one worktree per agent** — the git pattern that makes the three-pane race above safe to run on your real codebase.

--- a/docs/public/blog/byoh-og.SPEC.md
+++ b/docs/public/blog/byoh-og.SPEC.md
@@ -1,0 +1,58 @@
+# OG Image Spec — `byoh-og.png`
+
+Per-post Open Graph card for `/blog/byoh`. Maintainer renders the PNG and drops it at `docs/public/blog/byoh-og.png`. This file is the design brief, not the asset.
+
+## Mechanical requirements
+
+- **Filename**: `byoh-og.png` (must match `ogImage` frontmatter in `byoh.mdx`).
+- **Dimensions**: `1200 × 630` (Open Graph 1.91:1 — also fits Twitter/X summary_large_image, LinkedIn, dev.to cover).
+- **Format**: PNG, sRGB, ≤300 KB after compression. No transparency (social platforms flatten to white inconsistently).
+- **Safe zone**: keep all text inside a 1080×510 rectangle centered on the canvas. LinkedIn and Slack crop ~5% off each edge.
+- **Text rendering**: ship as rasterized text in the PNG (no live fonts). Min effective text size at thumbnail (≈400px wide) ≥ 24px equivalent — i.e. headline ≥ 72px in the source.
+
+## What to depict
+
+A laptop screen full of stacked Node version managers (visual chaos) on the left, collapsing into a single clean terminal pane on the right showing:
+
+```
+$ oh sandbox my-agent
+```
+
+Arrow or fold-line between the two halves communicates "many → one." The post's hook is _replacement_, so the image must read as "before / after" at thumbnail size, not as a feature list.
+
+If the visual gag is too busy at 1200×630, fall back to **Option B**: pure typographic card, headline only, no illustration. (Better to ship a clean type card than a cluttered illustration.)
+
+## Copy on the card
+
+- **Headline (large, top-left or center)**: `BYOH` (uppercase, monospace, brand color).
+- **Subhead (smaller, beneath)**: `Stop installing agent CLIs on your laptop.`
+- **Footer (small, bottom-right)**: `oh.mifune.dev` + small Open Harness mark.
+- **No date.** Posts get re-shared; dated cards age badly.
+
+## Color palette
+
+Pull from the Open Harness docs theme — match `docs/theme.config.tsx` brand colors. If the live palette isn't easy to extract:
+
+- **Background**: near-black `#0B0E14` (matches typical terminal dark theme).
+- **Primary text / headline**: warm white `#F5F2EA`.
+- **Accent (BYOH wordmark, terminal prompt `$`, accent strokes)**: amber `#F0B429` (reads well against dark on every social platform's preview chrome).
+- **Secondary text (subhead, footer URL)**: muted gray `#9AA0A6`.
+
+Avoid pure `#FFFFFF` — Twitter/X and LinkedIn render their own white chrome around it and the card disappears into the page.
+
+## Typography
+
+- **Headline**: monospace (JetBrains Mono, IBM Plex Mono, or whatever the docs site already uses for code). Reinforces the "this is a developer tool" read at a glance.
+- **Subhead**: same family for consistency, lighter weight.
+- **Footer URL**: same family, smaller, muted.
+
+## Accessibility / fallback
+
+- Provide a 2× retina version (`byoh-og@2x.png`, 2400×1260) if the rendering pipeline supports it. Optional.
+- Ensure headline contrast ratio against background ≥ 7:1 (AAA). The amber-on-near-black combo above is ~10:1 — safe.
+
+## Out of scope for this spec
+
+- Animated / video card (OG only renders the still).
+- Per-platform variants (Twitter card vs LinkedIn vs dev.to cover) — single PNG covers all three at 1200×630.
+- Auto-generation pipeline. If we add one later (Satori, @vercel/og, etc.) it lives in a separate PR; this file documents the manual asset for now.


### PR DESCRIPTION
Closes #144

**Stacked on #146** (`task/143-blog-scaffold`) — depends on the `/blog` scaffolding from that PR. When #146 merges, GitHub auto-rebases this PR's base to `development`. Do not force-push after that.

## Summary

- New post: `docs/pages/blog/byoh.mdx` — "BYOH — stop installing agent CLIs on your laptop" (~760 words, publishes 2026-04-28)
- Per-post OG image brief: `docs/public/blog/byoh-og.SPEC.md` (1200x630, dark amber typographic + before/after laptop visual; maintainer renders the PNG separately)
- Changelog entry under `## [Unreleased] / Added`

## Audience and angle

Indie hackers and agent-curious devs (not infra-first). Hook is the toolchain-rot pain story (14 Node versions, 3 Pythons, a Rust toolchain I never asked for) → three-command sandbox lifecycle → the parallel-agents-in-one-container unlock (Claude vs Codex vs Gemini racing on the same prompt across worktrees). BYOH appears throughout as a tag/concept; not the headline.

Word count verified: \`wc -w docs/pages/blog/byoh.mdx\` = **760** (target 750-900).

## Test plan

- [ ] \`pnpm docs:build\` succeeds and \`/blog/byoh\` renders
- [ ] Frontmatter has all 5 required fields (title, description, date, ogImage, canonical)
- [ ] OG SPEC mechanical numbers match real platform requirements
- [ ] CHANGELOG entry visible under \`## [Unreleased] / Added\`

---

## Cross-post copy drafts (maintainer publishes Tuesday 8am ET — DO NOT publish from this PR)

### 1. dev.to frontmatter

\`\`\`markdown
---
title: BYOH — stop installing agent CLIs on your laptop
published: false
description: My laptop had 14 Node versions, 3 Pythons, and a Rust toolchain I never asked for. Here's the one Docker command that replaced all of it — and let me run Claude, Codex, and Gemini in parallel.
tags: ai, docker, devtools, productivity
canonical_url: https://oh.mifune.dev/blog/byoh
cover_image: https://oh.mifune.dev/blog/byoh-og.png
---
\`\`\`

(Body: paste the post contents below the frontmatter. Once \`byoh-og.png\` is uploaded to \`docs/public/blog/\`, the cover_image URL above resolves automatically — no edit needed.)

### 2. LinkedIn long-form (~350 words)

> I ran \`ls ~/.nvm/versions/node\` last week and counted 14 Node versions. Three Pythons in pyenv. A Rust toolchain I'm pretty sure I installed for a Tauri experiment in 2023. My laptop was a museum of dependency archaeology.
>
> The trigger was Codex. I wanted to try OpenAI's CLI alongside Claude Code. Step one: "make sure you're on Node 20." Step two of the Gemini CLI: "make sure you're on Node 22." Step three of Pi (the agent runtime I wanted to glue everything together): "we recommend a clean Python 3.11 venv."
>
> Each agent CLI was a fresh archaeology dig and a fresh chance to break the other two.
>
> I gave up. I containerized the whole thing.
>
> Now my laptop runs Docker and one binary. Every agent CLI lives inside a sandbox I can blow away in a second:
>
> \`oh sandbox my-agent\` → build it
> \`oh shell my-agent\` → drop in
> \`oh clean my-agent\` → blow it away
>
> Inside: Claude Code, Codex, the Gemini CLI, and Pi all preinstalled, on the right Node, on the right Python, with gh, tmux, and a docker socket already wired. Onboarding (Slack, GitHub, Cloudflare, LLM keys) runs once.
>
> But here's the part I didn't expect.
>
> Once every CLI lives inside one sandbox, running them in parallel is trivial. Three tmux panes, three git worktrees, three agents on the same prompt. Twenty minutes later I git diff the branches and pick the implementation I like best — or cherry-pick the good ideas across all three.
>
> Claude usually wins on architecture. Codex usually wins on test coverage. Gemini occasionally surprises me on a corner case. The point isn't which one wins; it's that comparison is now cheap.
>
> You can't do this when each CLI demands a different Node version on the host. You can do it when they all share one well-tuned container.
>
> That's the actual product. We're calling the pattern BYOH — Bring Your Own Harness.
>
> Try it: https://oh.mifune.dev
>
> #AI #Docker #DeveloperTools #Productivity

### 3. X / Twitter thread (6 tweets)

**1/** My laptop had 14 Node versions, 3 Pythons, and a Rust toolchain I never asked for.

Here's the one Docker command that replaced all of it — and let me run Claude, Codex, and Gemini in parallel. 🧵

[attach \`byoh-og.png\`]

**2/** The trigger was Codex.

I wanted to try OpenAI's CLI alongside Claude Code. Step one: "Node 20." Gemini CLI: "Node 22." Pi runtime: "clean Python 3.11 venv."

Each install was a fresh chance to break the other two.

**3/** I gave up. I containerized everything.

\`\`\`
oh sandbox my-agent
oh shell my-agent
oh clean my-agent
\`\`\`

Three commands. Inside: Claude Code, Codex, Gemini CLI, Pi — all preinstalled, all on the right runtime, all isolated.

**4/** What you get out of the box:

- 4 agent CLIs, current
- SOUL.md / MEMORY.md / heartbeats
- Slack bot for mobile chat
- Cloudflare tunnel: \`oh expose docs 3000\` → real TLS URL
- Mounted docker socket so the agent can spawn its own throwaway containers

**5/** The unlock I didn't expect:

3 tmux panes, 3 git worktrees, 3 agents, same prompt.

20 min later I diff the branches and cherry-pick the best ideas.

Claude wins on architecture. Codex wins on tests. Gemini surprises me on corner cases. Comparison is now cheap.

**6/** That's BYOH — Bring Your Own Harness.

Stop installing agent CLIs on your laptop. Run them all in one sandbox. Race them against each other.

Docs: https://oh.mifune.dev
Source: https://github.com/ryaneggz/open-harness

Wednesday: one worktree per agent — the git pattern that makes it safe.

### 4. r/ClaudeAI text post (~150 words, NOT a link post)

**Title:** I containerized every agent CLI so I could run Claude, Codex, and Gemini in parallel

**Body:**

My laptop had 14 Node versions and 3 Pythons because every agent CLI demanded a different runtime. Codex wanted Node 20, Gemini wanted Node 22, Pi wanted a clean Python 3.11 venv. I was one bad upgrade from breaking all three.

So I built Open Harness — a Docker sandbox with Claude Code, Codex, the Gemini CLI, and Pi all preinstalled on the right runtimes, plus gh, tmux, and a mounted docker socket. Three commands: \`oh sandbox <name>\`, \`oh shell <name>\`, \`oh clean <name>\`.

The unlock isn't "no more Node versions" — it's that running 3 agents in 3 git worktrees on the same prompt is now trivial. \`tmux new-session\`, three panes, twenty minutes later \`git diff\` and pick the winner. Claude usually wins on architecture, Codex on tests.

Full write-up + repo: https://oh.mifune.dev/blog/byoh

🤖 Generated with [Claude Code](https://claude.com/claude-code)