### PR TITLE
FROM bug/183-install-silent-exit TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - 26 docs pages converted from Nextra MDX to plain markdown rendered by GitHub.
 
 ### Fixed
+- `install.sh` no longer silently exits when sourcing a pre-existing `~/.nvm/nvm.sh` under `set -euo pipefail`. nvm + corepack calls are bracketed with relaxed strict mode and explicit `$?` checks, an `ERR` trap surfaces unexpected failures with the failing command and line, and pnpm is pinned to `10.33.0` (matches `package.json#packageManager`) instead of resolving `pnpm@latest` over the network on every install.
 - Slack bot no longer drops oversized agent replies with cascading `msg_too_long` errors. Main message is capped at 2,900 chars with a `_message truncated — full response in thread_` footer; full content spills to thread replies; `setWorking(false)` always clears the working indicator. ([#135](https://github.com/ryaneggz/open-harness/issues/135))
 
 ### Removed

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Surface silent set -e exits — without this, any non-zero return mid-script
+# kills bash with no `ERROR:` line and the user is left staring at a prompt
+# wondering why install bailed.
+trap 'printf "\n\033[0;31mERROR:\033[0m install.sh aborted (exit %s) at line %s: %s\n" "$?" "$LINENO" "$BASH_COMMAND" >&2' ERR
+
 # ─── Colours / helpers ───────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
 banner() { printf "\n${CYAN}==> %s${NC}\n" "$*"; }
@@ -117,20 +122,42 @@ install_nvm() {
     ok "nvm $NVM_VERSION installed (SHA-256 verified)"
   fi
 
+  # nvm.sh and nvm's internal helpers are NOT strict-mode safe — they `return 1`
+  # on intentional branches, source unset vars (set -u), and run pipelines whose
+  # middle commands fail under pipefail. Bracket: relax strict mode for the nvm
+  # surface, restore immediately after, then check $? explicitly.
+  set +euo pipefail
   # shellcheck disable=SC1090,SC1091
   . "$NVM_DIR/nvm.sh"
-  if ! command -v nvm >/dev/null 2>&1; then
-    die "nvm sourced but 'nvm' is not on PATH. Aborting before nvm install. Try: 'source ~/.bashrc' and re-run."
+  __nvm_install_rc=0
+  if command -v nvm >/dev/null 2>&1; then
+    nvm install "$NODE_LTS_MAJOR"
+    __nvm_install_rc=$?
+    nvm alias default "$NODE_LTS_MAJOR"
+  else
+    __nvm_install_rc=127
   fi
+  set -euo pipefail
 
-  nvm install "$NODE_LTS_MAJOR" --lts
-  nvm alias default "$NODE_LTS_MAJOR"
+  if [ "$__nvm_install_rc" = 127 ]; then
+    die "nvm sourced but 'nvm' is not on PATH. Try: 'source ~/.bashrc' and re-run."
+  elif [ "$__nvm_install_rc" -ne 0 ]; then
+    die "nvm install $NODE_LTS_MAJOR failed (exit $__nvm_install_rc). If your existing ~/.nvm is from an older release, try: rm -rf ~/.nvm && re-run install.sh. For verbose output: bash -x install.sh."
+  fi
+  unset __nvm_install_rc
   ok "Node $(node --version) installed via nvm"
 
-  # Order matters: corepack runs in the nvm-managed Node context, never against
-  # system Node (which often needs sudo for global pnpm install).
+  # corepack invokes npm helpers that under set -e/pipefail can propagate
+  # transient pnpm registry hiccups as fatal. Same bracket pattern. Pin pnpm
+  # to package.json#packageManager — `pnpm@latest` is a network resolve every
+  # install + drift risk.
+  set +eu
   corepack enable
-  corepack prepare pnpm@latest --activate
+  corepack prepare pnpm@10.33.0 --activate
+  set -euo pipefail
+  if ! command -v pnpm >/dev/null 2>&1; then
+    die "pnpm not on PATH after 'corepack prepare'. Check that ~/.nvm shims are loaded."
+  fi
   ok "pnpm $(pnpm --version) — enabled via corepack"
 
   # Re-detect to verify the install actually produced a usable Node 20+.
@@ -434,7 +461,7 @@ if [ "$INSTALL_MODE" = "cli" ] || [ "$INSTALL_MODE" = "node-then-cli" ]; then
     ok "pnpm $(pnpm --version) — already installed"
   elif command -v corepack >/dev/null 2>&1; then
     corepack enable
-    corepack prepare pnpm@latest --activate
+    corepack prepare pnpm@10.33.0 --activate
     ok "pnpm $(pnpm --version) — enabled via corepack"
   else
     npm install -g pnpm


### PR DESCRIPTION
## Summary

Fixes the silent-exit bug introduced by PR #176 when running `install.sh` on hosts with a pre-existing `~/.nvm` directory.

- **Bracket nvm + corepack with relaxed strict mode** — `set +euo pipefail` around `. nvm.sh`, `nvm install`, `nvm alias`, `corepack enable`, `corepack prepare`; restored before any `die()`. Captures `$?` explicitly so failures still surface.
- **`ERR` trap** — new top-of-script trap prints `exit code, line, BASH_COMMAND` so future silent `set -e` exits stop being silent.
- **Pin pnpm to `10.33.0`** — matches `package.json#packageManager`. Replaces `pnpm@latest` (network resolve every run + spec drift) in both the nvm and CLI fallback paths.
- **Drop redundant `--lts` qualifier** — `nvm install 22` (Node 22 is already an LTS line; the qualifier was buggy on some nvm versions).

Closes #183

## Test plan

- [x] `bash -n install.sh` passes locally
- [x] `shellcheck install.sh` introduces zero new warnings (16 pre-existing SC2059 info-level untouched)
- [x] ERR-trap diagnostic verified with a synthetic `false`: `ERROR: install.sh aborted (exit 1) at line 6: false`
- [x] Pre-commit hook: full sandbox build + 397 tests pass
- [ ] Manual repro on a fresh Ubuntu host with pre-existing `~/.nvm` → install completes end-to-end (CLI built + linked, `oh --version` works)
- [ ] Manual repro on a fresh Ubuntu host with no nvm → nvm fresh-download path still works
- [ ] `--docker-only` regression check (skips `install_nvm` entirely)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)