### PR TITLE
fix: chown opencode config parent and add DeepAgents docs tile

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -37,12 +37,18 @@ for dir in .claude .codex .pi .deepagents .cloudflared .config/gh .ssh .openharn
   fi
 done
 
-# Fix ownership of /home/sandbox/.local and /home/sandbox/.local/share —
-# Docker auto-creates these as root to satisfy the opencode bind-mount path,
-# which then blocks `opencode` from creating siblings like `.local/state`
-# (EACCES on first run). Non-recursive so the bind-mounted
-# `.local/share/opencode` stays untouched when OPENCODE_HOST_BIND_MOUNT=1.
-for parent in /home/sandbox/.local /home/sandbox/.local/share; do
+# Fix ownership of parents Docker auto-creates as root to satisfy named-volume
+# or bind-mount targets, which then block the sandbox user from creating
+# sibling dirs (EACCES on first run). Two known cases:
+#   • `.local` / `.local/share` — parents of the opencode state mount; without
+#     this `opencode` can't create `.local/state`.
+#   • `.config` — parent of the `gh-config` named volume (see
+#     docker-compose.yml); without this `opencode` can't create
+#     `.config/opencode`, and any other tool writing under `~/.config/<tool>`
+#     would hit the same wall.
+# Non-recursive so the bind-mounted children (`.local/share/opencode`,
+# `.config/gh`) stay untouched.
+for parent in /home/sandbox/.local /home/sandbox/.local/share /home/sandbox/.config; do
   if [ -d "$parent" ]; then
     chown sandbox:sandbox "$parent" 2>/dev/null || true
   fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Fixed
