### PR TITLE
FROM development TO main

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -39,22 +39,50 @@ If `--dry-run`, report version + pre-flight results and **stop here**.
 
 ### Step 3 — Promote CHANGELOG `[Unreleased]`
 
-Rewrite `CHANGELOG.md` so the `## [Unreleased]` section becomes `## [$VERSION] - $(date '+%Y-%m-%d')` and a fresh empty `[Unreleased]` block is re-seeded above it. If `[Unreleased]` is empty, abort — no user-visible changes means nothing to release (ask the user to confirm before continuing).
+Abort if `## [Unreleased]` has no real entries (only category headers / blank lines):
 
-Template for the re-seeded block:
+```bash
+UNRELEASED_BODY=$(awk '
+  /^## \[Unreleased\]/ { in_block=1; next }
+  in_block && (/^## \[/ || /^---$/) { exit }
+  in_block { print }
+' CHANGELOG.md | grep -vE '^(### |\s*$)')
 
-```markdown
-## [Unreleased]
-
-### Added
-### Changed
-### Fixed
-### Removed
-### Deprecated
-### Security
+if [ -z "$UNRELEASED_BODY" ]; then
+  echo "Aborting: [Unreleased] is empty — nothing user-visible to release." >&2
+  echo "Add changelog entries on this branch (or confirm with the user before continuing)." >&2
+  exit 1
+fi
 ```
 
-Commit the change on the current branch with `task: promote CHANGELOG for $VERSION` before cutting the release branch.
+Promote `[Unreleased]` to `[$VERSION]` and re-seed an empty block above it, then commit on the current branch before cutting the release branch:
+
+```bash
+RELEASE_DATE=$(date '+%Y-%m-%d')
+
+awk -v ver="$VERSION" -v rdate="$RELEASE_DATE" '
+  /^## \[Unreleased\]$/ && !done {
+    print "## [Unreleased]"
+    print ""
+    print "### Added"
+    print "### Changed"
+    print "### Fixed"
+    print "### Removed"
+    print "### Deprecated"
+    print "### Security"
+    print ""
+    print "## [" ver "] - " rdate
+    done=1
+    next
+  }
+  { print }
+' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+
+git add CHANGELOG.md
+git commit -m "task: promote CHANGELOG for $VERSION"
+```
+
+The `[$VERSION]` section is the source of truth for the GitHub Release body — `release.yml` extracts it via `body_path` (no `generate_release_notes`).
 
 ### Step 4 — Push release branch + tag
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,22 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${{ steps.parse.outputs.version }}"
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          awk -v ver="$VERSION" '
+            $0 ~ ("^## \\[" ver "\\] - ") { in_block=1; next }
+            in_block && /^## \[/ { exit }
+            in_block && /^---[[:space:]]*$/ { exit }
+            in_block { print }
+          ' CHANGELOG.md > "$NOTES_FILE"
+          if [ ! -s "$NOTES_FILE" ] || ! grep -q '[^[:space:]]' "$NOTES_FILE"; then
+            echo "Release $VERSION — see CHANGELOG.md and commit history." > "$NOTES_FILE"
+          fi
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node 22.x
         uses: actions/setup-node@v4
         with:
@@ -55,4 +71,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: v${{ steps.parse.outputs.version }}
-          generate_release_notes: true
+          body_path: ${{ steps.notes.outputs.notes_file }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - Launch runbook consolidating manual cutover steps (DNS, GH settings, OG validation, GSC, promotion).
 
 ### Changed
+- `/release` now executes the `[Unreleased]` → `[$VERSION]` promotion (was prose-only) and `release.yml` sources the GitHub Release body from the promoted CHANGELOG section via `body_path` instead of `generate_release_notes`, so the GitHub Release notes match the changelog byte-for-byte.
 - Revert prior secondary product name; "Open Harness" is the sole brand across README, docs, and onboarding ([#157](https://github.com/ryaneggz/open-harness/issues/157)).
 - Cloudflare onboarding step now requires an explicit public hostname (no default domain) ([#157](https://github.com/ryaneggz/open-harness/issues/157)).
 - Slim README to ~110 lines, lead with oh CLI flow (#139).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - Launch runbook consolidating manual cutover steps (DNS, GH settings, OG validation, GSC, promotion).
 
 ### Changed
+- README and installation docs now use the short `https://oh.mifune.dev/install.sh` URL (302 redirect to the raw GitHub install script on `main`) instead of the long `raw.githubusercontent.com` URL.
 - `/release` now executes the `[Unreleased]` → `[$VERSION]` promotion (was prose-only) and `release.yml` sources the GitHub Release body from the promoted CHANGELOG section via `body_path` instead of `generate_release_notes`, so the GitHub Release notes match the changelog byte-for-byte.
 - Revert prior secondary product name; "Open Harness" is the sole brand across README, docs, and onboarding ([#157](https://github.com/ryaneggz/open-harness/issues/157)).
 - Cloudflare onboarding step now requires an explicit public hostname (no default domain) ([#157](https://github.com/ryaneggz/open-harness/issues/157)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- README "Docker only (no installer)" section — concise compose-based deploy path for hosts that have only Docker + git.
 - Per-page OpenGraph + canonical link tags via theme.config.tsx head function ([#140](https://github.com/ryaneggz/open-harness/issues/140)).
 - Blog post draft: Worktree-per-agent — stages for Wed publish ([#145](https://github.com/ryaneggz/open-harness/pull/145)).
 - Blog section at /blog and About page nav entry (#143).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - Launch runbook consolidating manual cutover steps (DNS, GH settings, OG validation, GSC, promotion).
 
 ### Changed
-- Rebrand docs domain from `https://ryaneggz.github.io/open-harness/` to `https://oh.mifune.dev/`; default cloudflared tunnel hostname updated from `*.ruska.dev` to `*.mifune.dev`. ([#137](https://github.com/ryaneggz/open-harness/issues/137))
-- Adopt Mifune positioning copy across README, docs landing, and About page (#138).
+- Revert prior secondary product name; "Open Harness" is the sole brand across README, docs, and onboarding ([#157](https://github.com/ryaneggz/open-harness/issues/157)).
+- Cloudflare onboarding step now requires an explicit public hostname (no default domain) ([#157](https://github.com/ryaneggz/open-harness/issues/157)).
 - Slim README to ~110 lines, lead with oh CLI flow (#139).
 - Wiki promoted from `workspace/wiki/` to `docs/wiki/` — same structure (`pages/`, `sources/`, `index.md`, `log.md`), now top-level alongside human-curated docs.
 - 26 docs pages converted from Nextra MDX to plain markdown rendered by GitHub.
@@ -28,7 +28,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - Slack bot no longer drops oversized agent replies with cascading `msg_too_long` errors. Main message is capped at 2,900 chars with a `_message truncated — full response in thread_` footer; full content spills to thread replies; `setWorking(false)` always clears the working indicator. ([#135](https://github.com/ryaneggz/open-harness/issues/135))
 
 ### Removed
-- Nextra docs site (`oh.mifune.dev`) and the `.github/workflows/docs.yml` deployment — documentation is now plain markdown in `docs/`, read in the GitHub UI.
+- Nextra docs site and the `.github/workflows/docs.yml` deployment — documentation is now plain markdown in `docs/`, read in the GitHub UI.
 - Reference Next.js application at `workspace/projects/next-app/`, along with its CI jobs (`workspace/projects/next-app` paths in `ci.yml` / `release.yml`) and the release pre-flight gate referencing it.
 - Root `package.json` scripts: `dev`, `docs:dev`, `docs:build`, `docs:preview`.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Only host dependency: [Docker](https://docs.docker.com/get-docker/). Add `-s -- 
 
 ## 🚀 Quickstart
 
-The full sandbox lifecycle is three commands:
+Requires the `oh` CLI on your host — install with `-s -- --with-cli` above (Node 20+). The full sandbox lifecycle is three commands:
 
 ```bash
 oh onboard            # one-time: GitHub, LLM, Slack, Claude auth wizard
@@ -37,6 +37,30 @@ Inside the shell, start working:
 claude                # terminal coding agent
 pi                    # automations — Slack, heartbeats, extensions
 ```
+
+## 🐳 Docker only (no installer)
+
+Alternative path for hosts with only Docker + git — no `bash` piping, no Node, no `oh` CLI:
+
+```bash
+git clone https://github.com/ryaneggz/open-harness.git && cd open-harness
+cp .devcontainer/.example.env .devcontainer/.env
+# edit .devcontainer/.env: set GH_TOKEN, optionally rename SANDBOX_NAME,
+# and set INSTALL_AGENT_BROWSER=false unless you need headless Chromium
+docker compose -f .devcontainer/docker-compose.yml up -d --build  # ~10 min on cold cache
+docker compose -f .devcontainer/docker-compose.yml exec -u sandbox sandbox zsh
+```
+
+Inside the sandbox, finish auth and start an agent:
+
+```bash
+gh auth login && gh auth setup-git    # one-time, if GH_TOKEN wasn't set in .env
+claude                                # or: pi, codex, gemini
+```
+
+Cleanup: `docker compose -f .devcontainer/docker-compose.yml down -v`.
+
+For Postgres, Slack, SSH, or the Caddy gateway, chain overlay files with extra `-f` flags — see [Compose overlays](https://github.com/ryaneggz/open-harness/blob/main/docs/guide/overlays.md).
 
 ## ✨ What you get
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## 📦 Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ryaneggz/open-harness/refs/heads/main/install.sh | bash
+curl -fsSL https://oh.mifune.dev/install.sh | bash
 ```
 
 Only host dependency: [Docker](https://docs.docker.com/get-docker/). Add `-s -- --with-cli` to also install the `oh` CLI on the host (requires Node 20+).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Mifune Open Harness
+# Open Harness
 
-**Mifune Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
+**Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
 
 - **Worktree-per-agent.** Each agent gets its own branch, its own SOUL, its own schedule.
 - **Agents that work while you sleep.** Cron-driven heartbeats wake them to do real work, autonomously.
@@ -79,7 +79,7 @@ oh clean my-agent
 
 ## 🤝 Contributing & community
 
-Issues and PRs welcome at [github.com/ryaneggz/open-harness](https://github.com/ryaneggz/open-harness). If Mifune Open Harness is useful to you, please [give us a star](https://github.com/ryaneggz/open-harness/stargazers).
+Issues and PRs welcome at [github.com/ryaneggz/open-harness](https://github.com/ryaneggz/open-harness). If Open Harness is useful to you, please [give us a star](https://github.com/ryaneggz/open-harness/stargazers).
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Harness
+# 🏗️ Open Harness
 
 **Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
 ---
-title: "Mifune Open Harness"
+title: "Open Harness"
 ---
 
-# Mifune Open Harness
+# Open Harness
 
-**Mifune Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
+**Open Harness** — run Claude, Codex, Gemini, and Pi side-by-side from one `docker compose up`. Each agent gets its own branch, its own SOUL, its own schedule.
 
 - **Worktree-per-agent.** Each agent gets its own branch, its own SOUL, its own schedule.
 - **Agents that work while you sleep.** Cron-driven heartbeats wake them to do real work, autonomously.
@@ -36,7 +36,7 @@ AI coding agents are powerful — but they run with broad system permissions, ex
 - [CLI Reference](./cli/commands.md) — Full command reference
 - [Blog](./blog/README.md) — Engineering notes and deep-dives
 - [Wiki](./wiki/index.md) — Long-form notes and synthesis pages
-- [About](./about.md) — What Open Harness is and where the name comes from
+- [About](./about.md) — What Open Harness is
 - [Launch Runbook](./launch-runbook.md) — Maintainer-only cutover checklist
 
 ## Quick Links
@@ -45,7 +45,3 @@ AI coding agents are powerful — but they run with broad system permissions, ex
 - [Quickstart](./getting-started/quickstart.md) — Start a sandbox in 3 steps
 - [CLI Commands](./cli/commands.md) — Full command reference
 - [Slack Bot](./slack/overview.md) — Connect agents to Slack
-
----
-
-*Named for Captain Mifune — the one who held the gate open.*

--- a/docs/about.md
+++ b/docs/about.md
@@ -4,8 +4,4 @@ title: About
 
 # About
 
-Mifune Open Harness lets you run Claude, Codex, Gemini, and Pi side-by-side from a single `docker compose up`. Each agent gets its own git branch, its own SOUL identity, and its own cron schedule, so they can work independently without stepping on each other. Cron-driven heartbeats wake agents to do real work autonomously while you sleep, and the only host dependency is Docker — no Node, no Python, no toolchain rot on your laptop. Composable infra lets you cherry-pick Postgres, Cloudflare tunnels, SSH, Slack, and the Caddy gateway as you need them.
-
-## The name
-
-*Named for Captain Mifune — the one who held the gate open.*
+Open Harness lets you run Claude, Codex, Gemini, and Pi side-by-side from a single `docker compose up`. Each agent gets its own git branch, its own SOUL identity, and its own cron schedule, so they can work independently without stepping on each other. Cron-driven heartbeats wake agents to do real work autonomously while you sleep, and the only host dependency is Docker — no Node, no Python, no toolchain rot on your laptop. Composable infra lets you cherry-pick Postgres, Cloudflare tunnels, SSH, Slack, and the Caddy gateway as you need them.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,7 +8,7 @@ title: "Installation"
 ## One-line install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ryaneggz/open-harness/refs/heads/main/install.sh | bash
+curl -fsSL https://oh.mifune.dev/install.sh | bash
 ```
 
 The installer checks for Docker and git, prompts for a container name and password, clones the repo, and starts the sandbox. No Node.js required.
@@ -18,7 +18,7 @@ The installer checks for Docker and git, prompts for a container name and passwo
 If you want the `openharness` CLI available on your host machine (not just inside the container), pass `--with-cli`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ryaneggz/open-harness/refs/heads/main/install.sh | bash -s -- --with-cli
+curl -fsSL https://oh.mifune.dev/install.sh | bash -s -- --with-cli
 ```
 
 This additionally requires [Node.js 20+](https://nodejs.org/) and builds/links the CLI via pnpm.

--- a/packages/sandbox/src/__tests__/onboard-cloudflare.test.ts
+++ b/packages/sandbox/src/__tests__/onboard-cloudflare.test.ts
@@ -66,7 +66,7 @@ describe("cloudflare step", () => {
     const deps = makeFakeDeps({
       which: { cloudflared: "/usr/bin/cloudflared" },
       files: { "/home/sandbox/.cloudflared/cert.pem": "pem" },
-      askAnswers: ["my-tun", "", ""],
+      askAnswers: ["my-tun", "my-tun.example.com", ""],
       execStubs: [
         {
           match: (cmd) => cmd[0] === "sh" && cmd[2].includes("config-*.yml"),
@@ -84,9 +84,26 @@ describe("cloudflare step", () => {
           cmd[0] === "bash" &&
           cmd[1].endsWith("/install/cloudflared-tunnel.sh") &&
           cmd[2] === "my-tun" &&
-          cmd[3] === "my-tun.mifune.dev" &&
+          cmd[3] === "my-tun.example.com" &&
           cmd[4] === "3000",
       ),
     ).toBe(true);
+  });
+
+  it("empty hostname → failed", async () => {
+    const deps = makeFakeDeps({
+      which: { cloudflared: "/usr/bin/cloudflared" },
+      files: { "/home/sandbox/.cloudflared/cert.pem": "pem" },
+      askAnswers: ["my-tun", ""],
+      execStubs: [
+        {
+          match: (cmd) => cmd[0] === "sh" && cmd[2].includes("config-*.yml"),
+          result: { status: 1, stdout: "", stderr: "" },
+        },
+      ],
+    });
+    const result = await cloudflareStep.run(deps, { force: false });
+    expect(result.status).toBe("failed");
+    expect(ioMessages(deps, "fail").some((m) => m.includes("hostname"))).toBe(true);
   });
 });

--- a/packages/sandbox/src/onboard/steps/cloudflare.ts
+++ b/packages/sandbox/src/onboard/steps/cloudflare.ts
@@ -54,9 +54,11 @@ export const cloudflareStep: Step = {
     io.ok("Cloudflare authenticated");
 
     const tunnelName = (await io.ask("Tunnel name (default: open-harness):")) || "open-harness";
-    const tunnelHost =
-      (await io.ask(`Public hostname (default: ${tunnelName}.mifune.dev):`)) ||
-      `${tunnelName}.mifune.dev`;
+    const tunnelHost = (await io.ask("Public hostname (e.g., my-tunnel.example.com):")).trim();
+    if (!tunnelHost) {
+      io.fail("Public hostname is required");
+      return { id: "cloudflare", status: "failed" };
+    }
     const tunnelPort = (await io.ask("Local port (default: 3000):")) || DEFAULT_PORT;
 
     io.raw("\n");

--- a/workspace/memory/2026-04-26.md
+++ b/workspace/memory/2026-04-26.md
@@ -1,0 +1,8 @@
+# 2026-04-26
+
+## nightly-release heartbeat — 05:55 UTC
+- **Result**: NO-OP (release already in flight)
+- **Item**: tag `2026.4.25` already pushed at 05:52Z by another actor; release workflow (run 24949542649) building Docker image
+- **Action**: skipped /release; verified release/2026.4.25 worktree, tag, and in-progress CI
+- **Duration**: ~60s
+- **Observation**: "Build Open Harness" workflow failed at GHCR login (`Password required`) — separate from "Release" workflow which authenticated fine. Build workflow may have a missing/broken secret; investigate next session if the failure persists. Also: nightly-release heartbeat runs from worktree HEAD (not main), so `git describe --tags` returned `2026.4.24` and reported "2 new commits" — misleading. Heartbeat should fetch and check `origin/main..HEAD` of the actual release source branch, not the worktree's branch.


### PR DESCRIPTION
## Summary

Routine sync of `development` into `main`. Catches `main` up with all merged work since #156.

## Commits included

- 9cc09b4 task: short install URL via oh.mifune.dev (#162)
- 94d7898 task: /release auto-promotes CHANGELOG and uses it as Release body
- ce2bb42 task: add docker-only setup section to README (#160)
- ea55406 Change project title and add emoji
- ca2d439 task: drop secondary product name; product is "Open Harness" (#157)

## Test plan

All commits already merged into `development` via individual PRs that ran their own checks. This PR is a fast-forward-equivalent sync — no new content beyond what's already on `development`.

- [x] `git diff origin/development...origin/main` is empty (main has no unique content)