### PR TITLE
FROM feat/239-opencode-harness TO development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,17 +60,18 @@ RUN corepack enable && corepack prepare pnpm@latest --activate \
 # by default without extra configuration.
 #
 # AGENTS is a comma-separated list of agent CLI keys to install. The default
-# is claude-code + codex + pi-coding-agent. Downstream harness packs (e.g.
+# is claude-code + codex + pi-coding-agent + opencode. Downstream harness packs (e.g.
 # @ryaneggz/mifune) install additional CLIs via their install-hook.sh.
 SHELL ["/bin/bash", "-c"]
 
-ARG AGENTS="claude-code,codex,pi-coding-agent"
+ARG AGENTS="claude-code,codex,pi-coding-agent,opencode"
 
 RUN set -e; \
     declare -A PKG=( \
         [claude-code]=@anthropic-ai/claude-code \
         [codex]=@openai/codex \
         [pi-coding-agent]=@mariozechner/pi-coding-agent \
+        [opencode]=opencode-ai \
     ); \
     IFS=',' read -ra agents <<< "$AGENTS"; \
     for a in "${agents[@]}"; do \

--- a/.devcontainer/docker-compose.opencode-host.yml
+++ b/.devcontainer/docker-compose.opencode-host.yml
@@ -1,0 +1,47 @@
+# OpenCode Host Auth Mount Overlay
+# =================================
+# Purpose: Bind-mount the host's ~/.local/share/opencode directory into
+# the sandbox, so the sandboxed `opencode` CLI inherits host provider
+# auth tokens and session state. Developers running multiple sandboxes no
+# longer re-authenticate OpenCode per sandbox.
+#
+# One mount, one concern:
+#   - ~/.local/share/opencode/ (dir) — auth.json (provider OAuth/API-key
+#                                      credentials), sessions, app state
+#
+# Pre-flight:
+#   $HOST_OPENCODE_DIR (default ~/.local/share/opencode) must exist as a
+# directory. If the target is missing, Docker auto-creates it as a
+# directory owned by root — `opencode` then fails to read/write auth.json.
+#
+# Requirements: Host UID MUST equal the sandbox UID (1000). Provider auth
+# files may be owner-only, so the group-membership trick used elsewhere
+# in entrypoint.sh does NOT grant access. If host UID != 1000, `opencode`
+# may fail to read credentials despite the bind-mount succeeding.
+#
+# Security tradeoff: this mounts provider credentials and session history
+# into a container that may execute untrusted agent code. Enable only for
+# trusted workflows. OpenAI OAuth through OpenCode's /connect flow is the
+# expected default auth path for opencode in this harness, so the overlay
+# is enabled by default in .openharness/config.json.
+#
+# Permissions: Read-write (sandbox writes host sessions/provider state).
+# Replaces: opencode-auth named volume from base docker-compose.yml at the
+# /home/sandbox/.local/share/opencode target path. The named volume
+# declaration stays in the base compose — it becomes orphaned (unmounted)
+# while this overlay is active and is reinstated when the overlay is
+# removed.
+#
+# Entrypoint coordination: sets OPENCODE_HOST_BIND_MOUNT=1 so
+# entrypoint.sh skips recursive chown on /home/sandbox/.local/share/opencode
+# (which would otherwise rewrite host file ownership).
+#
+# Usage: enable via .openharness/config.json composeOverrides[]:
+#   ".devcontainer/docker-compose.opencode-host.yml"
+
+services:
+  sandbox:
+    volumes:
+      - ${HOST_OPENCODE_DIR:-~/.local/share/opencode}:/home/sandbox/.local/share/opencode
+    environment:
+      - OPENCODE_HOST_BIND_MOUNT=1

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,6 +10,7 @@
 #   - claude-auth:/home/sandbox/.claude — Persistent Claude CLI auth
 #   - codex-auth:/home/sandbox/.codex — Persistent Codex CLI auth
 #   - pi-auth:/home/sandbox/.pi — Persistent Pi Agent (oh/pi CLI) auth
+#   - opencode-auth:/home/sandbox/.local/share/opencode — Persistent OpenCode auth
 #   - cloudflared-auth:/home/sandbox/.cloudflared — Cloudflare credentials
 #   - gh-config:/home/sandbox/.config/gh — GitHub CLI config
 #
@@ -46,6 +47,7 @@ services:
       - claude-auth:/home/sandbox/.claude
       - codex-auth:/home/sandbox/.codex
       - pi-auth:/home/sandbox/.pi
+      - opencode-auth:/home/sandbox/.local/share/opencode
       - cloudflared-auth:/home/sandbox/.cloudflared
       - gh-config:/home/sandbox/.config/gh
     extra_hosts:
@@ -70,5 +72,6 @@ volumes:
   claude-auth:
   codex-auth:
   pi-auth:
+  opencode-auth:
   cloudflared-auth:
   gh-config:

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -13,9 +13,9 @@ if [ -S "$SOCK" ]; then
 fi
 
 # Fix ownership of mounted volumes (created as root by Docker).
-# Skip .claude / .codex / .pi when their host-mount overlays are active —
+# Skip .claude / .codex / .pi / opencode when their host-mount overlays are active —
 # they're host bind-mounts and chown would rewrite host file ownership
-# (see docker-compose.{claude,codex,pi}-host.yml).
+# (see docker-compose.{claude,codex,pi,opencode}-host.yml).
 # Harness packs that introduce their own host-mount overlays should add
 # their own skip clauses or run a *-entrypoint-hook.sh.
 for dir in .claude .codex .pi .cloudflared .config/gh .ssh .openharness; do
