### PR TITLE
FROM task/331-self-hosting-dx-docs TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 
 ### Changed
 - All 15 skills in `.claude/skills/` now sourced from and version-pinned to `github.com/mifunedev/skills` (commit `c559c100`) via `.mifune/skills.lock`; `interview` and `render-html` contributed upstream and added to the lock ([#327](https://github.com/ryaneggz/open-harness/issues/327)).
+- `README.md`, `docs/installation.md`, and `docs/quickstart.md` restructured to surface fork-and-clone and clone-and-own as first-class install paths alongside the upstream one-liner; `scripts/install.sh` local-run detection is now the documented bootstrap for self-hosters ([#331](https://github.com/ryaneggz/open-harness/issues/331)).
 - Skill `LICENSE` files updated to `Copyright (c) 2026 Mifune Dev (mifune.dev)` to match upstream correction.
 ### Fixed
 ### Removed

--- a/README.md
+++ b/README.md
@@ -13,28 +13,41 @@
 
 ## 📦 Install
 
+**Option A — Upstream (try it without any setup):**
+
 ```bash
 curl -fsSL https://oh.mifune.dev/install.sh | bash
 ```
 
-The installer clones into `~/.openharness`, offers to share your host
-`gh` token, writes `.devcontainer/.env`, and builds the image (~10 min
-cold, ~30s warm). Only host dependency: [Docker](https://docs.docker.com/get-docker/).
+Clones into `~/.openharness`, offers to share your host `gh` token, writes `.devcontainer/.env`, and builds the image (~10 min cold, ~30s warm). Only host dependency: [Docker](https://docs.docker.com/get-docker/).
 
-### 📦 For forks / self-host
+**Option B — Fork and clone (recommended for self-hosting):**
 
-> **Forking this repo?** The block above pulls upstream code. Use the block below to install your fork instead.
+```bash
+# 1. Fork on GitHub, then clone YOUR fork:
+git clone https://github.com/<your-org>/<your-fork>.git && cd <your-fork>
+# 2. Bootstrap — installer auto-detects the local clone, no env vars needed:
+bash scripts/install.sh
+```
+
+**Option C — Clone upstream, then re-point to your repo:**
+
+```bash
+git clone https://github.com/ryaneggz/open-harness.git my-harness && cd my-harness
+git remote set-url origin https://github.com/<your-org>/<your-repo>.git
+bash scripts/install.sh
+```
+
+<details><summary>Advanced: install directly from your fork without cloning first</summary>
 
 ```bash
 OH_GITHUB_REPO=<your-org>/<your-fork> curl -fsSL \
   https://raw.githubusercontent.com/<your-org>/<your-fork>/main/scripts/install.sh | bash
 ```
 
-If your fork uses a default branch other than `main`, set `OH_GITHUB_REF=<branch>` and replace `main` in the URL.
+If your fork uses a default branch other than `main`, set `OH_GITHUB_REF=<branch>` and replace `main` in the URL. See [Installation docs](https://oh.mifune.dev/docs/installation) for all environment overrides.
 
-`curl | bash` from a branch HEAD is mutable — pin to a tag/SHA for production installs.
-
-> **Note:** Forks restructuring `.devcontainer/` should also patch the local-run detection in `scripts/install.sh` (the `-f .devcontainer/docker-compose.yml` check near line 173) — update the paths to match the new layout.
+</details>
 
 ## 🚀 Use it
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,45 @@ Open Harness is a Docker-based sandbox image. Installation is `docker compose` a
 
 That is the entire host requirement. Node.js, pnpm, and any AI CLI live inside the sandbox.
 
-## One-line installer (recommended)
+## Self-hosting: I already have a clone
+
+If you've already cloned your fork — or cloned upstream and re-pointed the remote — run the installer from inside the directory. It auto-detects the local repo and skips any network clone:
+
+```bash
+cd <your-clone>
+bash scripts/install.sh
+```
+
+The installer prompts for `SANDBOX_NAME`, writes `.devcontainer/.env`, and starts the sandbox. No `OH_GITHUB_REPO` environment variable required.
+
+### Fork-and-clone
+
+1. Fork `ryaneggz/open-harness` on GitHub.
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/<your-org>/<your-fork>.git && cd <your-fork>
+   ```
+3. Run the installer — it detects the local clone automatically:
+   ```bash
+   bash scripts/install.sh
+   ```
+
+### Clone-and-own (re-point)
+
+1. Clone upstream:
+   ```bash
+   git clone https://github.com/ryaneggz/open-harness.git my-harness && cd my-harness
+   ```
+2. Re-point origin to your repo:
+   ```bash
+   git remote set-url origin https://github.com/<your-org>/<your-repo>.git
+   ```
+3. Run the installer:
+   ```bash
+   bash scripts/install.sh
+   ```
+
+## One-line installer (upstream only)
 
 ```bash
 curl -fsSL https://oh.mifune.dev/install.sh | bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,6 +17,8 @@ Install Docker with the Compose plugin: [docs.docker.com/get-docker](https://doc
 curl -fsSL https://oh.mifune.dev/install.sh | bash
 ```
 
+> **Self-hosting?** If you've already cloned your fork or re-pointed origin, skip the curl command above and run `bash scripts/install.sh` from inside the directory instead — the installer detects the local clone automatically.
+
 The installer clones into `~/.openharness`, prompts to share your host
 `gh` token, writes `.devcontainer/.env` with safe defaults, and brings
 the sandbox up via `docker compose`.


### PR DESCRIPTION
## Summary

- Restructures `README.md` Install section into three equal-weight options: upstream one-liner (A), fork-and-clone (B), clone-and-own/re-point (C)
- Adds "Self-hosting: I already have a clone" section to `docs/installation.md` as the primary entry point for self-hosters, with fork-and-clone and clone-and-own sub-flows; relabels the one-liner as "upstream only"
- Adds a self-hosting callout to `docs/quickstart.md` after the curl block

The key insight surfaced: `scripts/install.sh` already auto-detects when run from inside a local clone (lines 193–199) and skips all clone/`OH_GITHUB_REPO` logic — no env vars needed. This was completely absent from the docs.

## Test plan

- [ ] Read through `README.md` — three install options are visually distinct and equally prominent
- [ ] Read through `docs/installation.md` — new section appears before the one-liner, covers both fork and re-point sub-flows with numbered steps
- [ ] Read through `docs/quickstart.md` — self-hosting note is present after the curl block
- [ ] Verify no script, CI, or Dockerfile changes are included

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)