### PR TITLE
FROM task/145-blog-wpa TO task/143-blog-scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- Blog post draft: Worktree-per-agent — stages for Wed publish ([#145](https://github.com/ryaneggz/openharness/pull/145)).
 - Blog section at /blog and About page nav entry (#143).
 - Root `CHANGELOG.md` and Keep-a-Changelog workflow documented in `.claude/rules/git.md`; `/release` now promotes `[Unreleased]` to the new version section at tag time.
 

--- a/docs/pages/blog/worktree-per-agent.mdx
+++ b/docs/pages/blog/worktree-per-agent.mdx
@@ -1,0 +1,90 @@
+---
+title: "One Worktree Per Agent"
+description: "We tried one container per agent. It cost $40/month per agent. Here is what we did instead — one container, many git worktrees, full isolation, one bill."
+date: 2026-04-29
+ogImage: /blog/worktree-per-agent-og.png
+canonical: https://oh.mifune.dev/blog/worktree-per-agent
+draft: true
+---
+
+# One Worktree Per Agent
+
+We tried one container per agent. It cost $40 a month per agent. Here is what we did instead.
+
+## The $40 problem
+
+Spinning up a fresh container for every coding agent is the obvious first move. It is also the wrong one. A small VPS that can comfortably host a Claude Code session — Node, pnpm, Python, Docker-in-Docker, a checkout of the repo, and enough memory not to thrash — runs about $8 a month on a budget host. Multiply that by five agents and you are at $40 a month before you have shipped a single feature. Make it ten and you are paying $80 to keep ten copies of the same toolchain warm.
+
+The cost is the visible part of the problem. The hidden part is worse. Each container has its own `node_modules`, its own pnpm store, its own Docker image cache, its own git object database. A change to a shared dependency means rebuilding it five times. A new tool installed for one agent has to be reinstalled for the rest, or the agents diverge. There is no shared workspace, so when two agents need to look at the same generated artifact they each have to regenerate it. The agents are isolated, and that isolation has a real cost in money, in disk, and in the friction of keeping five identical setups identical.
+
+## The constraint
+
+What do agents actually need from each other? Two things, mostly: a separate branch and separate state. One agent should be able to commit to `feat/docs` while another commits to `feat/tests` without either one stepping on the other. One agent should be able to keep its memory, its current task, and its working files distinct from the next agent's.
+
+Notice what is **not** on that list. Agents do not need separate kernels. They do not need separate package managers. They do not need separate Docker daemons. They do not even need separate filesystems — they need separate **views** of a filesystem.
+
+Git already solves the "separate branch, separate working tree" problem cheaply. It is called `git worktree`. A worktree is a second working directory backed by the same `.git` object store as your main checkout. Each worktree is on a different branch, has its own staged index, its own untracked files. From the inside, an agent in a worktree looks like an agent that owns the whole repo. From the outside, it is just another directory pointing at shared objects.
+
+So the design fell out: one container, many worktrees, one agent per worktree. The container handles the toolchain and the kernel and the Docker socket. The worktree handles the branch and the working state. An agent gets full isolation where isolation matters and shares everything where sharing is free.
+
+## The architecture
+
+```mermaid
+graph TD
+  Host[Host machine] --> Container[oh sandbox container<br/>shared toolchain + docker socket]
+  Container --> WT1[.worktrees/feat-docs<br/>AGENTS.md / SOUL.md / MEMORY.md]
+  Container --> WT2[.worktrees/feat-tests<br/>AGENTS.md / SOUL.md / MEMORY.md]
+  Container --> WT3[.worktrees/review-all<br/>AGENTS.md / SOUL.md / MEMORY.md]
+  Container --> HB[heartbeat scheduler<br/>cron-style ticks]
+  WT1 --> A1[Claude Code<br/>SOUL: writer<br/>branch: feat/docs]
+  WT2 --> A2[Codex<br/>SOUL: tester<br/>branch: feat/tests]
+  WT3 --> A3[Pi<br/>SOUL: reviewer<br/>branch: review/all]
+  A1 --> Push1[git push origin feat/docs]
+  A2 --> Push2[git push origin feat/tests]
+  A3 --> Push3[git push origin review/all]
+  HB -.fires per worktree.-> A1
+  HB -.fires per worktree.-> A2
+  HB -.fires per worktree.-> A3
+```
+
+One sandbox container at the top. Inside it, `oh worktree <name>` carves a new directory under `.worktrees/`. Each worktree gets its own `AGENTS.md` (operating procedures), `SOUL.md` (persona), `MEMORY.md` (running notes), and its own heartbeat config. The heartbeat scheduler runs once at the container level and fans out per worktree, so agent A's hourly check does not block agent B's nightly release. Every agent gets the same Docker socket — they can all build images, run containers, talk to the same registry — but no agent can see another agent's branch or working tree without crossing a directory boundary.
+
+The cost model collapses. One VPS, one toolchain, one pnpm store, one Docker image cache. The marginal cost of adding the sixth agent is whatever a new directory and a new branch costs, which is to say, nothing.
+
+## A real example
+
+Suppose you want a Claude Code agent writing documentation and a Codex agent writing tests, both on the same repo, both committing without stepping on each other. From the host you start the sandbox once:
+
+```bash
+openharness sandbox up
+```
+
+Inside the sandbox you create two worktrees, one per agent:
+
+```bash
+oh worktree feat/docs    # cuts .worktrees/feat/docs from development
+oh worktree feat/tests   # cuts .worktrees/feat/tests from development
+```
+
+Each worktree comes with the workspace template — an `AGENTS.md` you edit to give that agent its operating rules, a `SOUL.md` for personality, a `MEMORY.md` it will write to as it works. You launch the agents in their own tmux sessions so they survive disconnects:
+
+```bash
+tmux new-session -d -s agent-docs  -c .worktrees/feat/docs  'claude'
+tmux new-session -d -s agent-tests -c .worktrees/feat/tests 'codex'
+```
+
+Two agents, two branches, one container. Claude opens files under `.worktrees/feat/docs/` and commits to `feat/docs`. Codex does the same under `feat/tests`. They never see each other's working files. When they push, two separate PRs land on GitHub. You can attach to either tmux session at any time, watch the agent work, detach, and walk away. You could run five Claudes and five Codexes the same way — ten worktrees, ten branches, one bill. The constraint is your CPU, not your billing page.
+
+Heartbeats per worktree fire independently. Drop a `heartbeats/nightly-release.md` into the docs worktree and only the docs agent runs it. The tests worktree has its own `heartbeats/` directory and its own schedule. No global cron file to coordinate.
+
+## The honest tradeoffs
+
+What worktree-per-agent does **not** solve: concurrent writes to non-git state. Two agents installing different versions of the same npm package into a shared `node_modules` will fight. We handle that with per-worktree `node_modules` (a symlink dance, or just a plain `pnpm install` per worktree) — the disk cost is trivial because the pnpm store is shared, and most installs are hardlinks. If your toolchain has its own global cache (Cargo, Go modules, Maven), the same logic applies: shared store, per-worktree resolution.
+
+The other thing it does not solve is genuinely incompatible toolchains. If one agent needs Node 18 and another needs Node 22, you are back to multiple containers. We have not hit that yet — most coding agents are happy on the same Node — but it is the obvious cliff.
+
+## Try it
+
+The whole pattern lives in [open-harness](https://github.com/ryaneggz/open-harness). Clone it, run `openharness sandbox up`, run `oh worktree my-first-agent`, and you have your first isolated agent workspace in under a minute. The full walkthrough is in the [docs](/), and the companion piece on the wider design — [Bring Your Own Harness](/blog/byoh) — dropped Tuesday and explains why the harness itself is a project worth owning, not a SaaS to rent.
+
+If you have been hesitating because you assumed multi-agent setups were expensive, they are not. They are one container and a few `git worktree add` commands away.

--- a/docs/public/blog/worktree-per-agent-og.SPEC.md
+++ b/docs/public/blog/worktree-per-agent-og.SPEC.md
@@ -1,0 +1,67 @@
+# OG Image Spec — Worktree Per Agent
+
+Target file: `docs/public/blog/worktree-per-agent-og.png`
+Status: NOT YET GENERATED — maintainer supplies offline before Wednesday publish.
+
+## Dimensions
+
+- 1200 x 630 px (Open Graph standard, also valid for Twitter `summary_large_image`)
+- PNG, sRGB, < 300 KB
+
+## Layout
+
+Three-column visual showing the core idea: one container, many worktrees, one agent per worktree.
+
+```
++------------------------------------------------------------+
+|  [oh sandbox container]                                    |
+|       |                                                    |
+|   .worktrees/                                              |
+|     +---- feat/docs   -> Claude Code   -> push feat/docs   |
+|     +---- feat/tests  -> Codex         -> push feat/tests  |
+|     +---- review/all  -> Pi            -> push review/all  |
+|                                                            |
+|  ONE WORKTREE PER AGENT                                    |
+|  oh.mifune.dev/blog/worktree-per-agent                     |
++------------------------------------------------------------+
+```
+
+A simplified version of the in-post Mermaid diagram is fine — drop the
+heartbeat scheduler and any decorative arrows so it reads at thumbnail size.
+
+## Typography
+
+- Title: "ONE WORKTREE PER AGENT" — bold sans-serif (Inter / Space Grotesk),
+  ~72 px, white on dark bg
+- Sub-line: "$40/mo per agent? No. One container. Many worktrees." —
+  ~32 px, muted gray
+- URL: bottom right, monospace, ~24 px
+
+## Color Palette
+
+Match Open Harness brand:
+
+- Background: `#0a0a0a` (near-black)
+- Primary text: `#ffffff`
+- Accent (boxes / arrows): `#7c3aed` (Open Harness purple)
+- Muted: `#a1a1aa`
+- Code / mono: `#34d399` (mint green) for branch names
+
+## Logo
+
+Bottom-left: Open Harness logomark (16 px from edge), 48 px tall.
+Asset: `docs/public/icon.svg`.
+
+## Variants
+
+Optional twitter-only variant at 1600 x 900 if a higher-res share card
+is wanted — same composition, scaled.
+
+## Verification
+
+Once generated:
+
+1. Drop into `docs/public/blog/worktree-per-agent-og.png`
+2. Confirm `frontmatter.ogImage: /blog/worktree-per-agent-og.png` resolves
+3. Test render at https://www.opengraph.xyz/url/<url-encoded-canonical>
+4. Test Twitter card at https://cards-dev.twitter.com/validator


### PR DESCRIPTION
Closes #145.

> **STAGED — DO NOT PUBLISH UNTIL WED 9AM ET**
> Frontmatter has `draft: true`. Maintainer flips to `draft: false`,
> uncomments the `worktree-per-agent` line in `docs/pages/blog/_meta.js`,
> and runs the cross-post sequence below on Wednesday.
>
> **Stacked on #146** (`task/143-blog-scaffold` → `development`).
> When #146 merges, GitHub will auto-retarget this PR's base to `development`.

## Summary

- Drafts `docs/pages/blog/worktree-per-agent.mdx` (~1208 words, target 1100–1350) — the deeper, more technical of the two launch-week posts. Hook is `$40/mo per agent → one container, many worktrees`.
- Embeds a Mermaid diagram showing one container → N worktrees in `.worktrees/` → one agent per worktree (each with its own `AGENTS.md` / `SOUL.md` / `MEMORY.md` / heartbeats), with the heartbeat scheduler fanning out per worktree.
- Walks through a real example (Claude Code on `feat/docs` + Codex on `feat/tests` in tmux sessions, same container, no collisions) and is honest about tradeoffs (per-worktree `node_modules`, incompatible toolchains).
- Adds `docs/public/blog/worktree-per-agent-og.SPEC.md` (1200×630 brand-palette card; PNG generated by maintainer offline).
- CHANGELOG entry under `## [Unreleased]` → `### Added`.
- `docs/pages/blog/_meta.js` is intentionally **not** modified — the `worktree-per-agent` slug is already commented in the scaffold and the maintainer uncomments it at publish.

## Word count

```
$ wc -w docs/pages/blog/worktree-per-agent.mdx
1208 docs/pages/blog/worktree-per-agent.mdx
```

---

## Cross-post drafts (maintainer publishes Wed 9–11am ET)

### 1. dev.to

```yaml
---
title: One Worktree Per Agent
published: false
description: We tried one container per agent. It cost $40/month per agent. Here is what we did instead — one container, many git worktrees, full isolation, one bill.
tags: ai, devops, docker, git
canonical_url: https://oh.mifune.dev/blog/worktree-per-agent
cover_image: https://oh.mifune.dev/blog/worktree-per-agent-og.png
---
```

Body: paste full MDX prose, strip frontmatter, replace the Mermaid block with a rendered PNG export (or a static ASCII fallback) since dev.to does not natively render Mermaid in posts marked `published: false` previews.

### 2. X / Twitter thread (10 tweets)

> 1/ We tried one-container-per-agent.
>
> It cost $40/mo per agent. (5 agents × $8/mo VPS.)
>
> Here is what we did instead. 🧵

> 2/ The hidden cost wasn't the $40.
>
> It was: 5 copies of the toolchain. 5 npm caches. 5 Docker image pulls. 5 places to keep in sync.
>
> When everything is "isolated," nothing is shared. Friction compounds.

> 3/ So what do agents actually need from each other?
>
> Two things:
> – a separate branch
> – separate working state
>
> They do NOT need separate kernels, separate package managers, or separate Docker daemons.

> 4/ Git already solves "separate branch + separate working tree" cheaply.
>
> It is called `git worktree`.
>
> One repo. N working directories. Shared object store. Each tree on a different branch with its own index.

> 5/ So the design fell out:
>
> 1 container.
> N worktrees.
> 1 agent per worktree.
>
> Isolation where it matters. Sharing where it is free.

> 6/ Architecture:
>
> [diagram image — 1200×630 OG card]

> 7/ Real flow:
>
> ```
> openharness sandbox up
> oh worktree feat/docs
> oh worktree feat/tests
> tmux new -s agent-docs  -c .worktrees/feat/docs  'claude'
> tmux new -s agent-tests -c .worktrees/feat/tests 'codex'
> ```
>
> Two agents. Two branches. One container. One bill.

> 8/ Each worktree has its own:
> – AGENTS.md (procedures)
> – SOUL.md (persona)
> – MEMORY.md (running notes)
> – heartbeats/ (per-tree cron)
>
> Same Docker socket, same toolchain, totally separate git state.

> 9/ Honest tradeoff: shared `node_modules` will fight if two agents install conflicting versions.
>
> Fix: per-worktree `pnpm install`. Disk cost is trivial because the pnpm store is shared (hardlinks).

> 10/ Full write-up + the harness itself:
>
> https://oh.mifune.dev/blog/worktree-per-agent
> https://github.com/ryaneggz/open-harness
>
> If you have been hesitating because you assumed multi-agent setups were expensive — they are not. One container and a few `git worktree add`s away.

### 3. Show HN

**Title**: `Show HN: One worktree per agent — running 10 Claudes in one container, not ten`

**First comment**:

> Author here. Quick context for HN:
>
> When we started running multiple coding agents in parallel, the obvious move was one container per agent. That ran us about $8/mo on a budget VPS times five agents = $40/mo, plus 5x toolchain duplication, 5x docker image cache, no shared workspace, and constant drift between identical setups. It felt wasteful in a way that grew worse as we added agents.
>
> The fix turned out to be a primitive that has been sitting in git since 2015: `git worktree`. A worktree is a second working directory backed by the same `.git` object store. Different branch, different index, different untracked files — but shared objects.
>
> So we collapsed to: 1 container, N worktrees, 1 agent per worktree. The container handles the toolchain and the docker socket. Each worktree owns a branch, its own AGENTS.md / SOUL.md / MEMORY.md, and its own heartbeat schedule. Agents share the Docker socket but not git state. Marginal cost of agent N+1 is one `git worktree add`.
>
> The post walks through a real example (Claude Code + Codex in the same container committing to separate branches without stepping on each other) and is honest about what this does NOT solve (concurrent writes to non-git state like `node_modules`, incompatible toolchains).
>
> The harness is open source: https://github.com/ryaneggz/open-harness — would love feedback from people running similar multi-agent setups, especially what their isolation cliff looks like.

### 4. r/ClaudeAI (text post — NOT link)

**Title**: `Running 5+ Claude Code instances on one VPS using git worktrees (write-up + diagram)`

**Body**:

> Spent the last few weeks figuring out how to run multiple Claude Code agents in parallel without paying for one VPS per agent. Sharing what worked.
>
> **The expensive way (what we tried first)**: one container per agent. ~$8/mo per agent on a budget VPS. Five agents = $40/mo. Plus you maintain five copies of the toolchain, five Docker image caches, five npm stores, all of which drift over time.
>
> **The cheap way (what we landed on)**: one container, many git worktrees. Each agent gets its own worktree (its own branch + its own working directory + its own AGENTS.md / SOUL.md / MEMORY.md / heartbeat schedule), but they share the kernel, the toolchain, and the Docker socket. Marginal cost of adding an agent is approximately zero.
>
> Full write-up with architecture diagram and a worked example (Claude Code on `feat/docs` + Codex on `feat/tests` in the same container, no collisions): https://oh.mifune.dev/blog/worktree-per-agent
>
> Repo (open source): https://github.com/ryaneggz/open-harness
>
> Honest about tradeoffs in the post — `node_modules` collisions and incompatible toolchains are the two cliffs. Curious if anyone here is running a similar setup and what their isolation breakdown looks like.

### 5. LinkedIn (long-form, 400–500 words excerpt + link out)

**Title**: `One Worktree Per Agent: How We Run 10+ Coding Agents on a Single VPS`

**Body** (long-form post):

> We tried one container per agent. It cost $40/month per agent. Here is what we did instead.
>
> When we started running multiple coding agents in parallel — one writing docs, one writing tests, one reviewing PRs — the obvious move was to give each agent its own container. A small VPS that can comfortably host a Claude Code session runs about $8/month on a budget host. Five agents put us at $40/month before we shipped anything. Ten agents was $80.
>
> The cost was the visible part of the problem. The hidden part was worse. Every container had its own `node_modules`, its own pnpm store, its own Docker image cache, its own git object database. A change to a shared dependency meant rebuilding it five times. A new tool installed for one agent had to be reinstalled for the rest, or the agents diverged. We were paying $40/month for the privilege of keeping five identical setups identical.
>
> So we asked: what do agents actually need from each other?
>
> Two things, mostly: a separate branch and separate state. One agent should be able to commit to `feat/docs` while another commits to `feat/tests` without stepping on each other. They should each keep their own memory, their own current task, their own working files.
>
> Notice what is NOT on that list. Agents do not need separate kernels. They do not need separate package managers. They do not need separate Docker daemons. They do not even need separate filesystems — they need separate VIEWS of a filesystem.
>
> Git already solves the "separate branch, separate working tree" problem cheaply. It is called `git worktree`. One repo. N working directories. Shared object store. Each tree on a different branch with its own index.
>
> So the design collapsed: one container, many worktrees, one agent per worktree. The container handles the toolchain and the Docker socket. The worktree handles the branch and the working state. Marginal cost of adding the sixth agent is whatever a new directory and a new branch costs — which is to say, nothing.
>
> Full architecture write-up + diagram + a worked example with Claude Code and Codex sharing a container without collisions: https://oh.mifune.dev/blog/worktree-per-agent
>
> If you have been hesitating because you assumed multi-agent setups were expensive — they are not. They are one container and a few `git worktree add` commands away.
>
> The harness itself is open source: https://github.com/ryaneggz/open-harness

---

## Test plan

- [ ] `pnpm docs:build` succeeds (Mermaid renders, no MDX parse errors)
- [ ] `pnpm docs:preview` shows post at `/open-harness/blog/worktree-per-agent` after maintainer uncomments `_meta.js`
- [ ] Word count: 1208 (within 1100–1350 target)
- [ ] Frontmatter has `draft: true`
- [ ] OG SPEC at `docs/public/blog/worktree-per-agent-og.SPEC.md` describes the card the maintainer must produce before publish