### PR TITLE
FROM task/159-readme-docker-only TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- README "Docker only (no installer)" section — concise compose-based deploy path for hosts that have only Docker + git.
 - Per-page OpenGraph + canonical link tags via theme.config.tsx head function ([#140](https://github.com/ryaneggz/open-harness/issues/140)).
 - Blog post draft: Worktree-per-agent — stages for Wed publish ([#145](https://github.com/ryaneggz/open-harness/pull/145)).
 - Blog section at /blog and About page nav entry (#143).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Only host dependency: [Docker](https://docs.docker.com/get-docker/). Add `-s -- 
 
 ## 🚀 Quickstart
 
-The full sandbox lifecycle is three commands:
+Requires the `oh` CLI on your host — install with `-s -- --with-cli` above (Node 20+). The full sandbox lifecycle is three commands:
 
 ```bash
 oh onboard            # one-time: GitHub, LLM, Slack, Claude auth wizard
@@ -37,6 +37,30 @@ Inside the shell, start working:
 claude                # terminal coding agent
 pi                    # automations — Slack, heartbeats, extensions
 ```
+
+## 🐳 Docker only (no installer)
+
+Alternative path for hosts with only Docker + git — no `bash` piping, no Node, no `oh` CLI:
+
+```bash
+git clone https://github.com/ryaneggz/open-harness.git && cd open-harness
+cp .devcontainer/.example.env .devcontainer/.env
+# edit .devcontainer/.env: set GH_TOKEN, optionally rename SANDBOX_NAME,
+# and set INSTALL_AGENT_BROWSER=false unless you need headless Chromium
+docker compose -f .devcontainer/docker-compose.yml up -d --build  # ~10 min on cold cache
+docker compose -f .devcontainer/docker-compose.yml exec -u sandbox sandbox zsh
+```
+
+Inside the sandbox, finish auth and start an agent:
+
+```bash
+gh auth login && gh auth setup-git    # one-time, if GH_TOKEN wasn't set in .env
+claude                                # or: pi, codex, gemini
+```
+
+Cleanup: `docker compose -f .devcontainer/docker-compose.yml down -v`.
+
+For Postgres, Slack, SSH, or the Caddy gateway, chain overlay files with extra `-f` flags — see [Compose overlays](https://github.com/ryaneggz/open-harness/blob/main/docs/guide/overlays.md).
 
 ## ✨ What you get
 


### PR DESCRIPTION
## Summary

- Adds a `## 🐳 Docker only (no installer)` section to the README between Quickstart and "What you get", surfacing the existing compose-based deploy as an inline alternative for hosts with only Docker + git.
- Documents the Quickstart's `oh` CLI prerequisite (Node 20+, install via `--with-cli`) so the easier-but-required-deps path is honest about what it needs.
- Adds CHANGELOG entry under `[Unreleased] › Added`.

The new section uses `docker compose ... exec sandbox` (service name, fixed) instead of `docker exec <container>` so it stays correct regardless of `SANDBOX_NAME`. Includes a follow-up onboarding/agent-launch block so users don't land at a dead shell, and an inline cleanup line.

Closes #159.

## Test plan

- [x] Pre-commit hooks (build + 397 tests) green locally.
- [ ] CI green on push.
- [ ] Smoke test on a clean host (Linux/macOS, Docker + git only):
  - clone repo, `cp .devcontainer/.example.env .devcontainer/.env`, edit values
  - flip `INSTALL_AGENT_BROWSER=false`
  - `docker compose -f .devcontainer/docker-compose.yml up -d --build`
  - `docker compose -f .devcontainer/docker-compose.yml exec -u sandbox sandbox zsh -c 'whoami && which claude'`
  - cleanup: `down -v`
- [ ] README renders cleanly on GitHub (heading hierarchy, code fences, links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
