### PR TITLE
FROM hotfix/install-pnpm-home TO main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - 26 docs pages converted from Nextra MDX to plain markdown rendered by GitHub.
 
 ### Fixed
+- `install.sh` bootstraps `PNPM_HOME` before `pnpm link --global` so the CLI install no longer dies with `ERR_PNPM_NO_GLOBAL_BIN_DIR` on fresh nvm-installed Node. Runs `pnpm setup` (writes `PNPM_HOME` export to `~/.bashrc` + `~/.zshrc`) and also exports `PNPM_HOME`/`PATH` inline so the link step succeeds in the current shell regardless of rc state.
 - `install.sh` no longer silently exits when sourcing a pre-existing `~/.nvm/nvm.sh` under `set -euo pipefail`. nvm + corepack calls are bracketed with relaxed strict mode and explicit `$?` checks, an `ERR` trap surfaces unexpected failures with the failing command and line, and pnpm is pinned to `10.33.0` (matches `package.json#packageManager`) instead of resolving `pnpm@latest` over the network on every install.
 - Slack bot no longer drops oversized agent replies with cascading `msg_too_long` errors. Main message is capped at 2,900 chars with a `_message truncated — full response in thread_` footer; full content spills to thread replies; `setWorking(false)` always clears the working indicator. ([#135](https://github.com/ryaneggz/open-harness/issues/135))
 

--- a/install.sh
+++ b/install.sh
@@ -470,6 +470,24 @@ if [ "$INSTALL_MODE" = "cli" ] || [ "$INSTALL_MODE" = "node-then-cli" ]; then
 
   pnpm install
   pnpm -r run build
+
+  # `pnpm link --global` writes a symlink into pnpm's global bin directory.
+  # Fresh nvm-installed Node has no PNPM_HOME, so the link step dies with
+  # ERR_PNPM_NO_GLOBAL_BIN_DIR. `pnpm setup` is the supported bootstrap:
+  # it creates $PNPM_HOME, configures global-bin-dir, and writes the
+  # PNPM_HOME export into ~/.bashrc (+ ~/.zshrc) for future shells. Modern
+  # pnpm runs it non-interactively. We also export PATH/PNPM_HOME inline
+  # so `pnpm link --global` works in *this* shell regardless of rc state.
+  export SHELL="${SHELL:-/bin/bash}"
+  pnpm setup >/dev/null 2>&1 || warn "pnpm setup returned non-zero — falling back to manual PNPM_HOME bootstrap."
+  export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+  mkdir -p "$PNPM_HOME"
+  case ":$PATH:" in
+    *":$PNPM_HOME:"*) ;;
+    *) export PATH="$PNPM_HOME:$PATH" ;;
+  esac
+  pnpm config set global-bin-dir "$PNPM_HOME" >/dev/null 2>&1 || true
+
   pnpm link --global ./packages/sandbox
   ok "openharness CLI built and linked"
 


### PR DESCRIPTION
## Summary

Hotfix to `main` so `oh.mifune.dev/install.sh` completes the CLI build on fresh nvm-installed Node. The previous hotfix (PR #185) added the `ERR` trap that surfaced this exact failure:

```
ERR_PNPM_NO_GLOBAL_BIN_DIR  Unable to find the global bin directory

ERROR: install.sh aborted (exit 1) at line 473: pnpm link --global ./packages/sandbox
```

### Fix

Before `pnpm link --global`:
- Run `pnpm setup` (idempotent in pnpm 9+) to create `$HOME/.local/share/pnpm`, configure `global-bin-dir`, and write `PNPM_HOME` to `~/.bashrc` + `~/.zshrc` for future shells.
- Export `PNPM_HOME` and prepend it to `PATH` inline so the link step works in *this* shell regardless of rc state.
- If `pnpm setup` itself returns non-zero (older pnpm, weird shell), fall back to `mkdir -p $PNPM_HOME` + `pnpm config set global-bin-dir`.

Closes #186

## Sync

Will open companion PR to `development` immediately after this merges.

## Test plan

- [x] `bash -n install.sh` passes
- [x] `shellcheck install.sh` introduces zero new warnings
- [x] Pre-commit hook: 397 sandbox tests pass
- [ ] After merge, re-run `curl -fsSL https://oh.mifune.dev/install.sh | bash` on the affected Ubuntu host — install should complete through `pnpm link --global` and end with `openharness available on PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)