### PR TITLE
FROM task/161-short-install-url TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - Launch runbook consolidating manual cutover steps (DNS, GH settings, OG validation, GSC, promotion).
 
 ### Changed
+- README and installation docs now use the short `https://oh.mifune.dev/install.sh` URL (302 redirect to the raw GitHub install script on `main`) instead of the long `raw.githubusercontent.com` URL.
 - `/release` now executes the `[Unreleased]` → `[$VERSION]` promotion (was prose-only) and `release.yml` sources the GitHub Release body from the promoted CHANGELOG section via `body_path` instead of `generate_release_notes`, so the GitHub Release notes match the changelog byte-for-byte.
 - Revert prior secondary product name; "Open Harness" is the sole brand across README, docs, and onboarding ([#157](https://github.com/ryaneggz/open-harness/issues/157)).
 - Cloudflare onboarding step now requires an explicit public hostname (no default domain) ([#157](https://github.com/ryaneggz/open-harness/issues/157)).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## 📦 Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ryaneggz/open-harness/refs/heads/main/install.sh | bash
+curl -fsSL https://oh.mifune.dev/install.sh | bash
 ```
 
 Only host dependency: [Docker](https://docs.docker.com/get-docker/). Add `-s -- --with-cli` to also install the `oh` CLI on the host (requires Node 20+).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,7 +8,7 @@ title: "Installation"
 ## One-line install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ryaneggz/open-harness/refs/heads/main/install.sh | bash
+curl -fsSL https://oh.mifune.dev/install.sh | bash
 ```
 
 The installer checks for Docker and git, prompts for a container name and password, clones the repo, and starts the sandbox. No Node.js required.
@@ -18,7 +18,7 @@ The installer checks for Docker and git, prompts for a container name and passwo
 If you want the `openharness` CLI available on your host machine (not just inside the container), pass `--with-cli`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ryaneggz/open-harness/refs/heads/main/install.sh | bash -s -- --with-cli
+curl -fsSL https://oh.mifune.dev/install.sh | bash -s -- --with-cli
 ```
 
 This additionally requires [Node.js 20+](https://nodejs.org/) and builds/links the CLI via pnpm.


### PR DESCRIPTION
## Summary

- Swap README + installation docs to use `https://oh.mifune.dev/install.sh` (Cloudflare Worker → 302 → raw GitHub on `main`)
- CHANGELOG entry under `[Unreleased] / Changed`

The Worker source lives in a private sibling repo (`ryaneggz/cloudflare-workers/oh-redirect/`), not committed here. Source-of-truth (the actual install.sh on `main`) is unchanged.

## Test plan

- [x] `curl -sI https://oh.mifune.dev/install.sh` → `HTTP/2 302` with `Location` pointing at raw GitHub on `main`
- [x] `curl -fsSL https://oh.mifune.dev/install.sh | head` → install script (`#!/usr/bin/env bash`)
- [x] `curl -sI https://oh.mifune.dev/nope` → `HTTP/2 404` (Worker doesn't shadow the zone)
- [x] Public DNS resolves via Google DoH (`104.21.83.243, 172.67.183.153`)
- [x] Pre-commit `pnpm test` — 397/397 passing

Closes #161