### PR TITLE
FROM task/323-remove-config-example TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ### Changed
 ### Fixed
 ### Removed
+- `config.example.json` and its install-time seeding step (`scripts/install.sh`); the base ships zero compose overlays and all readers tolerate a missing `config.json`, so the example template was dead weight. Packs that need overlays create their own `config.json` ([#323](https://github.com/ryaneggz/open-harness/issues/323)).
 ### Deprecated
 ### Security
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,0 @@
-{
-  "composeOverrides": [
-    ".devcontainer/docker-compose.claude-host.yml",
-    ".devcontainer/docker-compose.codex-host.yml",
-    ".devcontainer/docker-compose.opencode-host.yml"
-  ]
-}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -299,12 +299,6 @@ else
     fi
   fi
 
-  # ── Seed config.json from example if missing ──────────────────────────
-  if [ ! -f "$REPO_DIR/config.json" ] && [ -f "$REPO_DIR/config.example.json" ]; then
-    cp "$REPO_DIR/config.example.json" "$REPO_DIR/config.json"
-    ok "Seeded config.json from config.example.json"
-  fi
-
   # ── Shell CWD notice (for B migration) ────────────────────────────────
   # If the user's shell was open in ~/openharness, that path no longer exists.
   printf "\n"


### PR DESCRIPTION
## Summary
Removes `config.example.json` and its dead install-time seeding step.

`config.example.json` was the tracked seed template for the gitignored `config.json` (`composeOverrides[]`). The base harness ships **zero** compose overlays, and all three real readers — `Makefile`, `scripts/install.sh`, `install/banner.sh` — already tolerate a missing `config.json` via guarded `jq` fallbacks. The only consumer of the *example* file was the seeding block at `scripts/install.sh:302-306`, so the template was dead weight.

## Changes
- Delete `config.example.json`
- Remove the now-dead seeding block from `scripts/install.sh`
- Add a `CHANGELOG` `[Unreleased]` → `### Removed` entry

## Notes
- No runtime impact: an absent `config.json` is functionally identical to one with an empty `composeOverrides` array.
- Historical breaking-change note in `CHANGELOG.md` (versioned section) intentionally left untouched.
- Packs that need overlays create their own `config.json` (documented in `docs/quickstart.md` / `docs/installation.md`).

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)