### PR TITLE
FROM sync/install-pnpm-home TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - 26 docs pages converted from Nextra MDX to plain markdown rendered by GitHub.
 
 ### Fixed
+- `install.sh` bootstraps `PNPM_HOME` before `pnpm link --global` so the CLI install no longer dies with `ERR_PNPM_NO_GLOBAL_BIN_DIR` on fresh nvm-installed Node. Runs `pnpm setup` (writes `PNPM_HOME` export to `~/.bashrc` + `~/.zshrc`) and also exports `PNPM_HOME`/`PATH` inline so the link step succeeds in the current shell regardless of rc state.
 - `install.sh` no longer silently exits when sourcing a pre-existing `~/.nvm/nvm.sh` under `set -euo pipefail`. nvm + corepack calls are bracketed with relaxed strict mode and explicit `$?` checks, an `ERR` trap surfaces unexpected failures with the failing command and line, and pnpm is pinned to `10.33.0` (matches `package.json#packageManager`) instead of resolving `pnpm@latest` over the network on every install.
 - Slack bot no longer drops oversized agent replies with cascading `msg_too_long` errors. Main message is capped at 2,900 chars with a `_message truncated — full response in thread_` footer; full content spills to thread replies; `setWorking(false)` always clears the working indicator. ([#135](https://github.com/ryaneggz/open-harness/issues/135))
 

--- a/install.sh
+++ b/install.sh
@@ -470,6 +470,24 @@ if [ "$INSTALL_MODE" = "cli" ] || [ "$INSTALL_MODE" = "node-then-cli" ]; then
 
   pnpm install
   pnpm -r run build
+
+  # `pnpm link --global` writes a symlink into pnpm's global bin directory.
+  # Fresh nvm-installed Node has no PNPM_HOME, so the link step dies with
+  # ERR_PNPM_NO_GLOBAL_BIN_DIR. `pnpm setup` is the supported bootstrap:
+  # it creates $PNPM_HOME, configures global-bin-dir, and writes the
+  # PNPM_HOME export into ~/.bashrc (+ ~/.zshrc) for future shells. Modern
+  # pnpm runs it non-interactively. We also export PATH/PNPM_HOME inline
+  # so `pnpm link --global` works in *this* shell regardless of rc state.
+  export SHELL="${SHELL:-/bin/bash}"
+  pnpm setup >/dev/null 2>&1 || warn "pnpm setup returned non-zero — falling back to manual PNPM_HOME bootstrap."
+  export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+  mkdir -p "$PNPM_HOME"
+  case ":$PATH:" in
+    *":$PNPM_HOME:"*) ;;
+    *) export PATH="$PNPM_HOME:$PATH" ;;
+  esac
+  pnpm config set global-bin-dir "$PNPM_HOME" >/dev/null 2>&1 || true
+
   pnpm link --global ./packages/sandbox
   ok "openharness CLI built and linked"
 


### PR DESCRIPTION
## Summary

Sync companion to PR #187 (now merged to `main`). Brings the `pnpm link --global` PNPM_HOME bootstrap fix to `development` so future branches don't drift from main.

Identical commit (`6795fb1`) to what merged on main.

Closes #186

## Test plan

- [x] Cherry-picked cleanly from `f7f72a0` (no conflicts)
- [x] Pre-commit hook: 397 sandbox tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)