@@ -33,6 +33,13 @@ for dir in .claude .codex .pi .cloudflared .config/gh .ssh .openharness; do
     [ "$dir" = ".ssh" ] && chmod 700 "/home/sandbox/$dir" 2>/dev/null || true
   fi
 done
+
+OPENCODE_STATE="/home/sandbox/.local/share/opencode"
+if [ -d "$OPENCODE_STATE" ]; then
+  if [ "${OPENCODE_HOST_BIND_MOUNT:-0}" != "1" ]; then
+    chown -R sandbox:sandbox "$OPENCODE_STATE" 2>/dev/null || true
+  fi
+fi
 
 # ─── Host UID reconciliation ────────────────────────────────────────
 # The repo is bind-mounted at /home/sandbox/harness with its host UID/GID.

--- a/.openharness/config.json
+++ b/.openharness/config.json
@@ -2,6 +2,7 @@
   "composeOverrides": [
     ".devcontainer/docker-compose.claude-host.yml",
     ".devcontainer/docker-compose.codex-host.yml",
-    ".devcontainer/docker-compose.pi-host.yml"
+    ".devcontainer/docker-compose.pi-host.yml",
+    ".devcontainer/docker-compose.opencode-host.yml"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- OpenCode as a core sandbox agent: install `opencode-ai` in the base image, persist `~/.local/share/opencode`, add the `opencode-host` overlay, support `scripts/ralph.sh --harness=opencode`, and document OpenAI OAuth as the default OpenCode provider path.
 - `docs/agents/pi.md` stub (linking upstream to `badlogic/pi-mono`) and a Pi entry in the home-page agent grid at `apps/docs/src/pages/index.tsx`, matching Pi's restoration as a default-installed CLI. ([#233](https://github.com/ryaneggz/open-harness/pull/233))
 - Top-level `Makefile` wrapping `docker compose -f .devcontainer/docker-compose.yml` so users type `make sandbox` / `make shell` / `make destroy` instead of the 50-character compose lines. Targets: `sandbox`, `shell`, `destroy`, `stop`, `logs`, `ps`, `restart`, `help` (default, self-documenting via awk). Uses `-include .devcontainer/.env` so `SANDBOX_NAME` flows through. No agent-CLI targets — the harness's value is sandbox isolation, agent choice (`claude` / `codex` / `pi`) happens inside `make shell`.
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ cold, ~30s warm). Only host dependency: [Docker](https://docs.docker.com/get-doc
 ```bash
 cd ~/openharness
 make shell       # enter the isolated sandbox
-# inside the sandbox, launch any agent you have installed:
+# inside the sandbox, launch any core agent:
 #   claude   # Claude Code
 #   codex    # OpenAI Codex CLI
+#   opencode # OpenCode
 #   pi       # Pi Coding Agent
 make destroy     # stop and remove the sandbox
 make help        # all targets
@@ -56,7 +57,7 @@ make shell
 
 | | |
 |---|---|
-| **Default agent** | Claude Code (terminal coding agent) |
+| **Core agents** | Claude Code, Codex, OpenCode, Pi |
 | **Runtimes** | Node 22, pnpm, Bun, uv (Python) |
 | **DevOps** | Docker CLI + Compose, GitHub CLI, cloudflared, tmux, croner |
 | **Browser** | agent-browser + Chromium (headless) |

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -9,7 +9,7 @@ import { terminalDark, terminalLight } from "./src/theme/prism-terminal";
 const config: Config = {
   title: "Open Harness",
   tagline:
-    "Run Claude, Codex, and Pi side-by-side from one Docker-powered agent harness.",
+    "A Docker sandbox for Claude, Codex, OpenCode, or Pi.",
   favicon: "img/favicon.svg",
 
   url: "https://oh.mifune.dev",

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -11,7 +11,7 @@ curl -fsSL https://oh.mifune.dev/install.sh | bash
 cd ~/openharness && make shell
 
 # inside the sandbox, pick your agent
-claude        # or codex, pi`;
+claude        # or codex, opencode, pi`;
 
 const AGENTS: Array<{
   name: string;
@@ -30,6 +30,12 @@ const AGENTS: Array<{
     description: "OpenAI's CLI coding agent.",
     href: "/docs/agents/codex",
     icon: <img src="/img/agents/codex.png" alt="" width={28} height={28} />,
+  },
+  {
+    name: "OpenCode",
+    description: "Terminal agent with OpenAI OAuth support.",
+    href: "/docs/agents/opencode",
+    icon: <OpenCodeIcon />,
   },
   {
     name: "Pi",
@@ -56,7 +62,7 @@ const WHY: Array<{ title: string; body: string }> = [
 
 export default function Home(): React.ReactElement {
   return (
-    <Layout description="We provide the sandbox; you choose the agent. Open Harness is a long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, or Pi inside.">
+    <Layout description="We provide the sandbox; you choose the agent. Open Harness is a long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, or Pi inside.">
       <main>
         <section className={styles.hero}>
           <div className={styles.heroBg} aria-hidden="true" />
@@ -70,7 +76,7 @@ export default function Home(): React.ReactElement {
                 We provide the sandbox. You choose the harness.
               </h1>
               <p className={styles.heroSubtitle}>
-                A long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, or Pi inside, and let it work on demand or on a cron while you sleep.
+                A long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, or Pi inside, and let it work on demand or on a cron while you sleep.
               </p>
               <div className={styles.heroButtons}>
                 <Link
@@ -110,7 +116,7 @@ export default function Home(): React.ReactElement {
           <div className={styles.container}>
             <h2 className={styles.sectionTitle}>Pick your agent.</h2>
             <p className={styles.sectionLede}>
-              Claude Code, Codex, and Pi ship preinstalled. Switch between them inside the sandbox — or add your own by editing the Dockerfile.
+              Claude Code, Codex, OpenCode, and Pi ship preinstalled. Switch between them inside the sandbox — or add your own by editing the Dockerfile.
             </p>
             <div className={styles.agentGrid}>
               {AGENTS.map((agent) => (
@@ -216,3 +222,14 @@ function PiIcon(): React.ReactElement {
   );
 }
 
+function OpenCodeIcon(): React.ReactElement {
+  return (
+    <svg viewBox="0 0 28 28" width="28" height="28" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect x="3" y="3" width="22" height="22" rx="5" fill="currentColor" opacity="0.14" />
+      <path
+        fill="currentColor"
+        d="M8 14c0-3.6 2.5-6.2 6-6.2s6 2.6 6 6.2-2.5 6.2-6 6.2-6-2.6-6-6.2Zm3.1 0c0 2 1.1 3.4 2.9 3.4s2.9-1.4 2.9-3.4-1.1-3.4-2.9-3.4-2.9 1.4-2.9 3.4Z"
+      />
+    </svg>
+  );
+}

--- a/apps/docs/static/img/SOCIAL-CARD-TODO.md
+++ b/apps/docs/static/img/SOCIAL-CARD-TODO.md
@@ -7,7 +7,7 @@ To generate the PNG from the SVG, run the following command:
 ```bash
 convert -size 1200x630 xc:'#0b1220' \
   -fill '#f1f5fb' -gravity center -font DejaVu-Sans-Bold -pointsize 110 -annotate +0-40 'Open Harness' \
-  -fill '#92a0b6' -font DejaVu-Sans -pointsize 36 -annotate +0+80 'Run Claude, Codex, and Pi side-by-side.' \
+  -fill '#92a0b6' -font DejaVu-Sans -pointsize 36 -annotate +0+80 'A Docker sandbox for Claude, Codex, OpenCode, or Pi.' \
   -fill '#4e9af1' -draw 'rectangle 0,618 1200,630' \
   apps/docs/static/img/social-card.png
 ```

--- a/apps/docs/static/img/social-card.svg
+++ b/apps/docs/static/img/social-card.svg
@@ -14,6 +14,6 @@
   <rect width="1280" height="720" fill="url(#glow)"/>
   <text x="640" y="280" font-family="DejaVu Sans, Inter, sans-serif" font-size="32" font-weight="700" fill="#6faef3" text-anchor="middle" letter-spacing="6">OPEN SOURCE AGENT HARNESS</text>
   <text x="640" y="400" font-family="DejaVu Sans, Inter, sans-serif" font-size="140" font-weight="800" fill="#f1f5fb" text-anchor="middle" letter-spacing="-3">Open Harness</text>
-  <text x="640" y="470" font-family="DejaVu Sans, Inter, sans-serif" font-size="40" font-weight="400" fill="#92a0b6" text-anchor="middle">Run Claude, Codex, and Pi side-by-side.</text>
+  <text x="640" y="470" font-family="DejaVu Sans, Inter, sans-serif" font-size="40" font-weight="400" fill="#92a0b6" text-anchor="middle">A Docker sandbox for Claude, Codex, OpenCode, or Pi.</text>
   <rect x="0" y="706" width="1280" height="14" fill="url(#stripe)"/>
 </svg>

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 5
+title: "OpenCode"
+---
+
+# OpenCode
+
+OpenCode is a terminal coding agent that can run interactively or execute one-shot tasks. It ships preinstalled in the sandbox image alongside Claude Code, Codex, and Pi.
+
+## Install
+
+OpenCode is installed by default during sandbox provisioning. The npm package is `opencode-ai`, installed globally with npm in the sandbox image:
+
+```bash
+npm install -g opencode-ai
+```
+
+Verify the install:
+
+```bash
+opencode --version
+```
+
+## Authentication
+
+For ChatGPT Plus and Pro users, the recommended default is OpenAI OAuth through OpenCode:
+
+```bash
+opencode
+/connect
+```
+
+Choose **OpenAI** in the `/connect` flow. OpenCode stores auth at `~/.local/share/opencode/auth.json` inside the sandbox.
+
+API key and provider environment variables are secondary. Use them when you need a non-OAuth provider or service-account style setup.
+
+## Common usage
+
+```bash
+# Start an interactive session
+opencode
+
+# Run a one-shot task
+opencode run "Add input validation to the signup form"
+```
+
+Run inside a dedicated tmux session to keep the agent alive across disconnects:
+
+```bash
+tmux new-session -d -s agent-opencode 'opencode'
+tmux attach -t agent-opencode
+```
+
+## Host auth overlay
+
+The `opencode-host` overlay bind-mounts your host OpenCode state from `~/.local/share/opencode` into the sandbox. Enable it only for trusted workflows, because any code running in the sandbox can read those credentials.
+
+## Upstream documentation
+
+- [OpenCode CLI](https://opencode.ai/docs/cli/)
+- [OpenCode providers](https://opencode.ai/docs/providers/)

--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -5,9 +5,9 @@ title: "Agents Overview"
 
 # Agents Overview
 
-Open Harness ships with three agent CLIs preinstalled in the sandbox image: **Claude Code**, **Codex**, and **Pi**. Inside the sandbox, launch whichever you prefer — switch between them at any time, or stack them in tmux sessions for parallel work.
+Open Harness ships with four agent CLIs preinstalled in the sandbox image: **Claude Code**, **Codex**, **OpenCode**, and **Pi**. Inside the sandbox, launch whichever you prefer and keep long-running sessions in tmux.
 
-The sandbox is the product; the harness is your call. To go beyond the three preinstalled options, install via `npm` / `pip` / `cargo` inside the sandbox, edit the Dockerfile, or layer in a [harness pack](../guide/bring-your-own-harness.md) like [`@ryaneggz/mifune`](https://github.com/ryaneggz/mifune) (Pi+Mom Slack bot).
+The sandbox is the product; the harness is your call. To go beyond the four preinstalled options, install via `npm` / `pip` / `cargo` inside the sandbox, edit the Dockerfile, or layer in a [harness pack](../guide/bring-your-own-harness.md) like [`@ryaneggz/mifune`](https://github.com/ryaneggz/mifune) (Pi+Mom Slack bot).
 
 ## Supported agents
 
@@ -15,6 +15,7 @@ The sandbox is the product; the harness is your call. To go beyond the three pre
 |---|---|---|---|
 | [Claude Code](./claude-code.md) | Anthropic's terminal coding agent | `claude` | preinstalled |
 | [Codex](./codex.md) | OpenAI's CLI coding agent | `codex` | preinstalled |
+| [OpenCode](./opencode.md) | Terminal coding agent with OpenAI OAuth support | `opencode` | preinstalled |
 | [Pi](./pi.md) | Lightweight, customizable harness | `pi` | preinstalled |
 
 ## Verifying installation
@@ -22,6 +23,7 @@ The sandbox is the product; the harness is your call. To go beyond the three pre
 ```bash
 claude --version
 codex --version
+opencode --version
 pi --version
 ```
 
@@ -32,6 +34,7 @@ Use separate tmux sessions so each agent's output stays isolated and survives di
 ```bash
 tmux new-session -d -s agent-claude 'claude'
 tmux new-session -d -s agent-codex  'codex --dangerously-bypass-approvals-and-sandbox'
+tmux new-session -d -s agent-opencode 'opencode'
 tmux new-session -d -s agent-pi     'pi'
 ```
 

--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -5,7 +5,7 @@ title: "Pi"
 
 # Pi
 
-Pi is a lightweight, customizable harness — a hackable agent framework you can shape to your project. It ships preinstalled in the sandbox image alongside Claude Code and Codex.
+Pi is a lightweight, customizable harness — a hackable agent framework you can shape to your project. It ships preinstalled in the sandbox image alongside Claude Code, Codex, and OpenCode.
 
 ## Verify installation
 

--- a/docs/guide/overlays.md
+++ b/docs/guide/overlays.md
@@ -4,9 +4,9 @@ sidebar_position: 2
 ---
 
 
-All sandboxes are built from `.devcontainer/Dockerfile` — a Debian Bookworm image with Node.js 22, pnpm, agent CLIs (Claude Code, Codex), and dev tools pre-installed.
+All sandboxes are built from `.devcontainer/Dockerfile` — a Debian Bookworm image with Node.js 22, pnpm, agent CLIs (Claude Code, Codex, OpenCode, Pi), and dev tools pre-installed.
 
-Compose overlays in `.devcontainer/` add optional services. Enable them in `.openharness/config.json`.
+Compose overlays in `.devcontainer/` add optional services or host-state mounts. Enable or disable them in `.openharness/config.json`.
 
 ## Available overlays
 
@@ -18,7 +18,10 @@ Compose overlays in `.devcontainer/` add optional services. Enable them in `.ope
 | `docker-compose.ssh.yml` | Mount host `~/.ssh` read-only |
 | `docker-compose.ssh-generate.yml` | Generate keypair in persistent volume |
 | `docker-compose.sshd.yml` | SSH server daemon (port 2222, password auth) |
-| `docker-compose.claude-host.yml` | Bind-mount host `~/.claude` (auth, memory, projects) — opt-in |
+| `docker-compose.claude-host.yml` | Bind-mount host `~/.claude` (auth, memory, projects) |
+| `docker-compose.codex-host.yml` | Bind-mount host `~/.codex` (auth, config) |
+| `docker-compose.opencode-host.yml` | Bind-mount host `~/.local/share/opencode` (auth) |
+| `docker-compose.pi-host.yml` | Bind-mount host `~/.pi` (auth, config) |
 | `docker-compose.gateway.yml` | [Caddy reverse-proxy sidecar](./exposure.md) (auto-activated by first `openharness expose`) |
 
 ## Configuration
@@ -28,14 +31,13 @@ Edit `.openharness/config.json` to enable or disable overlays:
 ```json
 {
   "composeOverrides": [
-    ".devcontainer/docker-compose.cloudflared.yml",
-    ".devcontainer/docker-compose.slack.yml",
+    ".devcontainer/docker-compose.postgres.yml",
     ".devcontainer/docker-compose.ssh-generate.yml"
   ]
 }
 ```
 
-Default enabled: `cloudflared`, `slack`. Docker socket is mounted in the base compose file.
+Default enabled: `claude-host`, `codex-host`, `opencode-host`, and `pi-host` when the install host UID is 1000. `scripts/install.sh` disables host auth overlays on other UIDs so named Docker volumes take over. Docker socket is mounted in the base compose file.
 
 After editing, run `make sandbox` (or `make destroy && make sandbox` if the container is already up) to apply changes.
 
@@ -95,8 +97,7 @@ Enable it by adding the overlay path to your existing
 ```json
 {
   "composeOverrides": [
-    ".devcontainer/docker-compose.cloudflared.yml",
-    ".devcontainer/docker-compose.slack.yml",
+    ".devcontainer/docker-compose.codex-host.yml",
     ".devcontainer/docker-compose.claude-host.yml"
   ]
 }
@@ -138,3 +139,34 @@ group-based access reconciliation does not help. The overlay sets
 1000, the sandbox user cannot read `.credentials.json` and `claude`
 will prompt for auth anyway. Check with `id -u` on the host before
 enabling.
+
+## Sharing host OpenCode state (`opencode-host`)
+
+Without the host overlay, each sandbox stores OpenCode auth in a named Docker volume mounted at `~/.local/share/opencode`. OpenCode writes OpenAI OAuth credentials to `~/.local/share/opencode/auth.json`.
+
+The `opencode-host` overlay replaces that volume with a read-write bind-mount of your host state:
+
+- `~/.local/share/opencode/` — OpenCode auth and provider state
+
+Enable it by adding the overlay path to your existing `composeOverrides` array:
+
+```json
+{
+  "composeOverrides": [
+    ".devcontainer/docker-compose.cloudflared.yml",
+    ".devcontainer/docker-compose.opencode-host.yml"
+  ]
+}
+```
+
+Override the default via `.devcontainer/.env` if your state lives elsewhere:
+
+- `HOST_OPENCODE_DIR` — alternate path for the directory (default `~/.local/share/opencode`)
+
+Pre-flight:
+
+```bash
+test -d ~/.local/share/opencode && echo OK
+```
+
+Only enable host auth overlays for trusted workflows. OAuth tokens are readable by any code running in the sandbox, and sandbox writes propagate to the host directory.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -94,6 +94,7 @@ Debian Bookworm (slim). The `sandbox` user has passwordless sudo.
 |------|---------|-------------|
 | Claude Code | `claude` | Anthropic's coding agent (aliased to `claude --dangerously-skip-permissions`) |
 | OpenAI Codex | `codex` | OpenAI's coding agent (aliased to `codex --dangerously-bypass-approvals-and-sandbox`) |
+| OpenCode | `opencode` | `opencode-ai` — terminal coding agent with OpenAI OAuth support |
 | Pi | `pi` | `@mariozechner/pi-coding-agent` — local-first coding agent |
 | agent-browser | `agent-browser` | Headless Chromium for web-capable agents |
 
@@ -145,6 +146,7 @@ Auth credentials survive container rebuilds via named Docker volumes:
 
 - `claude-auth` → `~/.claude` (Claude Code OAuth) — or, with the [`claude-host` overlay](./guide/overlays.md#sharing-host-claude-state-claude-host), a RW bind-mount of your host `~/.claude`.
 - `codex-auth` → `~/.codex` (Codex OAuth) — or, with the `codex-host` overlay, a RW bind-mount of your host `~/.codex`.
+- `opencode-auth` → `~/.local/share/opencode` (OpenCode OAuth; `auth.json`) — or, with the [`opencode-host` overlay](./guide/overlays.md#sharing-host-opencode-state-opencode-host), a RW bind-mount of your host `~/.local/share/opencode`.
 - `pi-auth` → `~/.pi` (Pi Agent OAuth) — or, with the `pi-host` overlay, a RW bind-mount of your host `~/.pi`.
 - `cloudflared-auth` → `~/.cloudflared` (Cloudflare credentials)
 - `gh-config` → `~/.config/gh` (GitHub CLI tokens)

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -31,17 +31,20 @@ Verify with `gh auth status`. If it succeeds, you are done with this step.
 
 ### Step 2 — LLM provider
 
-Authenticate Claude Code, Codex, and Pi (each ships in the base sandbox) so they can make API calls.
+Authenticate Claude Code, Codex, OpenCode, and Pi (each ships in the base sandbox) so they can make API calls.
 
 ```bash
 claude   # opens the OAuth flow on first run; follow the printed URL
 codex    # OpenAI auth, only if you intend to use Codex
+opencode # run /connect, then choose OpenAI
 pi       # @mariozechner/pi-coding-agent; OAuth on first run
 ```
 
-Each writes tokens to its directory under the sandbox home (`~/.claude/`, `~/.codex/`, `~/.pi/`). With the persistent named volumes, credentials survive container rebuilds. The `*-host` overlays (enabled by default in `.openharness/config.json`) bind-mount the matching host directories so your laptop's existing auth carries straight in — see [provision.md](./operations/provision.md).
+OpenCode's recommended default for ChatGPT Plus and Pro users is OpenAI OAuth through `/connect` → OpenAI. It writes auth to `~/.local/share/opencode/auth.json`.
 
-If you prefer API keys over OAuth, set the relevant variables in `.devcontainer/.env` (e.g. `OPENAI_API_KEY`) before bringing the sandbox up.
+Each agent writes tokens to its directory under the sandbox home (`~/.claude/`, `~/.codex/`, `~/.local/share/opencode/`, `~/.pi/`). With persistent named volumes, credentials survive container rebuilds. The `*-host` overlays (enabled by default in `.openharness/config.json`) bind-mount matching host directories so your laptop's existing auth carries straight in — see [provision.md](./operations/provision.md).
+
+If you prefer API keys or provider env over OAuth, set the relevant variables in `.devcontainer/.env` (e.g. `OPENAI_API_KEY`) before bringing the sandbox up.
 
 ### Step 3 — SSH key (optional)
 
@@ -95,6 +98,8 @@ See `.claude/rules/sandbox-processes.md` (rendered in the Architecture section) 
 **Cloudflare login opens no browser:** `cloudflared login` prints a URL — paste it into any browser on your laptop.
 
 **Claude Code auth fails:** Run `claude` directly inside the sandbox to retrigger the OAuth flow interactively. If you mounted host `~/.claude` via the `claude-host` overlay, your laptop's existing credentials are reused and no in-sandbox flow is needed.
+
+**OpenCode auth fails:** Run `opencode`, then `/connect` → OpenAI. If you mounted host `~/.local/share/opencode` via the `opencode-host` overlay, your laptop's existing OpenCode auth is reused.
 
 **Slack bot not responding (mifune pack):** Attach to the agent's tmux session to see error output:
 

--- a/docs/operations/provision.md
+++ b/docs/operations/provision.md
@@ -12,7 +12,7 @@ That single command builds the image (Node 22, agent CLIs, procps, tmux), starts
 
 ## Compose overlays
 
-Overlays live in `.devcontainer/docker-compose.*.yml` and are opt-in via `.openharness/config.json` → `composeOverrides`. Each entry adds another `-f <file>` to the compose invocation.
+Overlays live in `.devcontainer/docker-compose.*.yml` and are selected through `.openharness/config.json` → `composeOverrides`. Each entry adds another `-f <file>` to the compose invocation.
 
 | Overlay | Purpose |
 |---|---|
@@ -23,11 +23,12 @@ Overlays live in `.devcontainer/docker-compose.*.yml` and are opt-in via `.openh
 | `docker-compose.sshd.yml` | sshd as main process, port 2222:22 |
 | `docker-compose.claude-host.yml` | Bind-mount host `~/.claude` (trust tradeoff) |
 | `docker-compose.codex-host.yml` | Bind-mount host `~/.codex` (trust tradeoff) |
+| `docker-compose.opencode-host.yml` | Bind-mount host `~/.local/share/opencode` (trust tradeoff) |
 | `docker-compose.pi-host.yml` | Bind-mount host `~/.pi` (trust tradeoff) |
 | `docker-compose.ssh.yml` | Mount host `~/.ssh` read-only — git-over-SSH, mutually exclusive with `ssh-generate` |
 | `docker-compose.ssh-generate.yml` | Generate persistent ED25519 keypair in named volume |
 
-> The `claude-host`, `codex-host`, and `pi-host` overlays all require host UID = 1000 and pre-existing host directories (`~/.claude` + `~/.claude.json` for claude; `~/.codex` for codex; `~/.pi` for pi). See the trust tradeoffs in each `.devcontainer/docker-compose.*-host.yml` file.
+> The `claude-host`, `codex-host`, `opencode-host`, and `pi-host` overlays all require host UID = 1000 and pre-existing host directories (`~/.claude` + `~/.claude.json` for claude; `~/.codex` for codex; `~/.local/share/opencode` for OpenCode; `~/.pi` for pi). See the trust tradeoffs in each `.devcontainer/docker-compose.*-host.yml` file.
 
 To enable an overlay, add its path to `.openharness/config.json`:
 

--- a/docs/operations/repair.md
+++ b/docs/operations/repair.md
@@ -17,6 +17,7 @@ The remediation paths differ slightly: from the host you wrap commands in `docke
 ```bash
 node --version                             # expect >= 22
 command -v claude && claude --version      # default agent CLI
+command -v opencode && opencode --version  # OpenCode CLI
 docker ps >/dev/null 2>&1 && echo OK       # docker socket (if docker overlay enabled)
 tmux ls                                    # expect system-cron session
 ```
@@ -27,6 +28,7 @@ tmux ls                                    # expect system-cron session
 docker exec -u sandbox openharness bash -c '
   node --version
   command -v claude && claude --version
+  command -v opencode && opencode --version
   docker ps >/dev/null 2>&1 && echo OK
   tmux ls
 '
@@ -42,6 +44,7 @@ If the container itself is down, `docker exec` returns non-zero. Bring it back w
 | Container restart-loops | `docker logs openharness` — usually a missing env var or volume permission issue |
 | `claude --version` fails | `docker exec -u sandbox openharness sudo npm install -g @anthropic-ai/claude-code` |
 | `codex --version` fails | `docker exec -u sandbox openharness sudo npm install -g @openai/codex` |
+| `opencode --version` fails | `docker exec -u sandbox openharness sudo npm install -g opencode-ai` |
 | `pi --version` fails | `docker exec -u sandbox openharness sudo npm install -g @mariozechner/pi-coding-agent` |
 | Node version wrong | Image is stale. Rebuild: `docker compose ... down -v && docker compose ... up -d --build` |
 | `docker ps` fails inside sandbox | Verify the `/var/run/docker.sock` bind mount in `.devcontainer/docker-compose.yml` is intact; usually a host-side socket permission issue, not a missing overlay |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,6 +39,7 @@ you prefer:
 ```bash
 claude        # Claude Code
 codex         # OpenAI Codex CLI
+opencode      # OpenCode
 pi            # Pi Coding Agent
 ```
 

--- a/install/banner.sh
+++ b/install/banner.sh
@@ -53,12 +53,28 @@ if [ -s "${HOME}/.claude/.credentials.json" ]; then
   claude_detail="authenticated"
 fi
 
+# codex — check for populated auth.json
+codex_status="[✗]"
+codex_detail="not authenticated — run: codex"
+if [ -s "${HOME}/.codex/auth.json" ]; then
+  codex_status="[✓]"
+  codex_detail="authenticated"
+fi
+
 # pi — check for populated .pi directory
 pi_status="[✗]"
 pi_detail="not authenticated — run: pi"
 if [ -s "${HOME}/.pi/agent/auth.json" ]; then
   pi_status="[✓]"
   pi_detail="authenticated"
+fi
+
+# opencode — check for populated provider auth file
+opencode_status="[✗]"
+opencode_detail="not authenticated — run: opencode, then /connect"
+if [ -s "${HOME}/.local/share/opencode/auth.json" ]; then
+  opencode_status="[✓]"
+  opencode_detail="authenticated"
 fi
 
 # openharness CLI — verify the bind-mounted package built and symlinked
@@ -83,10 +99,12 @@ printf '\n'
 printf '  Onboarding:\n'
 printf '    %-6s %-11s %s\n' "$gh_status"     "gh"          "$gh_detail"
 printf '    %-6s %-11s %s\n' "$claude_status" "claude"      "$claude_detail"
+printf '    %-6s %-11s %s\n' "$codex_status"  "codex"       "$codex_detail"
+printf '    %-6s %-11s %s\n' "$opencode_status" "opencode"  "$opencode_detail"
 printf '    %-6s %-11s %s\n' "$pi_status"     "pi"          "$pi_detail"
 printf '    %-6s %-11s %s\n' "$oh_status"     "openharness" "$oh_detail"
 printf '\n'
-printf '  Shortcuts: claude · pi · tmux attach -t system-cron\n'
+printf '  Shortcuts: claude · codex · opencode · pi · tmux attach -t system-cron\n'
 printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
 printf '\n'
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -294,8 +294,8 @@ ENVEOF
 fi
 
 # ─── Pre-create host auth source dirs ────────────────────────────────
-# Default config enables host-bind overlays (claude-host.yml, codex-host.yml)
-# that bind ~/.claude and ~/.codex from the host into the container. Two
+# Default config enables host-bind overlays (claude-host.yml, codex-host.yml,
+# pi-host.yml, opencode-host.yml) that bind host agent state into the container. Two
 # preconditions (each documented in the overlay headers):
 #   1. Host UID == 1000 (credential files are mode 0600 — group-membership
 #      trick in entrypoint.sh cannot bypass owner-only reads).
@@ -306,7 +306,7 @@ fi
 # (1) is checked below and surfaced as a warning — the user must opt
 # out by hand if their host UID isn't 1000.
 banner "Preparing host auth dirs for sandbox bind-mounts"
-for d in .claude .codex .pi; do
+for d in .claude .codex .pi .local/share/opencode; do
   if [ ! -d "$HOME/$d" ]; then
     mkdir -p "$HOME/$d"
     ok "Created ~/$d (empty — first-time auth will populate it)"
@@ -324,9 +324,9 @@ if [ "$__HOST_UID" != "1000" ]; then
   __OH_CONFIG="$REPO_DIR/.openharness/config.json"
   if command -v jq >/dev/null 2>&1 && [ -f "$__OH_CONFIG" ]; then
     # Filter *-host.yml entries out of composeOverrides. Mode-0600
-    # credential files in ~/.claude / ~/.codex can't be read by the
+    # credential files in host agent state dirs can't be read by the
     # sandbox user (UID 1000) when the host UID differs. Drop the
-    # overlays so the base named volumes (claude-auth, codex-auth)
+    # overlays so the base named volumes
     # take over; entrypoint.sh chowns those to UID 1000.
     __OH_TMP="$(mktemp)"
     if jq '.composeOverrides |= map(select(test("-host\\.yml$") | not))' \
@@ -334,7 +334,7 @@ if [ "$__HOST_UID" != "1000" ]; then
       if ! cmp -s "$__OH_CONFIG" "$__OH_TMP"; then
         mv "$__OH_TMP" "$__OH_CONFIG"
         ok "Host UID $__HOST_UID ≠ 1000 — disabled host-bind overlays in $__OH_CONFIG"
-        ok "Auth will live in named volumes; first run of claude/codex inside the sandbox will authenticate"
+        ok "Auth will live in named volumes; first run of each agent inside the sandbox will authenticate"
         warn "$__OH_CONFIG now has a local diff — \`git pull\` in $REPO_DIR will be skipped until you commit or revert it"
       else
         rm -f "$__OH_TMP"
@@ -351,15 +351,17 @@ if [ "$__HOST_UID" != "1000" ]; then
   fi
   if [ "${__OH_FALLBACK:-0}" = "1" ]; then
     warn "Host UID is $__HOST_UID — sandbox user is UID 1000."
-    warn "Credential files in ~/.claude / ~/.codex are mode 0600;"
+    warn "Credential files in host agent state dirs may be mode 0600;"
     warn "the sandbox WILL NOT be able to read them despite the bind-mount."
     warn ""
     warn "Install jq, OR edit $REPO_DIR/.openharness/config.json"
     warn "and remove these overlays from composeOverrides:"
     warn "    .devcontainer/docker-compose.claude-host.yml"
     warn "    .devcontainer/docker-compose.codex-host.yml"
+    warn "    .devcontainer/docker-compose.pi-host.yml"
+    warn "    .devcontainer/docker-compose.opencode-host.yml"
     warn ""
-    warn "The base named volumes (claude-auth, codex-auth) will take over"
+    warn "The base named volumes will take over"
     warn "and entrypoint.sh chowns them to UID 1000 on boot."
   fi
   unset __OH_CONFIG __OH_FALLBACK
@@ -389,7 +391,7 @@ printf "  ${CYAN}Lifecycle (from %s)${NC}\n" "$REPO_DIR"
 printf "  ──────────────────────────────────────\n"
 printf "       cd %s\n" "$REPO_DIR"
 printf "       make shell        # enter the sandbox\n"
-printf "                         # then pick your agent: claude, codex, pi, ...\n"
+printf "                         # then pick your agent: claude, codex, opencode, pi, ...\n"
 printf "       make help         # all targets\n"
 printf "       make destroy      # tear down later\n"
 printf "\n"

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # scripts/ralph.sh — Ralph loop runner per SPEC §scripts.
 #
-# Usage:   scripts/ralph.sh [--harness=claude|pi|codex] <taskdesc>
+# Usage:   scripts/ralph.sh [--harness=claude|pi|codex|opencode] <taskdesc>
 # Example: scripts/ralph.sh openharness-v07-convergence
 # Example: scripts/ralph.sh --harness=pi openharness-v07-convergence
 # Example: scripts/ralph.sh --harness=codex openharness-v07-convergence
+# Example: scripts/ralph.sh --harness=opencode openharness-v07-convergence
 #
 # Validates the four-file contract (prd.md, prd.json, prompt.md, progress.txt),
 # launches a named tmux session running the loop. Each iteration sends prompt.md
@@ -22,29 +23,31 @@
 #   --harness=pi       run Pi for every iteration; fall back to Codex if Pi is
 #                      unavailable
 #   --harness=codex    run Codex for every iteration
+#   --harness=opencode run OpenCode for every iteration
 #
 # Configuration (env vars):
-#   RALPH_HARNESS        default harness if --harness is omitted (claude|pi|codex)
+#   RALPH_HARNESS        default harness if --harness is omitted (claude|pi|codex|opencode)
 #   RALPH_CLAUDE_FLAGS   Claude flags (default: --dangerously-skip-permissions --print)
 #   RALPH_AGENT_FLAGS    backwards-compatible alias for RALPH_CLAUDE_FLAGS
 #   RALPH_PI_FLAGS       Pi flags (default: --print)
+#   RALPH_OPENCODE_FLAGS OpenCode run flags (default: empty)
 #   RALPH_MAX_ITERATIONS safety cap (default: 50)
 #   RALPH_SLEEP          seconds between iterations (default: 2)
 
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 [--harness=claude|pi|codex] <taskdesc>" >&2
+  echo "Usage: $0 [--harness=claude|pi|codex|opencode] <taskdesc>" >&2
 }
 
 normalize_harness() {
   local harness="$1"
   case "$harness" in
-    claude|pi|codex)
+    claude|pi|codex|opencode)
       printf '%s\n' "$harness"
       ;;
     *)
-      echo "Error: unknown harness '$harness' (expected: claude, pi, or codex)." >&2
+      echo "Error: unknown harness '$harness' (expected: claude, pi, codex, or opencode)." >&2
       exit 2
       ;;
   esac
@@ -62,7 +65,7 @@ parse_args() {
       --harness)
         shift
         if [ "${1-}" = "" ]; then
-          echo "Error: --harness requires a value (claude, pi, or codex)." >&2
+          echo "Error: --harness requires a value (claude, pi, codex, or opencode)." >&2
           exit 2
         fi
         HARNESS="$1"
@@ -188,6 +191,15 @@ run_codex() {
   codex exec --sandbox danger-full-access "$task"
 }
 
+run_opencode() {
+  local task="$1"
+  local opencode_flags="${RALPH_OPENCODE_FLAGS:-}"
+
+  # Intentionally leave flags unquoted so callers can provide multiple flags.
+  # shellcheck disable=SC2086
+  opencode run $opencode_flags "$task"
+}
+
 run_iteration() {
   local harness="$1"
   local task="$2"
@@ -206,6 +218,10 @@ run_iteration() {
       ;;
     codex)
       run_codex "$task" 2>&1 | tee "$output_file"
+      status=${PIPESTATUS[0]}
+      ;;
+    opencode)
+      run_opencode "$task" 2>&1 | tee "$output_file"
       status=${PIPESTATUS[0]}
       ;;
     *)
@@ -240,6 +256,7 @@ if [ "${1-}" = "--loop" ]; then
   printf '│  claude: claude %s\n' "$CLAUDE_FLAGS"
   printf '│  pi: pi %s <task>\n' "${RALPH_PI_FLAGS:---print}"
   printf '│  codex: codex exec --sandbox danger-full-access <task>\n'
+  printf '│  opencode: opencode run %s <task>\n' "${RALPH_OPENCODE_FLAGS:-}"
   printf '│  max iterations: %s\n' "$MAX_ITER"
   printf '│  progress: %s\n╰─\n\n' "$PROGRESS"
 
@@ -254,7 +271,7 @@ if [ "${1-}" = "--loop" ]; then
     printf '\n── iteration %d / %s (%s) ──────────────────────────────\n' "$i" "$MAX_ITER" "$ACTIVE_HARNESS"
 
     # All harnesses receive the same Ralph task text from prompt.md. Claude gets
-    # it on stdin (matching historical behavior); Pi and Codex get it as the
+    # it on stdin (matching historical behavior); Pi, Codex, and OpenCode get it as the
     # prompt/task argument required by their CLIs.
     TASK_TEXT="$(cat "$PROMPT")"
     ITERATION_OUTPUT="$(mktemp -t "ralph-$TASKDESC-$i.XXXXXX")"


### PR DESCRIPTION
## Summary
- Add OpenCode (`opencode-ai`) as a fourth core sandbox agent alongside Claude Code, Codex, and Pi.
- New `opencode-host` overlay bind-mounts host `~/.local/share/opencode`; `opencode-auth` named volume covers UID-mismatch fallbacks.
- `scripts/ralph.sh --harness=opencode` runs OpenCode via `opencode run <task>`.
- Banner reports OpenCode auth status; install script pre-creates `~/.local/share/opencode` and disables host overlays when host UID ≠ 1000.
- Docs: new `docs/agents/opencode.md`, plus updates to overview, installation, onboarding, quickstart, overlays, provision, repair, README, CHANGELOG, home-page agent grid, and social card copy.

Closes #239

## Test plan
- [ ] `make destroy && make sandbox && make shell` — `opencode --version` resolves.
- [ ] `opencode` then `/connect` → OpenAI completes against the bind-mounted `~/.local/share/opencode/auth.json`.
- [ ] `scripts/ralph.sh --harness=opencode <taskdesc>` launches a tmux loop and runs at least one iteration.
- [ ] Host UID ≠ 1000 path: `scripts/install.sh` strips `*-host.yml` overlays from `.openharness/config.json` and base named volume mounts cleanly.
- [ ] Banner shows `[✓] opencode authenticated` after `/connect`.
- [ ] Docs site builds; `docs/agents/opencode.md` renders and the home-page agent grid shows OpenCode.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)