### PR TITLE
FROM task/launch-runbook TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 
 ### Added
 - Root `CHANGELOG.md` and Keep-a-Changelog workflow documented in `.claude/rules/git.md`; `/release` now promotes `[Unreleased]` to the new version section at tag time.
+- Launch runbook consolidating manual cutover steps (DNS, GH settings, OG validation, GSC, promotion).
 
 ### Changed
 ### Fixed

--- a/docs/pages/_meta.js
+++ b/docs/pages/_meta.js
@@ -6,4 +6,7 @@ export default {
   cli: "CLI Reference",
   architecture: "Architecture",
   wiki: "Wiki",
+  about: "About",
+  blog: "Blog",
+  "launch-runbook": "Launch Runbook",
 };

--- a/docs/pages/launch-runbook.mdx
+++ b/docs/pages/launch-runbook.mdx
@@ -1,0 +1,351 @@
+---
+title: "Launch Runbook"
+---
+
+# Launch Runbook — Mifune Cutover & Promotion
+
+Maintainer-only checklist. Every step in this document is a manual
+action against an external dashboard, DNS provider, or third-party
+validator — none of it is automated by the rebrand PRs ([#146](https://github.com/ryaneggz/open-harness/pull/146),
+[#147](https://github.com/ryaneggz/open-harness/pull/147),
+[#148](https://github.com/ryaneggz/open-harness/pull/148),
+[#149](https://github.com/ryaneggz/open-harness/pull/149),
+[#150](https://github.com/ryaneggz/open-harness/pull/150)).
+
+Execute top-to-bottom. Do not skip the pre-flight snapshot — it is
+your only rollback insurance.
+
+In-flight PRs this runbook depends on:
+
+| PR | Purpose |
+|---|---|
+| [#146](https://github.com/ryaneggz/open-harness/pull/146) | Blog scaffold ([#143](https://github.com/ryaneggz/open-harness/issues/143)) |
+| [#147](https://github.com/ryaneggz/open-harness/pull/147) | Theme + OG meta ([#140](https://github.com/ryaneggz/open-harness/issues/140), [#142](https://github.com/ryaneggz/open-harness/issues/142)) |
+| [#148](https://github.com/ryaneggz/open-harness/pull/148) | Positioning copy ([#138](https://github.com/ryaneggz/open-harness/issues/138)) |
+| [#149](https://github.com/ryaneggz/open-harness/pull/149) | sitemap.xml + robots.txt ([#141](https://github.com/ryaneggz/open-harness/issues/141)) |
+| [#150](https://github.com/ryaneggz/open-harness/pull/150) | Brand cutover — DNS, CNAME file, basePath, sweep ([#137](https://github.com/ryaneggz/open-harness/issues/137), [#139](https://github.com/ryaneggz/open-harness/issues/139)) |
+
+---
+
+## 1. Pre-flight (Friday night)
+
+Snapshot current DNS so a rollback is one `gh gist view` away.
+
+```bash
+{
+  echo "=== oh.ruska.dev ANY ==="
+  dig oh.ruska.dev ANY +short
+  echo "=== ruska.ai ANY ==="
+  dig ruska.ai ANY +short
+  echo "=== ruska.dev ANY ==="
+  dig ruska.dev ANY +short
+} > dns-snapshot.txt
+
+gh gist create dns-snapshot.txt --public \
+  --desc "ruska.ai pre-mifune snapshot ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+```
+
+Save the gist URL somewhere you can find it at 2am if a CNAME goes
+sideways.
+
+---
+
+## 2. Cloudflare — 301 redirect (do BEFORE the CNAME flip)
+
+The 301 must exist before `oh.mifune.dev` resolves. If you flip the
+CNAME first, traffic from existing links breaks instead of redirects.
+
+1. Cloudflare dash → `ruska.ai` zone → **Rules** → **Page Rules** →
+   **Create Page Rule**.
+2. URL pattern: `oh.ruska.dev/*`
+3. Setting: **Forwarding URL** → status code **301 (Permanent
+   Redirect)** → destination `https://oh.mifune.dev/$1`
+4. Save and deploy.
+
+Verify:
+
+```bash
+curl -I https://oh.ruska.dev/guide/workspace
+# Expect:
+#   HTTP/2 301
+#   location: https://oh.mifune.dev/guide/workspace
+```
+
+If the redirect resolves to `https://oh.mifune.dev/$1` (literal `$1`),
+the wildcard wasn't captured — fix the rule before continuing.
+
+---
+
+## 3. Cloudflare — DNS for the new domain
+
+1. Cloudflare dash → `mifune.dev` zone → **DNS** → **Records** →
+   **Add record**.
+2. Type **CNAME**, Name `oh`, Target `ryaneggz.github.io`,
+   Proxy status **DNS only** (grey cloud — GitHub Pages provisions
+   its own cert and orange-cloud breaks ACME).
+3. TTL Auto. Save.
+
+Wait for propagation (usually 1–5 min on Cloudflare):
+
+```bash
+dig +short oh.mifune.dev @1.1.1.1
+dig +short oh.mifune.dev @8.8.8.8
+# Both should return GitHub Pages IPs:
+#   185.199.108.153
+#   185.199.109.153
+#   185.199.110.153
+#   185.199.111.153
+```
+
+If only one resolver answers, wait another minute and retry. Do not
+proceed until both return the same set.
+
+---
+
+## 4. GitHub Pages — enable HTTPS on the custom domain
+
+PR [#150](https://github.com/ryaneggz/open-harness/pull/150) commits
+`docs/public/CNAME` containing `oh.mifune.dev`. GitHub reads that file
+on the next Pages deploy and accepts the custom domain — but cert
+provisioning is a separate manual step.
+
+1. Repo **Settings** → **Pages**.
+2. Confirm **Custom domain** shows `oh.mifune.dev` (auto-populated
+   from `docs/public/CNAME`).
+3. Wait for the **DNS check** banner to turn green and the cert
+   provisioning notice to disappear (typically 5–15 min).
+4. Tick **Enforce HTTPS**.
+
+Verify:
+
+```bash
+curl -I https://oh.mifune.dev
+# Expect: HTTP/2 200
+```
+
+If you see a TLS error, the cert is still provisioning — wait and
+retry. Do not toggle the custom domain off and on; that resets the
+cert state machine.
+
+---
+
+## 5. GitHub repo — description, homepage, topics
+
+```bash
+gh repo edit ryaneggz/open-harness \
+  --description "Mifune Open Harness — run Claude, Codex, Gemini, and Pi side-by-side from one docker compose up." \
+  --homepage https://oh.mifune.dev
+
+gh repo edit ryaneggz/open-harness --add-topic devcontainer
+gh repo edit ryaneggz/open-harness --add-topic agentic
+gh repo edit ryaneggz/open-harness --add-topic byoh
+```
+
+Drop ambiguous topics that no longer reflect positioning:
+
+```bash
+# Inspect first
+gh repo view ryaneggz/open-harness --json repositoryTopics
+
+# Drop as needed (example — adjust to your actual list)
+gh repo edit ryaneggz/open-harness --remove-topic ai
+gh repo edit ryaneggz/open-harness --remove-topic llm
+```
+
+Verify:
+
+```bash
+gh repo view ryaneggz/open-harness --json description,homepageUrl,repositoryTopics
+```
+
+---
+
+## 6. GitHub repo — social preview image (issue [#142](https://github.com/ryaneggz/open-harness/issues/142))
+
+This is **separate** from the docs OG card. It is the card GitHub
+serves when someone pastes the repo URL into Twitter/Slack.
+
+1. Repo **Settings** → scroll to **Social preview** → **Edit** →
+   **Upload an image**.
+2. Upload a **1280×640 PNG** (note: GitHub's spec, not the docs OG's
+   1200×630 — they are different surfaces). The
+   `og-card.png` from PR [#147](https://github.com/ryaneggz/open-harness/pull/147)
+   can be re-rendered at this size, or designed as a separate asset.
+3. Save.
+
+Verify:
+
+1. Open a draft tweet at https://twitter.com/compose/post.
+2. Paste `https://github.com/ryaneggz/open-harness`.
+3. Wait for the unfurl preview — it should show the new card.
+4. Discard the draft (do **not** post).
+
+Twitter caches unfurls aggressively. If the old card persists, also
+test in https://cards-dev.twitter.com/validator with the GitHub URL.
+
+---
+
+## 7. Drop in the OG card PNG (PR [#147](https://github.com/ryaneggz/open-harness/pull/147) spec)
+
+PR [#147](https://github.com/ryaneggz/open-harness/pull/147) commits a
+design spec at `docs/public/og-card.SPEC.md` (1200×630, Mifune
+wordmark, one-liner, color palette, no Matrix imagery — trademark
+hygiene). The PNG itself is human-supplied.
+
+1. Read the spec: `docs/public/og-card.SPEC.md`.
+2. Generate or design the 1200×630 PNG (Figma, Photoshop, Midjourney
+   + cleanup, etc.).
+3. Drop the file at `docs/public/og-card.png`.
+4. Commit on `main` directly (one-line PR is fine — the asset is
+   non-code):
+
+   ```bash
+   git checkout -b chore/og-card-asset
+   git add docs/public/og-card.png
+   git commit -m "chore: add og-card.png asset"
+   git push -u origin chore/og-card-asset
+   gh pr create --base main --title "chore: og-card.png asset" \
+     --body "Drops the 1200×630 OG card per docs/public/og-card.SPEC.md."
+   ```
+
+5. Same drill for `docs/public/blog/byoh-og.png` and
+   `docs/public/blog/worktree-per-agent-og.png` if you produce them
+   ahead of the post launches.
+
+---
+
+## 8. Validate the OG card after deploy
+
+Validators cache 404s aggressively, so smoke-test the asset URL
+**before** submitting.
+
+```bash
+curl -I https://oh.mifune.dev/og-card.png
+# Expect: HTTP/2 200, content-type: image/png
+
+curl -I https://oh.mifune.dev/blog/byoh-og.png
+curl -I https://oh.mifune.dev/blog/worktree-per-agent-og.png
+```
+
+Only after all three return 200, submit:
+
+1. **Twitter Card Validator** —
+   https://cards-dev.twitter.com/validator → enter
+   `https://oh.mifune.dev` → click **Preview card** → confirm new
+   card renders. Repeat for `/blog/byoh` and
+   `/blog/worktree-per-agent`.
+2. **LinkedIn Post Inspector** —
+   https://www.linkedin.com/post-inspector/ → enter URL → click
+   **Inspect** → confirm. Repeat for blog URLs.
+3. **Facebook Sharing Debugger** (optional, but it forces a re-scrape
+   that some downstream services trust) —
+   https://developers.facebook.com/tools/debug/ → enter URL → click
+   **Scrape Again**.
+
+If a validator shows the wrong card, click its **re-scrape** button —
+do not just retry the URL, because validators serve cached results
+even when the underlying tag changed.
+
+---
+
+## 9. Submit sitemap to Google Search Console (issue [#141](https://github.com/ryaneggz/open-harness/issues/141))
+
+PR [#149](https://github.com/ryaneggz/open-harness/pull/149) wires
+`next-sitemap` to emit `docs/out/sitemap.xml` and `docs/out/robots.txt`
+on every build. Submission to GSC is manual and one-time.
+
+1. Smoke check the deployed sitemap:
+
+   ```bash
+   curl -I https://oh.mifune.dev/sitemap.xml
+   # Expect: HTTP/2 200
+
+   curl -s https://oh.mifune.dev/sitemap.xml | head -20
+   # Expect: valid XML, includes /blog/byoh among <loc> entries
+   ```
+
+2. Open Google Search Console → https://search.google.com/search-console.
+3. Add property `https://oh.mifune.dev` (URL-prefix property, **not**
+   domain property — domain requires a TXT record and adds setup
+   time).
+4. Verify ownership via the HTML meta tag method (drop the meta tag
+   into `docs/theme.config.tsx` `head` function — already extensible
+   per PR [#147](https://github.com/ryaneggz/open-harness/pull/147)).
+5. Once verified: **Sitemaps** in left nav → enter `sitemap.xml` →
+   **Submit**.
+6. Status should show **Success** within ~24h. If it shows
+   **Couldn't fetch**, recheck the URL is publicly reachable and that
+   `robots.txt` does not block `/sitemap.xml`.
+
+---
+
+## 10. Promotion timing — LOCKED
+
+Council DevRel review locked these slots. **Do not deviate.** Monday
+9am ET is among the worst windows for X / LinkedIn / HN. Tue 8am ET
++ Wed 9am ET gives a clean two-wave launch and avoids cramming both
+posts into one news cycle.
+
+| When | What | Distribution |
+|---|---|---|
+| **Tue 8am ET** | Publish + promote BYOH post (issue [#144](https://github.com/ryaneggz/open-harness/issues/144), `docs/pages/blog/byoh.mdx`) | dev.to (with `canonical_url: https://oh.mifune.dev/blog/byoh`), LinkedIn long-form, X thread, r/ClaudeAI as **TEXT post** (not link — auto-removed for low-karma accounts) |
+| **Wed 9am ET** | Publish + promote worktree-per-agent post (issue [#145](https://github.com/ryaneggz/open-harness/issues/145), `docs/pages/blog/worktree-per-agent.mdx`) | X thread, **Show HN at 9–11am PT** (separate slot from main wave), r/ClaudeAI text post, dev.to |
+
+**Do not publish Monday.** Worst slot for X/LinkedIn/HN per AI council
+DevRel review.
+
+dev.to crossposts must include the `canonical_url` frontmatter field
+pointing at `https://oh.mifune.dev/blog/<slug>` — Google will treat
+the in-repo blog as canonical and dev.to as the syndication mirror.
+Verify this **before** publishing on dev.to (post-publish edits to
+canonical do not propagate cleanly).
+
+r/ClaudeAI posts: paste the post **text** into the submission, not a
+link. Link posts from low-karma accounts are auto-removed. End the
+post with the canonical URL as a single line so readers can click
+through.
+
+---
+
+## 11. Post-launch verification checklist
+
+Run these end-to-end before declaring the cutover done. From
+`.claude/plans/we-need-to-figure-shiny-plum.md` § Verification.
+
+1. **DNS** — `dig +short oh.mifune.dev @1.1.1.1` and
+   `dig +short oh.mifune.dev @8.8.8.8` both return GitHub Pages IPs;
+   `curl -I https://oh.mifune.dev` returns 200.
+2. **301** — `curl -I https://oh.ruska.dev/guide/workspace` returns
+   301 with `Location: https://oh.mifune.dev/guide/workspace`.
+3. **basePath** — `https://oh.mifune.dev` renders **styled** (CSS
+   loads, navigation works) — proves the basePath flip from PR
+   [#150](https://github.com/ryaneggz/open-harness/pull/150) didn't
+   break asset paths.
+4. **Repo sweep** —
+   `grep -rn "oh\.ruska\.dev\|ryaneggz\.github\.io/open-harness\|ruska\.dev" README.md docs/ packages/ .github/`
+   returns zero hits (worktrees excluded).
+5. **README** — `wc -l README.md` ≤ 130; click every doc link →
+   200 on `oh.mifune.dev`.
+6. **OG card** — Twitter Card Validator + LinkedIn Post Inspector
+   both render the new card; per-post OG renders for `/blog/byoh`
+   and `/blog/worktree-per-agent`.
+7. **Sitemap** — `curl -s https://oh.mifune.dev/sitemap.xml`
+   returns valid XML including `/blog/byoh`; submitted to Google
+   Search Console; status **Success**.
+8. **Canonical** —
+   `curl -s https://oh.mifune.dev/blog/byoh | grep canonical`
+   returns the absolute mifune.dev URL.
+9. **GitHub social preview** — paste repo URL into a draft tweet →
+   new card renders.
+10. **Blog publish dry run** — `https://oh.mifune.dev/blog` lists
+    BYOH; post page resolves; per-post OG image renders.
+11. **dev.to draft** — has `canonical_url: https://oh.mifune.dev/blog/byoh`
+    in frontmatter (verify **before** publish, not after — edits
+    don't propagate cleanly).
+12. **Word count** — `wc -w docs/pages/blog/byoh.mdx` between
+    750 and 900.
+
+If any check fails, fix before proceeding to the next promotion slot.
+A broken OG card during a launch wave is recoverable (re-submit
+validators after fix); a broken canonical tag during indexing is
+not (Google can lock in the wrong URL for weeks).


### PR DESCRIPTION
## Summary

Adds a single consolidated launch runbook at `docs/pages/launch-runbook.mdx` covering every manual step the maintainer must execute outside the in-flight rebrand worker PRs to take Mifune Open Harness live.

The runbook is the single doc the maintainer follows top-to-bottom on cutover day — DNS snapshot, 301 redirect, CNAME flip, GitHub Pages HTTPS, repo description/topics/social preview, OG card design + validation, GSC sitemap submission, locked Tue/Wed promotion timing, and 12-item post-launch verification.

## Sections

1. Pre-flight (Friday night) — DNS snapshot to gist
2. Cloudflare 301 (before CNAME flip)
3. Cloudflare DNS — `oh` CNAME → `ryaneggz.github.io`
4. GitHub Pages — enable HTTPS on custom domain
5. GitHub repo — description, homepage, topics
6. GitHub repo — social preview image (1280×640)
7. Drop in OG card PNG per PR #147 spec
8. Validate OG card via Twitter/LinkedIn/Facebook validators
9. Submit sitemap to Google Search Console
10. Promotion timing — Tue 8am ET BYOH, Wed 9am ET worktree-per-agent
11. Post-launch verification checklist (12 items)

## In-flight PRs this runbook references

- #146 — blog scaffold
- #147 — theme/OG meta
- #148 — positioning copy
- #149 — sitemap.xml + robots.txt
- #150 — brand cutover (DNS, CNAME file, basePath, sweep)

Issues referenced: #137, #138, #139, #140, #141, #142, #143, #144, #145.

## Conflict heads-up

`docs/pages/_meta.js` is also edited by PR #146 (adds `about` + `blog`). This PR adds `about`, `blog`, AND `launch-runbook` so whichever lands first leaves the other three keys intact. If both PRs are open at merge time, take the union of the two `_meta.js` versions.

## Test plan

- [ ] CI green on `task/launch-runbook`
- [ ] Maintainer reviews runbook for accuracy of dashboard paths (Cloudflare UI nav, GH Pages settings) — paths are stable at time of writing but verify against current GitHub UI
- [ ] After merge, runbook renders at `https://oh.mifune.dev/launch-runbook` (or the GH Pages preview URL pre-cutover)