### PR TITLE
FROM task/157-drop-mifune-branding TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - Launch runbook consolidating manual cutover steps (DNS, GH settings, OG validation, GSC, promotion).
 
 ### Changed
-- Rebrand docs domain from `https://ryaneggz.github.io/open-harness/` to `https://oh.mifune.dev/`; default cloudflared tunnel hostname updated from `*.ruska.dev` to `*.mifune.dev`. ([#137](https://github.com/ryaneggz/open-harness/issues/137))
-- Adopt Mifune positioning copy across README, docs landing, and About page (#138).
+- Revert prior secondary product name; "Open Harness" is the sole brand across README, docs, and onboarding ([#157](https://github.com/ryaneggz/open-harness/issues/157)).
+- Cloudflare onboarding step now requires an explicit public hostname (no default domain) ([#157](https://github.com/ryaneggz/open-harness/issues/157)).
 - Slim README to ~110 lines, lead with oh CLI flow (#139).
 - Wiki promoted from `workspace/wiki/` to `docs/wiki/` — same structure (`pages/`, `sources/`, `index.md`, `log.md`), now top-level alongside human-curated docs.
 - 26 docs pages converted from Nextra MDX to plain markdown rendered by GitHub.
@@ -28,7 +28,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - Slack bot no longer drops oversized agent replies with cascading `msg_too_long` errors. Main message is capped at 2,900 chars with a `_message truncated — full response in thread_` footer; full content spills to thread replies; `setWorking(false)` always clears the working indicator. ([#135](https://github.com/ryaneggz/open-harness/issues/135))
 
 ### Removed
-- Nextra docs site (`oh.mifune.dev`) and the `.github/workflows/docs.yml` deployment — documentation is now plain markdown in `docs/`, read in the GitHub UI.
+- Nextra docs site and the `.github/workflows/docs.yml` deployment — documentation is now plain markdown in `docs/`, read in the GitHub UI.
 - Reference Next.js application at `workspace/projects/next-app/`, along with its CI jobs (`workspace/projects/next-app` paths in `ci.yml` / `release.yml`) and the release pre-flight gate referencing it.
 - Root `package.json` scripts: `dev`, `docs:dev`, `docs:build`, `docs:preview`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Mifune Open Harness
+# Open Harness
 
-**Mifune Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
+**Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
 
 - **Worktree-per-agent.** Each agent gets its own branch, its own SOUL, its own schedule.
 - **Agents that work while you sleep.** Cron-driven heartbeats wake them to do real work, autonomously.
@@ -79,7 +79,7 @@ oh clean my-agent
 
 ## 🤝 Contributing & community
 
-Issues and PRs welcome at [github.com/ryaneggz/open-harness](https://github.com/ryaneggz/open-harness). If Mifune Open Harness is useful to you, please [give us a star](https://github.com/ryaneggz/open-harness/stargazers).
+Issues and PRs welcome at [github.com/ryaneggz/open-harness](https://github.com/ryaneggz/open-harness). If Open Harness is useful to you, please [give us a star](https://github.com/ryaneggz/open-harness/stargazers).
 
 ## 📄 License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
 ---
-title: "Mifune Open Harness"
+title: "Open Harness"
 ---
 
-# Mifune Open Harness
+# Open Harness
 
-**Mifune Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
+**Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
 
 - **Worktree-per-agent.** Each agent gets its own branch, its own SOUL, its own schedule.
 - **Agents that work while you sleep.** Cron-driven heartbeats wake them to do real work, autonomously.
@@ -36,7 +36,7 @@ AI coding agents are powerful — but they run with broad system permissions, ex
 - [CLI Reference](./cli/commands.md) — Full command reference
 - [Blog](./blog/README.md) — Engineering notes and deep-dives
 - [Wiki](./wiki/index.md) — Long-form notes and synthesis pages
-- [About](./about.md) — What Open Harness is and where the name comes from
+- [About](./about.md) — What Open Harness is
 - [Launch Runbook](./launch-runbook.md) — Maintainer-only cutover checklist
 
 ## Quick Links
@@ -45,7 +45,3 @@ AI coding agents are powerful — but they run with broad system permissions, ex
 - [Quickstart](./getting-started/quickstart.md) — Start a sandbox in 3 steps
 - [CLI Commands](./cli/commands.md) — Full command reference
 - [Slack Bot](./slack/overview.md) — Connect agents to Slack
-
----
-
-*Named for Captain Mifune — the one who held the gate open.*

--- a/docs/about.md
+++ b/docs/about.md
@@ -4,8 +4,4 @@ title: About
 
 # About
 
-Mifune Open Harness lets you run Claude, Codex, Gemini, and Pi side-by-side from a single `docker compose up`. Each agent gets its own git branch, its own SOUL identity, and its own cron schedule, so they can work independently without stepping on each other. Cron-driven heartbeats wake agents to do real work autonomously while you sleep, and the only host dependency is Docker — no Node, no Python, no toolchain rot on your laptop. Composable infra lets you cherry-pick Postgres, Cloudflare tunnels, SSH, Slack, and the Caddy gateway as you need them.
-
-## The name
-
-*Named for Captain Mifune — the one who held the gate open.*
+Open Harness lets you run Claude, Codex, Gemini, and Pi side-by-side from a single `docker compose up`. Each agent gets its own git branch, its own SOUL identity, and its own cron schedule, so they can work independently without stepping on each other. Cron-driven heartbeats wake agents to do real work autonomously while you sleep, and the only host dependency is Docker — no Node, no Python, no toolchain rot on your laptop. Composable infra lets you cherry-pick Postgres, Cloudflare tunnels, SSH, Slack, and the Caddy gateway as you need them.

--- a/packages/sandbox/src/__tests__/onboard-cloudflare.test.ts
+++ b/packages/sandbox/src/__tests__/onboard-cloudflare.test.ts
@@ -66,7 +66,7 @@ describe("cloudflare step", () => {
     const deps = makeFakeDeps({
       which: { cloudflared: "/usr/bin/cloudflared" },
       files: { "/home/sandbox/.cloudflared/cert.pem": "pem" },
-      askAnswers: ["my-tun", "", ""],
+      askAnswers: ["my-tun", "my-tun.example.com", ""],
       execStubs: [
         {
           match: (cmd) => cmd[0] === "sh" && cmd[2].includes("config-*.yml"),
@@ -84,9 +84,26 @@ describe("cloudflare step", () => {
           cmd[0] === "bash" &&
           cmd[1].endsWith("/install/cloudflared-tunnel.sh") &&
           cmd[2] === "my-tun" &&
-          cmd[3] === "my-tun.mifune.dev" &&
+          cmd[3] === "my-tun.example.com" &&
           cmd[4] === "3000",
       ),
     ).toBe(true);
+  });
+
+  it("empty hostname → failed", async () => {
+    const deps = makeFakeDeps({
+      which: { cloudflared: "/usr/bin/cloudflared" },
+      files: { "/home/sandbox/.cloudflared/cert.pem": "pem" },
+      askAnswers: ["my-tun", ""],
+      execStubs: [
+        {
+          match: (cmd) => cmd[0] === "sh" && cmd[2].includes("config-*.yml"),
+          result: { status: 1, stdout: "", stderr: "" },
+        },
+      ],
+    });
+    const result = await cloudflareStep.run(deps, { force: false });
+    expect(result.status).toBe("failed");
+    expect(ioMessages(deps, "fail").some((m) => m.includes("hostname"))).toBe(true);
   });
 });

--- a/packages/sandbox/src/onboard/steps/cloudflare.ts
+++ b/packages/sandbox/src/onboard/steps/cloudflare.ts
@@ -54,9 +54,11 @@ export const cloudflareStep: Step = {
     io.ok("Cloudflare authenticated");
 
     const tunnelName = (await io.ask("Tunnel name (default: open-harness):")) || "open-harness";
-    const tunnelHost =
-      (await io.ask(`Public hostname (default: ${tunnelName}.mifune.dev):`)) ||
-      `${tunnelName}.mifune.dev`;
+    const tunnelHost = (await io.ask("Public hostname (e.g., my-tunnel.example.com):")).trim();
+    if (!tunnelHost) {
+      io.fail("Public hostname is required");
+      return { id: "cloudflare", status: "failed" };
+    }
     const tunnelPort = (await io.ask("Local port (default: 3000):")) || DEFAULT_PORT;
 
     io.raw("\n");


### PR DESCRIPTION
## Summary

Drops the secondary product-name overlay from README, docs, and onboarding strings. The repo is now uniformly **Open Harness** — no exceptions, no brand-origin footer, no `*.mifune.dev` defaults. Mifune may return as the parent org slug after the project earns more stars; until then every surface should match the GitHub slug `ryaneggz/open-harness` and the package namespace `@openharness/*`.

## Changes

- `README.md`, `docs/README.md`, `docs/about.md`: replace product name; drop `## The name` section and the brand-origin footer
- `CHANGELOG.md` `[Unreleased]`: drop the unshipped rebrand entries; add this PR's revert
- `packages/sandbox/src/onboard/steps/cloudflare.ts`: drop the default tunnel domain — onboarding now requires an explicit public hostname and fails with a clear message if empty
- `packages/sandbox/src/__tests__/onboard-cloudflare.test.ts`: update fixture + assertion; add empty-hostname → failed test

Closes #157

## Test plan

- [x] `pnpm --filter @openharness/sandbox run ci` — lint + format + 397 tests pass
- [x] `pnpm --filter @openharness/sandbox build` — dist regenerates clean
- [x] `rg -ni mifune --no-ignore -g '!node_modules' -g '!.git' -g '!.claude/plans'` returns zero matches
- [x] `grep "name comes from" docs/README.md` returns zero matches
- [ ] CI green on `task/157-drop-mifune-branding`
- [ ] Visual smoke-test of rendered README, docs landing, and About page on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)