### PR TITLE
FROM task/242-remove-redundant-root-cname TO development

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-oh.mifune.dev


### PR DESCRIPTION
Closes #242

## Summary

Deletes the redundant `/CNAME` file at the repo root. The custom domain `oh.mifune.dev` stays live — it's wired through `apps/docs/static/CNAME` (which Docusaurus copies into the deployed Pages artifact), not via the root file.

## Why this is safe

- `.github/workflows/docs.yml` is in **workflow mode** for Pages: it uploads `apps/docs/build/` as the artifact (line 61), and `actions/deploy-pages@v4` deploys from that artifact.
- Docusaurus copies `apps/docs/static/CNAME` into `apps/docs/build/CNAME` during `pnpm run build`. GitHub Pages reads the CNAME from inside the artifact and applies the custom domain.
- The repo-root `/CNAME` is the format Pages reads in **branch-source mode** — which this repo isn't using. It's been dead since the Docusaurus migration in PR #165.
- Pages API confirms: `build_type: workflow`, `cname: oh.mifune.dev`, status `built`. No change to that surface from this PR.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the next docs deploy (`Docs: build & deploy` workflow on push to `main`) completes successfully
- [ ] `https://oh.mifune.dev` still resolves and serves the docs site
- [ ] `gh api repos/ryaneggz/open-harness/pages` still reports `cname: oh.mifune.dev`