+- Docs landing page supported-agent copy and agent grid now include DeepAgents with a matching icon tile.
 - `opencode --version` (and any `opencode` invocation) failing with `EACCES: permission denied, mkdir '/home/sandbox/.config/opencode'` on a fresh sandbox. Docker auto-creates `~/.config` as root to satisfy the `gh-config:/home/sandbox/.config/gh` named-volume mount, which then blocks the sandbox user from creating siblings like `~/.config/opencode`. The entrypoint's non-recursive parent-chown loop now also covers `~/.config` alongside the existing `~/.local` / `~/.local/share` parents, while leaving the bind-mounted `~/.config/gh` contents untouched. ([#247](https://github.com/ryaneggz/open-harness/issues/247))
 - `opencode` and `opencode /connect` failing with `EACCES: permission denied, mkdir '/home/sandbox/.local/state'` on a fresh sandbox. Docker auto-creates `~/.local` and `~/.local/share` as root to satisfy the `opencode-host` bind-mount path; the entrypoint now non-recursively chowns those parent dirs to `sandbox:sandbox` so the user can create siblings like `.local/state`. The bind-mounted `~/.local/share/opencode` itself stays untouched. Re-applies a fix that was lost when [#241](https://github.com/ryaneggz/open-harness/pull/241) merged a conflicting `entrypoint.sh`. ([#245](https://github.com/ryaneggz/open-harness/issues/245))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Fixed
+- `opencode --version` (and any `opencode` invocation) failing with `EACCES: permission denied, mkdir '/home/sandbox/.config/opencode'` on a fresh sandbox. Docker auto-creates `~/.config` as root to satisfy the `gh-config:/home/sandbox/.config/gh` named-volume mount, which then blocks the sandbox user from creating siblings like `~/.config/opencode`. The entrypoint's non-recursive parent-chown loop now also covers `~/.config` alongside the existing `~/.local` / `~/.local/share` parents, while leaving the bind-mounted `~/.config/gh` contents untouched. ([#247](https://github.com/ryaneggz/open-harness/issues/247))
 - `opencode` and `opencode /connect` failing with `EACCES: permission denied, mkdir '/home/sandbox/.local/state'` on a fresh sandbox. Docker auto-creates `~/.local` and `~/.local/share` as root to satisfy the `opencode-host` bind-mount path; the entrypoint now non-recursively chowns those parent dirs to `sandbox:sandbox` so the user can create siblings like `.local/state`. The bind-mounted `~/.local/share/opencode` itself stays untouched. Re-applies a fix that was lost when [#241](https://github.com/ryaneggz/open-harness/pull/241) merged a conflicting `entrypoint.sh`. ([#245](https://github.com/ryaneggz/open-harness/issues/245))
 
 ### Added

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -11,7 +11,7 @@ curl -fsSL https://oh.mifune.dev/install.sh | bash
 cd ~/openharness && make shell
 
 # inside the sandbox, pick your agent
-claude        # or codex, opencode, pi`;
+claude        # or codex, opencode, pi, deepagents`;
 
 const AGENTS: Array<{
   name: string;
@@ -43,6 +43,19 @@ const AGENTS: Array<{
     href: "/docs/agents/pi",
     icon: <PiIcon />,
   },
+  {
+    name: "DeepAgents",
+    description: "LangChain's multi-provider terminal agent.",
+    href: "/docs/agents/deepagents",
+    icon: (
+      <img
+        src="https://avatars.githubusercontent.com/u/126733545?s=200&v=4"
+        alt=""
+        width={28}
+        height={28}
+      />
+    ),
+  },
 ];
 
 const WHY: Array<{ title: string; body: string }> = [
@@ -62,7 +75,7 @@ const WHY: Array<{ title: string; body: string }> = [
 
 export default function Home(): React.ReactElement {
   return (
-    <Layout description="We provide the sandbox; you choose the agent. Open Harness is a long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, or Pi inside.">
+    <Layout description="We provide the sandbox; you choose the agent. Open Harness is a long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, Pi, or DeepAgents inside.">
       <main>
         <section className={styles.hero}>
           <div className={styles.heroBg} aria-hidden="true" />
@@ -76,7 +89,7 @@ export default function Home(): React.ReactElement {
                 We provide the sandbox. You choose the harness.
               </h1>
               <p className={styles.heroSubtitle}>
-                A long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, or Pi inside, and let it work on demand or on a cron while you sleep.
+                A long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, Pi, or DeepAgents inside, and let it work on demand or on a cron while you sleep.
               </p>
               <div className={styles.heroButtons}>
                 <Link
@@ -116,7 +129,7 @@ export default function Home(): React.ReactElement {
           <div className={styles.container}>
             <h2 className={styles.sectionTitle}>Pick your agent.</h2>
             <p className={styles.sectionLede}>
-              Claude Code, Codex, OpenCode, and Pi ship preinstalled. Switch between them inside the sandbox — or add your own by editing the Dockerfile.
+              Claude Code, Codex, OpenCode, Pi, and DeepAgents ship preinstalled. Switch between them inside the sandbox — or add your own by editing the Dockerfile.
             </p>
             <div className={styles.agentGrid}>
               {AGENTS.map((agent) => (
@@ -205,9 +218,8 @@ export default function Home(): React.ReactElement {
   );
 }
 
-/* ---------- Pi icon ----------
- * Inlined so `currentColor` adapts to light/dark theme. The other agents
- * have official PNG/SVG marks with their own colors (see /img/agents/). */
+/* ---------- Inline agent icons ----------
+ * Inlined so `currentColor` adapts to light/dark theme. */
 
 function PiIcon(): React.ReactElement {
   return (


### PR DESCRIPTION
Closes #247

## Summary
- Chown `/home/sandbox/.config` non-recursively during sandbox startup so `opencode` can create `~/.config/opencode` without rewriting the `~/.config/gh` volume contents.
- Update the docs landing page to include DeepAgents in the quickstart copy, hero metadata, agent grid, and logo tile.
- Use the DeepAgents GitHub avatar URL for the landing-page logo: `https://avatars.githubusercontent.com/u/126733545?s=200&v=4`.

## Verification
- Fresh sandbox checks from the original branch QA confirmed `.config` becomes `sandbox:sandbox`, `opencode --version` no longer hits EACCES, `.config/opencode` is created, `.config/gh` remains intact, and `gh auth status` still works.
- `bash -n .devcontainer/entrypoint.sh`
- Browser recheck was attempted with `agent-browser`; this environment had no docs server listening on `localhost:3000`, so the page could not be inspected there before PR creation.