### PR TITLE
FROM feat/237-deepagents-cli-support TO development

### DIFF
--- a/tasks/deepagents-cli-support/critique.md
+++ b/tasks/deepagents-cli-support/critique.md
@@ -1,0 +1,68 @@
+# Critique — deepagents-cli-support
+
+Generated 2026-05-04; reviews `prd.md` post-/prd, pre-/ralph.
+
+## Critic A — Implementer lens
+
+CRITIC_A -- IMPLEMENTER LENS
+
+[SEVERITY: H] [STORY: US-004] [Default DeepAgents Ralph flags risk unrestricted destructive shell execution against protected paths.] | [EVIDENCE: AC text: `deepagents -y --shell-allow-list all -n "$task" -q --no-stream`; .claude/protected-paths.txt] | [RECOMMENDATION: Make `all` explicit opt-in via `RALPH_DEEPAGENTS_FLAGS`; default to a narrow/recommended allow list and require the Ralph prompt to restate protected-path must-not-delete rules.]
+
+[SEVERITY: M] [STORY: US-004] [No per-invocation turn/time cap is required, so one DeepAgents call can hang inside a Ralph iteration despite `RALPH_MAX_ITERATIONS`.] | [EVIDENCE: US-004 AC omits `--max-turns`; scripts/ralph.sh has only loop-level `RALPH_MAX_ITERATIONS`] | [RECOMMENDATION: Add a default `--max-turns` value and `RALPH_DEEPAGENTS_MAX_TURNS` or require operators to set one.]
+
+[SEVERITY: M] [STORY: US-003] [Host-overlay install behavior is underspecified for non-UID-1000 hosts; `scripts/install.sh` filters `*-host.yml` overlays and warning text/manual fallback must be updated or the new overlay may be silently disabled/confusing.] | [EVIDENCE: scripts/install.sh UID guard; US-003 AC only says pre-create `~/.deepagents`] | [RECOMMENDATION: Add AC to update UID guard comments, warnings, fallback overlay list, and expected behavior for `.devcontainer/docker-compose.deepagents-host.yml`.]
+
+[SEVERITY: M] [STORY: US-005] [`install/banner.sh` status is vague: `~/.deepagents` will exist due named volume/precreation, but that does not prove provider credentials or usable configuration exist.] | [EVIDENCE: US-005 AC: "reports DeepAgents status based on `~/.deepagents` state"] | [RECOMMENDATION: Define exact status semantics, e.g. installed via `command -v deepagents`, configured via `~/.deepagents/.env` or `config.toml`, and avoid labeling an empty mounted directory as authenticated.]
+
+[SEVERITY: M] [STORY: US-005] [Docs scope is too broad to verify consistently.] | [EVIDENCE: US-005 AC: "Update installation, onboarding, repair, permissions, configuration, and architecture docs where they enumerate..."] | [RECOMMENDATION: Replace with an explicit file checklist from the current repo: README.md, docs/quickstart.md, docs/onboarding.md, docs/installation.md, docs/operations/provision.md, docs/operations/destroy.md, docs/guide/overlays.md, docs/guide/permissions.md, docs/architecture/container-runtime.md, docs/architecture/overview.md, docs/agents/overview.md.]
+
+[SEVERITY: M] [STORY: *] [The PRD omits the required user-visible CHANGELOG entry.] | [EVIDENCE: .claude/rules/git.md Changelog section; feature changes Docker image, compose volumes, installer, Ralph, and docs] | [RECOMMENDATION: Add AC requiring a `CHANGELOG.md` entry under `## [Unreleased]` in the same commit as the implementation.]
+
+### Rerun
+
+CRITIC_A -- IMPLEMENTER LENS -- RERUN
+
+[L] [STORY: US-004] [FINDING] | [EVIDENCE: US-004 AC requires `deepagents -y --shell-allow-list recommended -n "$task" -q --no-stream`, `RALPH_DEEPAGENTS_FLAGS` override for `--shell-allow-list all`, and `RALPH_DEEPAGENTS_MAX_TURNS`; FR-7/FR-8 repeat those constraints] | [RECOMMENDATION: No blocking issue remains. The previous high finding is mitigated because unrestricted shell execution is no longer the default and `all` requires an explicit operator override.]
+
+[L] [STORY: *] [FINDING] | [EVIDENCE: Technical Considerations names protected files `.devcontainer/Dockerfile`, `.devcontainer/entrypoint.sh`, `install/banner.sh`, and `scripts/ralph.sh`; `.claude/protected-paths.txt` marks these must-not-delete; no story asks to delete or deprecate protected entries] | [RECOMMENDATION: Proceed; keep implementation additive/conservative and do not delete protected paths without an explicit override.]
+
+## Critic B — User lens
+
+CRITIC_B -- USER LENS
+
+[SEVERITY: H] [STORY: US-004] [DeepAgents Ralph default would grant unrestricted non-interactive shell execution, which is a large trust escalation for an explicitly selected new runtime.] | [EVIDENCE: PRD US-004; PRD Technical Considerations; scripts/ralph.sh] | [RECOMMENDATION: Require an explicit opt-in env var or operator-provided `RALPH_DEEPAGENTS_FLAGS` for shell allowance; do not default to `--shell-allow-list all`, or document the default as intentionally equivalent to full shell access.]
+
+[SEVERITY: M] [STORY: US-005] [Docs scope risks drifting into multi-agent comparison/stacking, which conflicts with the v1 ICP's "one developer, one project, one harness" posture.] | [EVIDENCE: .claude/ICP.md; PRD US-005; docs/agents/overview.md] | [RECOMMENDATION: Frame DeepAgents as an optional supported runtime, keep Claude as the default path, and avoid copy that promotes racing or stacking multiple CLIs as the product surface.]
+
+[SEVERITY: M] [STORY: US-002] [State persistence is underspecified because DeepAgents can use both `~/.deepagents/` and repo-local `.deepagents/`, creating unclear expectations about what survives rebuilds versus what is versioned in the project.] | [EVIDENCE: PRD US-002; PRD Technical Considerations] | [RECOMMENDATION: State explicitly that v1 persists only `/home/sandbox/.deepagents`; repo-local `.deepagents/` is project data and must follow normal gitignore/review rules.]
+
+[SEVERITY: M] [STORY: US-003] [The host-state overlay lacks a user escape hatch in the PRD: users need clear disable, rollback, and cleanup instructions if host credentials or memory bleed into the sandbox unexpectedly.] | [EVIDENCE: PRD US-003; existing .devcontainer/docker-compose.*-host.yml comments; scripts/install.sh host overlay handling] | [RECOMMENDATION: Add acceptance criteria for disabling the overlay, returning to the named volume, and removing/resetting the `deepagents-auth` volume without touching host `~/.deepagents`.]
+
+[SEVERITY: L] [STORY: *] [Protected paths are acknowledged, and the PRD does not propose deleting protected entries, but it touches several load-bearing files.] | [EVIDENCE: .claude/protected-paths.txt; PRD Technical Considerations] | [RECOMMENDATION: Keep changes additive and conservative for `.devcontainer/Dockerfile`, `.devcontainer/entrypoint.sh`, `install/banner.sh`, and `scripts/ralph.sh`; do not delete or deprecate protected paths without an explicit override.]
+
+### Rerun
+
+CRITIC_B -- USER LENS -- RERUN
+
+[SEVERITY: M] [STORY: US-001] [Core-image scope still needs justification against v1 ICP pack-first guidance] | [EVIDENCE: .claude/ICP.md "Extension via packs, not core changes"; PRD Non-Goals "Do not implement a DeepAgents harness pack"] | [RECOMMENDATION: Add a short rationale explaining why DeepAgents belongs in the base image despite the pack-first ICP, or narrow the story to a pack/overlay if first-class core support is not intentional.]
+
+[SEVERITY: M] [STORY: US-004] [Previous high finding around unrestricted shell access is mitigated for defaults, but operator override docs need an explicit danger boundary] | [EVIDENCE: US-004 default `--shell-allow-list recommended`; `RALPH_DEEPAGENTS_FLAGS` can choose `--shell-allow-list all`; docs/guide/permissions.md says agents can run arbitrary shell and Docker socket is enabled by default] | [RECOMMENDATION: Require docs and inline comments to state that `--shell-allow-list all` plus Docker socket access can affect sibling containers/host Docker, and should only be used for trusted tasks.]
+
+[SEVERITY: L] [STORY: US-005] [Supported-agent inventory is stale/ambiguous before implementation] | [EVIDENCE: PRD Introduction says Claude Code, Codex, and Pi; docs/agents/overview.md currently lists Claude Code, Codex, OpenCode, and Pi] | [RECOMMENDATION: Update PRD wording or acceptance criteria so DeepAgents is added alongside the actual current supported set without omitting or regressing OpenCode.]
+
+[SEVERITY: L] [STORY: US-002] [Repo-local `.deepagents/` expectations are only partially bounded] | [EVIDENCE: US-002 says repo-local `.deepagents/` is project data and must follow normal git review and ignore rules; Technical Considerations says DeepAgents can load project-specific memory and skills from repo root] | [RECOMMENDATION: Require docs to warn that repo-local `.deepagents/` may be read by the agent and can be committed, so secrets/provider keys belong only in `~/.deepagents` or ignored local files.]
+
+[SEVERITY: L] [STORY: *] [No blocking protected-path violation remains] | [EVIDENCE: Technical Considerations names `.devcontainer/Dockerfile`, `.devcontainer/entrypoint.sh`, `install/banner.sh`, and `scripts/ralph.sh` as protected paths to modify conservatively and not delete; .claude/protected-paths.txt marks these must-not-delete] | [RECOMMENDATION: Proceed after addressing or explicitly accepting the medium findings.]
+
+## Synthesis
+
+- **High-severity findings**: 0 remaining after PRD revision.
+- **Medium-severity findings**: 0 unmitigated; the rerun medium findings from Critic B were absorbed into the PRD before proceeding.
+- **Recommendation**: PROCEED
+
+The original high-severity shell-risk finding changed the implementation plan:
+DeepAgents Ralph defaults now use `--shell-allow-list recommended`, unrestricted
+`all` requires explicit `RALPH_DEEPAGENTS_FLAGS`, and each DeepAgents call gets a
+max-turn cap. The PRD also now defines host-overlay rollback, UID-guard updates,
+banner status semantics, repo-local `.deepagents/` secret boundaries, a core-image
+rationale, and required CHANGELOG coverage.

--- a/tasks/deepagents-cli-support/prd.json
+++ b/tasks/deepagents-cli-support/prd.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": 1,
+  "project": "Open Harness",
+  "branchName": "feat/237-deepagents-cli-support",
+  "description": "Add DeepAgents CLI as a first-class supported Open Harness agent runtime. The feature installs deepagents-cli in the base sandbox image, persists ~/.deepagents state, adds an optional trusted host overlay, supports scripts/ralph.sh --harness=deepagents with constrained shell defaults and a max-turn cap, and updates docs, onboarding, and release notes.",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Install DeepAgents in the sandbox image",
+      "description": "As a sandbox user, I want deepagents available on PATH after provisioning so that I can launch it without manual installation.",
+      "acceptanceCriteria": [
+        ".devcontainer/Dockerfile installs deepagents-cli with uv tool install after uv is installed.",
+        "The install uses image-level tool locations, such as UV_TOOL_DIR=/opt/uv/tools and UV_TOOL_BIN_DIR=/usr/local/bin, so the deepagents executable is available to the sandbox user.",
+        "docker build -f .devcontainer/Dockerfile . reaches the DeepAgents install layer without requiring interactive input.",
+        "deepagents -v runs successfully inside a rebuilt sandbox.",
+        "Existing claude, codex, opencode, and pi installs remain unchanged.",
+        "Tests pass.",
+        "Typecheck passes."
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Persist DeepAgents state",
+      "description": "As a sandbox user, I want DeepAgents state to persist across container rebuilds so that provider keys, model configuration, memory, skills, and sessions are not lost.",
+      "acceptanceCriteria": [
+        ".devcontainer/docker-compose.yml mounts a named volume at /home/sandbox/.deepagents.",
+        "The compose volume is named consistently with existing agent auth volumes, for example deepagents-auth.",
+        ".devcontainer/entrypoint.sh includes .deepagents in the mounted directory ownership pass.",
+        "The ownership pass skips .deepagents when a host bind-mount overlay sets DEEPAGENTS_HOST_BIND_MOUNT=1.",
+        "Documentation states that v1 persists only /home/sandbox/.deepagents; repo-local .deepagents/ is project data and must follow normal git review and ignore rules.",
+        "docker exec -u sandbox openharness test -w ~/.deepagents succeeds after provisioning.",
+        "Existing auth volumes for Claude, Codex, OpenCode, and Pi remain unchanged.",
+        "Tests pass.",
+        "Typecheck passes."
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Add a DeepAgents host-state overlay",
+      "description": "As a trusted local user, I want an opt-in compose overlay that binds my host ~/.deepagents into the sandbox so that I can reuse existing DeepAgents provider configuration and memory.",
+      "acceptanceCriteria": [
+        "Add .devcontainer/docker-compose.deepagents-host.yml following the style and warning level of the existing Claude, Codex, and Pi host overlays.",
+        "The overlay bind-mounts ${HOST_DEEPAGENTS_DIR:-~/.deepagents} to /home/sandbox/.deepagents.",
+        "The overlay sets DEEPAGENTS_HOST_BIND_MOUNT=1.",
+        "Overlay comments document the credential blast radius, host write behavior, UID 1000 assumption, and the need for the host directory to pre-exist.",
+        "scripts/install.sh pre-creates ~/.deepagents with the other host auth directories.",
+        "scripts/install.sh UID guard comments, warnings, and fallback overlay list include the DeepAgents host overlay so non-UID-1000 hosts do not get confusing credential failures.",
+        "Host-overlay docs mention the DeepAgents overlay, its trust tradeoffs, how to disable it, how to return to the named volume, and how to reset the deepagents-auth volume without deleting host ~/.deepagents.",
+        "Tests pass.",
+        "Typecheck passes."
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Add DeepAgents to Ralph harness selection",
+      "description": "As a Ralph operator, I want to run task loops with DeepAgents when I choose it explicitly so that DeepAgents can execute the same four-file task contract as the existing harnesses.",
+      "acceptanceCriteria": [
+        "scripts/ralph.sh --harness=deepagents <task> is accepted by argument validation.",
+        "RALPH_HARNESS=deepagents scripts/ralph.sh <task> is accepted.",
+        "scripts/ralph.sh requires deepagents on PATH when DeepAgents is the active harness.",
+        "DeepAgents Ralph execution uses non-interactive mode, clean output, and a constrained default shell allowance: deepagents -y --shell-allow-list recommended -n \"$task\" -q --no-stream.",
+        "Add RALPH_DEEPAGENTS_FLAGS so operators can override the default DeepAgents flags, including explicitly choosing --shell-allow-list all when they accept unrestricted shell execution risk.",
+        "Inline comments and docs state that --shell-allow-list all combined with the mounted Docker socket can affect sibling containers or host Docker and should only be used for trusted tasks.",
+        "Add RALPH_DEEPAGENTS_MAX_TURNS with a default positive value and pass it to DeepAgents as --max-turns so one Ralph iteration cannot hang indefinitely inside a single DeepAgents call.",
+        "The generated Ralph prompt restates that protected paths in .claude/protected-paths.txt must not be deleted or deprecated without an explicit override.",
+        "Existing Claude, Pi, and Codex execution and fallback behavior remain unchanged.",
+        "Tests pass.",
+        "Typecheck passes."
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "Document DeepAgents support",
+      "description": "As a new Open Harness user, I want DeepAgents documented with the other supported agents so that I can install, authenticate, verify, and run it correctly.",
+      "acceptanceCriteria": [
+        "docs/agents/overview.md lists DeepAgents in the supported agents table and verification commands without omitting OpenCode.",
+        "Add docs/agents/deepagents.md with purpose, install verification, provider-key setup, common interactive and non-interactive usage, tmux usage, Ralph usage, and upstream documentation links.",
+        "Update these docs where they enumerate supported agent CLIs, auth/state volumes, overlays, permissions, or Ralph harness options: README.md, docs/quickstart.md, docs/onboarding.md, docs/installation.md, docs/operations/provision.md, docs/operations/destroy.md, docs/operations/repair.md, docs/guide/overlays.md, docs/guide/permissions.md, docs/guide/configuration.md, docs/architecture/container-runtime.md, docs/architecture/overview.md, and docs/agents/overview.md.",
+        "install/banner.sh reports DeepAgents status without treating an empty mounted directory as authenticated: installed status comes from command -v deepagents; configured status comes from ~/.deepagents/.env or ~/.deepagents/config.toml.",
+        "Docs frame DeepAgents as an optional supported runtime and keep Claude as the default path; they do not promote multi-agent racing as the product surface.",
+        "Documentation states that DeepAgents non-interactive shell execution is disabled unless a shell allow list is configured.",
+        "Documentation warns that repo-local .deepagents/ may be read by the agent and can be committed; secrets and provider keys belong only in ~/.deepagents or ignored local files.",
+        "pnpm docs:build passes.",
+        "Tests pass.",
+        "Typecheck passes."
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-006",
+      "title": "Add release note",
+      "description": "As a release reviewer, I want a changelog entry for DeepAgents support so that the user-visible sandbox and Ralph changes are captured.",
+      "acceptanceCriteria": [
+        "CHANGELOG.md has an entry under ## [Unreleased] describing DeepAgents CLI support.",
+        "The entry mentions the sandbox image, state volume or host overlay, Ralph harness selection, and docs/onboarding updates.",
+        "If an ### Added section already exists under [Unreleased], append to it instead of creating a duplicate heading.",
+        "Tests pass.",
+        "Typecheck passes."
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/tasks/deepagents-cli-support/prd.md
+++ b/tasks/deepagents-cli-support/prd.md
@@ -1,0 +1,249 @@
+# PRD: DeepAgents CLI Support
+
+## Introduction
+
+Add DeepAgents CLI as a supported Open Harness agent runtime. Open Harness
+currently documents and preinstalls Claude Code, Codex, OpenCode, and Pi;
+DeepAgents is a terminal coding agent with interactive and non-interactive
+modes that fits the same sandbox model if installation, state persistence,
+Ralph invocation, and onboarding docs are wired consistently.
+
+The implementation should make DeepAgents available in the base sandbox image,
+preserve its user configuration under `~/.deepagents`, and allow Ralph task
+loops to intentionally select it with `scripts/ralph.sh --harness=deepagents`.
+This is base-image support rather than a harness pack because DeepAgents is a
+single general-purpose terminal CLI, depends on `uv` which is already in the
+base image, and needs Ralph harness integration in `scripts/ralph.sh`; it is not
+an opinionated multi-service workflow like a pack.
+
+## Goals
+
+- Install `deepagents-cli` in the base sandbox image using the existing `uv`
+  runtime.
+- Persist DeepAgents configuration, provider keys, memory, skills, and sessions
+  across rebuilds with a sandbox-scoped named volume.
+- Provide an optional host bind-mount overlay for trusted workflows that want
+  to reuse host DeepAgents state.
+- Add DeepAgents as an explicit Ralph harness choice without changing the
+  existing Claude to Pi to Codex fallback behavior.
+- Update onboarding, repair, architecture, and agent docs so users can verify,
+  authenticate, and run DeepAgents in tmux.
+
+## User Stories
+
+### US-001: Install DeepAgents in the sandbox image
+
+**Description:** As a sandbox user, I want `deepagents` available on PATH after
+provisioning so that I can launch it without manual installation.
+
+**Acceptance Criteria:**
+
+- [ ] `.devcontainer/Dockerfile` installs `deepagents-cli` with `uv tool install`
+      after `uv` is installed.
+- [ ] The install uses image-level tool locations, such as
+      `UV_TOOL_DIR=/opt/uv/tools` and `UV_TOOL_BIN_DIR=/usr/local/bin`, so the
+      `deepagents` executable is available to the `sandbox` user.
+- [ ] `docker build -f .devcontainer/Dockerfile .` reaches the DeepAgents
+      install layer without requiring interactive input.
+- [ ] `deepagents -v` runs successfully inside a rebuilt sandbox.
+- [ ] Existing `claude`, `codex`, and `pi` installs remain unchanged.
+- [ ] Tests pass.
+
+### US-002: Persist DeepAgents state
+
+**Description:** As a sandbox user, I want DeepAgents state to persist across
+container rebuilds so that provider keys, model configuration, memory, skills,
+and sessions are not lost.
+
+**Acceptance Criteria:**
+
+- [ ] `.devcontainer/docker-compose.yml` mounts a named volume at
+      `/home/sandbox/.deepagents`.
+- [ ] The compose volume is named consistently with existing agent auth volumes,
+      for example `deepagents-auth`.
+- [ ] `.devcontainer/entrypoint.sh` includes `.deepagents` in the mounted
+      directory ownership pass.
+- [ ] The ownership pass skips `.deepagents` when a host bind-mount overlay sets
+      `DEEPAGENTS_HOST_BIND_MOUNT=1`.
+- [ ] Documentation states that v1 persists only `/home/sandbox/.deepagents`;
+      repo-local `.deepagents/` is project data and must follow normal git
+      review and ignore rules.
+- [ ] `docker exec -u sandbox openharness test -w ~/.deepagents` succeeds after
+      provisioning.
+- [ ] Existing auth volumes for Claude, Codex, and Pi remain unchanged.
+- [ ] Tests pass.
+
+### US-003: Add a DeepAgents host-state overlay
+
+**Description:** As a trusted local user, I want an opt-in compose overlay that
+binds my host `~/.deepagents` into the sandbox so that I can reuse existing
+DeepAgents provider configuration and memory.
+
+**Acceptance Criteria:**
+
+- [ ] Add `.devcontainer/docker-compose.deepagents-host.yml` following the style
+      and warning level of the existing Claude, Codex, and Pi host overlays.
+- [ ] The overlay bind-mounts `${HOST_DEEPAGENTS_DIR:-~/.deepagents}` to
+      `/home/sandbox/.deepagents`.
+- [ ] The overlay sets `DEEPAGENTS_HOST_BIND_MOUNT=1`.
+- [ ] Overlay comments document the credential blast radius, host write
+      behavior, UID 1000 assumption, and the need for the host directory to
+      pre-exist.
+- [ ] `scripts/install.sh` pre-creates `~/.deepagents` with the other host auth
+      directories.
+- [ ] `scripts/install.sh` UID guard comments, warnings, and fallback overlay
+      list include the DeepAgents host overlay so non-UID-1000 hosts do not get
+      confusing credential failures.
+- [ ] Host-overlay docs mention the DeepAgents overlay, its trust tradeoffs, how
+      to disable it, how to return to the named volume, and how to reset the
+      `deepagents-auth` volume without deleting host `~/.deepagents`.
+- [ ] Tests pass.
+
+### US-004: Add DeepAgents to Ralph harness selection
+
+**Description:** As a Ralph operator, I want to run task loops with DeepAgents
+when I choose it explicitly so that DeepAgents can execute the same four-file
+task contract as the existing harnesses.
+
+**Acceptance Criteria:**
+
+- [ ] `scripts/ralph.sh --harness=deepagents <task>` is accepted by argument
+      validation.
+- [ ] `RALPH_HARNESS=deepagents scripts/ralph.sh <task>` is accepted.
+- [ ] `scripts/ralph.sh` requires `deepagents` on PATH when DeepAgents is the
+      active harness.
+- [ ] DeepAgents Ralph execution uses non-interactive mode, clean output, and a
+      constrained default shell allowance:
+      `deepagents -y --shell-allow-list recommended -n "$task" -q --no-stream`.
+- [ ] Add `RALPH_DEEPAGENTS_FLAGS` so operators can override the default
+      DeepAgents flags, including explicitly choosing `--shell-allow-list all`
+      when they accept unrestricted shell execution risk.
+- [ ] Inline comments and docs state that `--shell-allow-list all` combined with
+      the mounted Docker socket can affect sibling containers or host Docker and
+      should only be used for trusted tasks.
+- [ ] Add `RALPH_DEEPAGENTS_MAX_TURNS` with a default positive value and pass it
+      to DeepAgents as `--max-turns` so one Ralph iteration cannot hang
+      indefinitely inside a single DeepAgents call.
+- [ ] The generated Ralph prompt restates that protected paths in
+      `.claude/protected-paths.txt` must not be deleted or deprecated without an
+      explicit override.
+- [ ] Existing Claude, Pi, and Codex execution and fallback behavior remain
+      unchanged.
+- [ ] Tests pass.
+
+### US-005: Document DeepAgents support
+
+**Description:** As a new Open Harness user, I want DeepAgents documented with
+the other supported agents so that I can install, authenticate, verify, and run
+it correctly.
+
+**Acceptance Criteria:**
+
+- [ ] `docs/agents/overview.md` lists DeepAgents in the supported agents table
+      and verification commands.
+- [ ] Add `docs/agents/deepagents.md` with purpose, install verification,
+      provider-key setup, common interactive and non-interactive usage, tmux
+      usage, Ralph usage, and upstream documentation links.
+- [ ] Update these docs where they enumerate supported agent CLIs, auth/state
+      volumes, overlays, permissions, or Ralph harness options: `README.md`,
+      `docs/quickstart.md`, `docs/onboarding.md`, `docs/installation.md`,
+      `docs/operations/provision.md`, `docs/operations/destroy.md`,
+      `docs/operations/repair.md`, `docs/guide/overlays.md`,
+      `docs/guide/permissions.md`, `docs/guide/configuration.md`,
+      `docs/architecture/container-runtime.md`,
+      `docs/architecture/overview.md`, and `docs/agents/overview.md`.
+- [ ] `install/banner.sh` reports DeepAgents status without treating an empty
+      mounted directory as authenticated: installed status comes from
+      `command -v deepagents`; configured status comes from
+      `~/.deepagents/.env` or `~/.deepagents/config.toml`.
+- [ ] Docs frame DeepAgents as an optional supported runtime and keep Claude as
+      the default path; they do not promote multi-agent racing as the product
+      surface.
+- [ ] Documentation states that DeepAgents non-interactive shell execution is
+      disabled unless a shell allow list is configured.
+- [ ] Documentation warns that repo-local `.deepagents/` may be read by the
+      agent and can be committed; secrets and provider keys belong only in
+      `~/.deepagents` or ignored local files.
+- [ ] `pnpm docs:build` passes.
+
+### US-006: Add release note
+
+**Description:** As a release reviewer, I want a changelog entry for DeepAgents
+support so that the user-visible sandbox and Ralph changes are captured.
+
+**Acceptance Criteria:**
+
+- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]` describing DeepAgents
+      CLI support.
+- [ ] The entry mentions the sandbox image, state volume or host overlay, Ralph
+      harness selection, and docs/onboarding updates.
+- [ ] If an `### Added` section already exists under `[Unreleased]`, append to
+      it instead of creating a duplicate heading.
+- [ ] Tests pass.
+
+## Functional Requirements
+
+- FR-1: The base Docker image must include a working `deepagents` executable.
+- FR-2: DeepAgents state must persist under `/home/sandbox/.deepagents`.
+- FR-3: A trusted host user must be able to opt into binding host
+  `~/.deepagents` into the sandbox.
+- FR-4: Ralph must accept `deepagents` as an explicit harness value.
+- FR-5: Ralph must pass task text to DeepAgents in non-interactive mode.
+- FR-6: Ralph must not silently fall back to DeepAgents from Claude, Pi, or
+  Codex.
+- FR-7: Ralph's DeepAgents default must use `--shell-allow-list recommended`;
+  unrestricted shell access must require an explicit operator override through
+  `RALPH_DEEPAGENTS_FLAGS`.
+- FR-8: Ralph's DeepAgents invocation must include a per-call max-turn cap.
+- FR-9: Existing supported harness behavior must remain backward compatible.
+- FR-10: User-facing docs must describe installation, authentication, tmux usage,
+  state persistence, and Ralph invocation for DeepAgents.
+
+## Non-Goals
+
+- Do not implement a DeepAgents harness pack; this feature adds first-class base
+  support because the CLI is a single general-purpose runtime and Ralph needs a
+  built-in harness selector.
+- Do not configure remote DeepAgents sandbox providers such as Daytona.
+- Do not select a default DeepAgents model or store provider keys in tracked
+  files.
+- Do not make DeepAgents the default Ralph harness.
+- Do not change Claude, Pi, or Codex fallback order.
+- Do not launch the Ralph loop automatically as part of the spec PR.
+
+## Technical Considerations
+
+- DeepAgents CLI is distributed as the Python package `deepagents-cli` and its
+  documented installer uses `uv tool install`.
+- DeepAgents stores global configuration under `~/.deepagents/`, with
+  project-specific memory and skills optionally loaded from `.deepagents/` in a
+  repository root.
+- DeepAgents supports non-interactive execution with `-n`; clean buffered output
+  can use `-q --no-stream`.
+- DeepAgents disables shell execution in non-interactive mode unless
+  `-S`/`--shell-allow-list` or `DEEPAGENTS_CLI_SHELL_ALLOW_LIST` is configured;
+  Open Harness should default to `recommended`, not `all`.
+- The Dockerfile should avoid user-home installs that leave executables only in
+  `/root/.local/bin` or `/home/sandbox/.local/bin`.
+- Existing protected paths touched by this work include `.devcontainer/Dockerfile`,
+  `.devcontainer/entrypoint.sh`, `install/banner.sh`, and `scripts/ralph.sh`;
+  these files must be modified conservatively and not deleted.
+
+## Success Metrics
+
+- A freshly built sandbox can run `deepagents -v` as the `sandbox` user.
+- A rebuilt sandbox preserves files under `~/.deepagents`.
+- `scripts/ralph.sh --harness=deepagents <task>` launches a tmux loop for a
+  valid four-file task.
+- Existing `scripts/ralph.sh --harness=claude|pi|codex` flows still work.
+- Harness docs build successfully.
+
+## Open Questions
+
+- None for v1. The implementation should use the defaults above.
+
+## References
+
+- DeepAgents CLI overview: https://docs.langchain.com/oss/python/deepagents/cli/overview
+- DeepAgents configuration: https://docs.langchain.com/oss/python/deepagents/cli/configuration
+- DeepAgents CLI source: https://github.com/langchain-ai/deepagents/tree/main/libs/cli

--- a/tasks/deepagents-cli-support/progress.txt
+++ b/tasks/deepagents-cli-support/progress.txt
@@ -1,0 +1,2 @@
+# progress
+

--- a/tasks/deepagents-cli-support/prompt.md
+++ b/tasks/deepagents-cli-support/prompt.md
@@ -1,0 +1,96 @@
+# Ralph iteration — deepagents-cli-support
+
+You are one iteration of a Ralph loop adding DeepAgents CLI as a supported Open Harness runtime. The full plan is in `tasks/deepagents-cli-support/prd.md`, the structured task list is in `tasks/deepagents-cli-support/prd.json`, and the critic gate is in `tasks/deepagents-cli-support/critique.md`. The loop calls you again until `progress.txt` contains a line `STATUS: COMPLETE`.
+
+## Your job in one iteration
+
+Pick **one** user story, implement it, commit, mark it `passes: true`, and append a progress entry. Then exit. The next iteration handles the next story. Do not attempt multiple stories per iteration.
+
+## Steps every iteration
+
+1. **Read context** — in this order:
+   - `tasks/deepagents-cli-support/prd.json` — find the lowest-`priority` story where `passes: false`. That is your story for this iteration.
+   - `tasks/deepagents-cli-support/prd.md` — read the user story's full description and rationale.
+   - `tasks/deepagents-cli-support/critique.md` — preserve the mitigations from the critic gate, especially the DeepAgents shell allow-list and protected-path constraints.
+   - `tasks/deepagents-cli-support/progress.txt` — read the "Codebase Patterns" section at the top, if present, and the most recent few iterations.
+   - `.claude/protected-paths.txt` — protected entries must not be deleted or deprecated without an explicit override note.
+   - `.claude/rules/git.md` for branch, commit, changelog, and worktree conventions.
+   - `.claude/rules/sandbox-processes.md` if your story touches tmux or long-running process guidance.
+
+2. **Verify branch** — your branch is `feat/237-deepagents-cli-support` (per `prd.json` `branchName`). If you are not on it:
+   ```bash
+   git fetch origin
+   git checkout -b feat/237-deepagents-cli-support origin/development 2>/dev/null \
+     || git checkout feat/237-deepagents-cli-support
+   ```
+   Never push to `development` or `main` directly.
+
+3. **Implement the chosen story** — make only the changes required by that story's `acceptanceCriteria`. Keep changes additive and conservative around protected files such as `.devcontainer/Dockerfile`, `.devcontainer/entrypoint.sh`, `install/banner.sh`, and `scripts/ralph.sh`.
+
+4. **DeepAgents safety constraints** — when working on Ralph support, do not default to unrestricted shell execution. The default DeepAgents flags must use `--shell-allow-list recommended`; `--shell-allow-list all` is only allowed through an explicit operator override such as `RALPH_DEEPAGENTS_FLAGS`. Include a per-call `--max-turns` cap through `RALPH_DEEPAGENTS_MAX_TURNS`.
+
+5. **Run quality checks** before commit:
+   ```bash
+   pnpm run lint 2>/dev/null || true
+   pnpm run test 2>/dev/null || true
+   ```
+   For docs changes, also run `pnpm docs:build` when practical. The pre-commit hook runs lint + test; do not bypass with `--no-verify`.
+
+6. **Commit** with this message format (per `.claude/rules/git.md`):
+   ```
+   feat: US-<NNN> — <story title>
+   ```
+   Example: `feat: US-001 — install DeepAgents in the sandbox image`. Stage only files touched by this story.
+
+7. **Update `prd.json`** — set `passes: true` for the completed story, and set `notes` to a one-line summary including iteration number, date, and short commit SHA:
+   ```json
+   "notes": "Completed iteration 1 on 2026-05-04; commit abc1234"
+   ```
+
+8. **Append to `progress.txt`** — append (never replace) using this format:
+   ```markdown
+   ## US-<NNN> — <YYYY-MM-DD HH:MM UTC>
+
+   **Title**: <story title>
+   **Files changed**: <list>
+   **Commit**: <short SHA>
+   **Result**: PASS | BLOCKED | DEFERRED
+
+   ### What I did
+   <2-4 sentences>
+
+   ### Learnings for future iterations
+   <patterns, gotchas, useful context>
+
+   ---
+   ```
+
+9. **Codebase Patterns** — if you discovered a pattern other iterations should know, append it to or create the `## Codebase Patterns` section at the **top** of `progress.txt`.
+
+10. **Stop condition** — after step 8, check whether all stories in `prd.json` now have `passes: true`. If yes, append a final line on its own to `progress.txt`:
+   ```
+   STATUS: COMPLETE
+   ```
+   This terminates the Ralph loop.
+
+11. **End response normally** — do not emit any completion sentinel in your reply text. Only the `STATUS: COMPLETE` line in `progress.txt` matters.
+
+## Critical rules
+
+- **One story per iteration.** Resist doing two.
+- **Never push** to `development` or `main`. Branch is `feat/237-deepagents-cli-support`.
+- **Never skip pre-commit hooks** (`--no-verify`).
+- **Never run `git clone` or `git init`** — you are already in a checkout.
+- **Do not delete protected paths.** `.claude/protected-paths.txt` is authoritative; any deletion/deprecation of an entry requires an explicit override note and human review.
+- **Preserve existing agents.** Claude Code, Codex, OpenCode, and Pi support must remain intact.
+- **Do not commit secrets.** Provider keys belong in `~/.deepagents/.env` or ignored local files, not in tracked docs or repo-local `.deepagents/`.
+- **CHANGELOG discipline.** US-006 owns the release note; do not add duplicate changelog entries in earlier story commits unless the story explicitly requires it.
+
+## Reference
+
+- PRD: `tasks/deepagents-cli-support/prd.md`
+- Critique: `tasks/deepagents-cli-support/critique.md`
+- Structured stories: `tasks/deepagents-cli-support/prd.json`
+- Branch: `feat/237-deepagents-cli-support`
+- Issue: [#237](https://github.com/ryaneggz/open-harness/issues/237)
+- Related prior art: [#130](https://github.com/ryaneggz/open-harness/issues/130) and closed PR #131


### PR DESCRIPTION
Closes #237.

**Status: DRAFT — ralph loop has not yet been launched.**

## Summary

Adds the critic-gated Ralph task scaffold for first-class DeepAgents CLI support in Open Harness.

The implementation target is base sandbox support: image installation via uv, persistent ~/.deepagents state, optional trusted host overlay, explicit Ralph harness selection with constrained shell defaults, and docs/onboarding updates.

## Stories

1. Install DeepAgents in the sandbox image
2. Persist DeepAgents state
3. Add a DeepAgents host-state overlay
4. Add DeepAgents to Ralph harness selection
5. Document DeepAgents support
6. Add release note

## Critique

- High-severity findings: 0 remaining after PRD revision
- Medium-severity findings: 0 unmitigated
- Recommendation: PROCEED

Original critic finding changed the plan: DeepAgents Ralph defaults now use `--shell-allow-list recommended`, unrestricted `all` requires explicit `RALPH_DEEPAGENTS_FLAGS`, and each DeepAgents call gets a max-turn cap.

## Related Prior Art

- Related: #130 and closed PR #131
- This spec supersedes the earlier optional-entrypoint direction with first-class support and safer Ralph defaults.

## Next steps (manual)

1. `scripts/ralph.sh --harness=claude deepagents-cli-support` — launch the loop in tmux
2. Monitor: `tmux attach -t deepagents-cli-support` or `tail -f tasks/deepagents-cli-support/progress.txt`
3. After `STATUS: COMPLETE`: `git push && gh pr ready <pr-number> && /ci-status`

Generated via /ship-spec.
