### PR TITLE
FROM skill/333-context-audit TO development

### DIFF
--- a/.claude/skills/context-audit/SKILL.md
+++ b/.claude/skills/context-audit/SKILL.md
@@ -1,0 +1,390 @@
+---
+name: context-audit
+description: |
+  Score the default-loaded context budget across 4 dimensions and emit
+  KEEP/TRIM/DEMOTE/CUT verdicts per file. Optional Tier-2 ablation harness
+  removes a target file, runs a fixed probe suite, and measures behavior
+  degradation — the only provably safe gate for cutting load-bearing content.
+  TRIGGER when: asked to audit context window, check default context load,
+  "what's in my context", evaluate rules for signal vs noise, or before/after
+  any change to context/rules/ or CLAUDE.md.
+argument-hint: "all | --baseline | --ablate <relative-path>"
+---
+
+# Context Audit
+
+Score every file in the default-loaded context set on 4 deterministic dimensions (footprint, load-bearing, integrity, redundancy). Emit KEEP / TRIM / DEMOTE / CUT verdicts and a total token budget. Optionally run the Tier-2 ablation harness to verify a proposed cut is safe.
+
+## Default-Loaded Set
+
+| Layer | Files | Loaded how |
+|-------|-------|-----------|
+| Bootloader | `CLAUDE.md` | always |
+| Rules | `context/rules/*.md` | always (auto via `.claude/rules` symlink) |
+| Context | `context/SOUL.md`, `context/IDENTITY.md`, `context/TOOLS.md`, `context/USER.md` | session start |
+| Memory | `memory/MEMORY.md` (+ today's log) | session start |
+| Skill metadata | frontmatter of all `**/SKILL.md` | always injected |
+
+## Instructions
+
+### 1. Parse arguments
+
+Arguments received: `$ARGUMENTS`
+
+| Argument | Mode |
+|----------|------|
+| empty or `all` | Tier-1 scorecard only |
+| `--baseline` | Tier-1 scorecard + record durable baseline snapshot to `memory/YYYY-MM-DD/context-audit-baseline/` |
+| `--ablate <file>` | Tier-1 scorecard + Tier-2 ablation against `<file>` (path relative to harness root) |
+
+### 2. Inventory the default-loaded set
+
+```bash
+HARNESS=/home/sandbox/harness
+TODAY=$(date -u +%Y-%m-%d)
+
+# Enumerate all files and their footprint
+for f in \
+  "$HARNESS/CLAUDE.md" \
+  "$HARNESS"/context/rules/*.md \
+  "$HARNESS/context/SOUL.md" \
+  "$HARNESS/context/IDENTITY.md" \
+  "$HARNESS/context/TOOLS.md" \
+  "$HARNESS/context/USER.md" \
+  "$HARNESS/memory/MEMORY.md"; do
+  [ -f "$f" ] || continue
+  chars=$(wc -c < "$f")
+  words=$(wc -w < "$f")
+  echo "$((chars/4)) $words $f"
+done
+
+# Skill metadata aggregate (all SKILL.md description fields)
+skill_chars=$(grep -h -A10 '^description:' \
+  "$HARNESS"/.claude/skills/*/SKILL.md \
+  "$HARNESS"/workspace/.claude/skills/*/SKILL.md 2>/dev/null \
+  | wc -c)
+echo "$((skill_chars/4)) skill-metadata-aggregate (all trigger descriptions)"
+```
+
+Collect the list as `ALL_FILES` for use in the scoring steps below.
+
+### 3. Score each file on 4 dimensions
+
+For every file in the inventory (skip the skill-metadata aggregate row — no verdict, budget line only), compute 4 dimensions using shell commands only.
+
+---
+
+#### Dimension A — Footprint (0-2)
+
+Token cost (chars/4). Lower cost earns a higher score — every token in the default-loaded set is paid on every session start.
+
+```bash
+TOKENS=$(($(wc -c < "$f") / 4))
+```
+
+| Tokens | Score |
+|--------|-------|
+| < 500 | 2 |
+| 500 – 1,500 | 1 |
+| > 1,500 | 0 |
+
+---
+
+#### Dimension B — Load-bearing (0-2)
+
+Citation count: how many skills, agents, tracked docs, and orchestrator files reference this file by name (a measurable proxy for "this content is actively consumed").
+
+```bash
+FILE_BASE=$(basename "$f")
+REFS=$(grep -rl "$FILE_BASE" \
+  "$HARNESS/.claude/skills" \
+  "$HARNESS/.claude/agents" \
+  "$HARNESS/AGENTS.md" \
+  "$HARNESS/CLAUDE.md" \
+  "$HARNESS/context" \
+  "$HARNESS/docs" 2>/dev/null \
+  | grep -v "^${f}$" | wc -l)
+```
+
+| Citations | Score |
+|-----------|-------|
+| >= 5 | 2 |
+| 1 – 4 | 1 |
+| 0 | 0 |
+
+---
+
+#### Dimension C — Integrity (0-2)
+
+Verify that every file path and skill reference within the file resolves. Broken references are load-bearing context that actively misleads.
+
+```bash
+# Absolute paths referenced in backticks or quotes
+PATH_REFS=$(grep -oP '`[^`]+`|"[^"]+"' "$f" \
+  | grep -oP '/[a-zA-Z0-9_./-]+' | sort -u)
+
+# Skill invocations like /release, /ci-status (exclude filesystem paths)
+SKILL_REFS=$(grep -oP '/[a-z][a-z0-9-]+' "$f" \
+  | grep -v '^/home' | sort -u)
+
+BROKEN=0
+for p in $PATH_REFS; do
+  [ -e "$p" ] || BROKEN=$((BROKEN + 1))
+done
+for s in $SKILL_REFS; do
+  name="${s#/}"
+  { [ -d "$HARNESS/.claude/skills/$name" ] || \
+    [ -d "$HARNESS/workspace/.claude/skills/$name" ]; } \
+    || BROKEN=$((BROKEN + 1))
+done
+```
+
+| Broken refs | Score |
+|-------------|-------|
+| 0 | 2 |
+| 1 – 2 | 1 |
+| 3+ | 0 |
+
+---
+
+#### Dimension D — Redundancy (0-2)
+
+Check whether this file's section-header structure substantially duplicates another loaded file. Redundant files add cost without adding unique signal.
+
+```bash
+HEADS=$(grep '^## ' "$f" | sed 's/^## //')
+OVERLAP=0
+for other in $ALL_FILES; do
+  [ "$other" = "$f" ] && continue
+  [ -f "$other" ] || continue
+  match=$(grep '^## ' "$other" | sed 's/^## /' \
+    | grep -cFf <(echo "$HEADS") 2>/dev/null || echo 0)
+  [ "$match" -gt 2 ] && OVERLAP=$((OVERLAP + 1))
+done
+```
+
+| Overlap files | Score |
+|---------------|-------|
+| 0 | 2 |
+| 1 | 1 |
+| 2+ | 0 |
+
+---
+
+### 4. Compute total and verdict
+
+```
+TOTAL = A + B + C + D  (max 8)
+```
+
+| Total | Verdict | Meaning |
+|-------|---------|---------|
+| 7 – 8 | **KEEP** | Signal justified; no action needed |
+| 5 – 6 | **TRIM** | Reduce footprint or remove duplicate sections; stays default-loaded |
+| 3 – 4 | **DEMOTE** | Move to on-demand (session-start explicit read or skill); remove from auto-load |
+| 0 – 2 | **CUT** | Not earning its slot; remove or merge. Run Tier-2 ablation first if B > 0. |
+
+### 5. Emit Tier-1 report
+
+Print today's date as `YYYY-MM-DD`.
+
+```
+## Context Audit — YYYY-MM-DD
+
+### Budget
+Total default-loaded (scored files): X tokens
+Skill metadata aggregate: ~Y tokens
+Grand total: ~Z tokens
+
+### Scorecard
+| File | Tokens | A:Foot | B:Load | C:Integ | D:Redun | Total | Verdict |
+|------|-------:|:------:|:------:|:-------:|:-------:|------:|---------|
+| ...  |        |        |        |         |         |       |         |
+
+(sorted by Total ascending — worst first)
+
+### Recommendations
+- **CUT**: <file> — <one-line reason>
+- **DEMOTE**: <file> — <one-line reason>
+- **TRIM**: <file> — <one-line reason>
+```
+
+Omit KEEP files from Recommendations. Use the short filename (e.g. `recursive-delegation.md`), not the full path.
+
+### 6. Tier-2 ablation (skip if mode is `all`)
+
+**Purpose**: determine whether removing a file degrades observable behavior. This is the only step that goes beyond static proxies to provide an empirical signal measurement.
+
+Do not apply Tier-2 to `CLAUDE.md` — removing orchestrator instructions produces meaningless probe results.
+
+#### 6a. Baseline probe run
+
+Run all probes in `.claude/skills/context-audit/probes/` with the full default-loaded set present.
+
+```bash
+SKILL_DIR="$HARNESS/.claude/skills/context-audit"
+PROBE_DIR="$SKILL_DIR/probes"
+RESULTS="/tmp/context-audit-$(date +%s)"
+mkdir -p "$RESULTS"
+
+extract_body() {
+  # strips YAML frontmatter; prints body (text after closing ---)
+  awk '/^---/{n++; if(n==2){p=1;next}} p{print}' "$1"
+}
+
+for probe in "$PROBE_DIR"/*.md; do
+  pname=$(basename "$probe" .md)
+  claude -p "$(extract_body "$probe")" --output-format text \
+    > "$RESULTS/baseline-${pname}.txt" 2>&1
+  echo "baseline: $pname → $RESULTS/baseline-${pname}.txt"
+done
+```
+
+If `--baseline` mode: copy results to `memory/$TODAY/context-audit-baseline/` for durable storage.
+
+```bash
+mkdir -p "$HARNESS/memory/$TODAY/context-audit-baseline"
+cp "$RESULTS"/baseline-*.txt "$HARNESS/memory/$TODAY/context-audit-baseline/"
+```
+
+#### 6b. Ablation run
+
+Back up the target file, run all probes, restore. Use `trap` to guarantee restore on error.
+
+```bash
+TARGET="$HARNESS/$ARGUMENTS_FILE"   # the <file> arg from --ablate
+cp "$TARGET" "${TARGET}.bak"
+trap 'mv "${TARGET}.bak" "$TARGET" 2>/dev/null; echo "restored $TARGET"' EXIT
+
+mv "${TARGET}.bak.tmp" "${TARGET}.bak" 2>/dev/null || true
+mv "$TARGET" "${TARGET}.bak"
+
+for probe in "$PROBE_DIR"/*.md; do
+  pname=$(basename "$probe" .md)
+  claude -p "$(extract_body "$probe")" --output-format text \
+    > "$RESULTS/ablation-${pname}.txt" 2>&1
+  echo "ablation: $pname → $RESULTS/ablation-${pname}.txt"
+done
+
+# trap fires on EXIT and restores the file
+```
+
+#### 6c. Evaluate degradation
+
+For each probe, read MUST-CONTAIN markers from the probe's frontmatter `markers:` list. Count how many markers appear in the baseline vs. ablation response.
+
+```bash
+extract_markers() {
+  # prints one marker per line from YAML frontmatter markers: list
+  awk '/^markers:/{f=1;next} f && /^  - /{print substr($0,5)} f && /^[a-z]/{exit}' "$1"
+}
+
+for probe in "$PROBE_DIR"/*.md; do
+  pname=$(basename "$probe" .md)
+  baseline_hits=0; ablation_hits=0; total=0
+
+  while IFS= read -r marker; do
+    [ -z "$marker" ] && continue
+    total=$((total + 1))
+    grep -qi "$marker" "$RESULTS/baseline-${pname}.txt" \
+      && baseline_hits=$((baseline_hits + 1))
+    grep -qi "$marker" "$RESULTS/ablation-${pname}.txt" \
+      && ablation_hits=$((ablation_hits + 1))
+  done < <(extract_markers "$probe")
+
+  drop=$((baseline_hits - ablation_hits))
+  [ "$drop" -le 0 ] && severity="none" \
+    || { [ "$drop" -eq 1 ] && severity="LOW" || severity="HIGH"; }
+  echo "$pname|$baseline_hits|$ablation_hits|$total|$drop|$severity"
+done
+```
+
+#### 6d. Emit Tier-2 report
+
+```
+## Ablation: <target-file> — YYYY-MM-DD HH:MM UTC
+
+### Probe Results
+| Probe | Baseline | Ablation | Markers | Drop | Severity |
+|-------|:--------:|:--------:|:-------:|:----:|:--------:|
+| probe-git-branch | 3/3 | 1/3 | 3 | 2 | HIGH |
+| ...              |     |     |   |   |      |
+
+### Verdict
+SAFE TO CUT — all probes degraded ≤ 1 marker
+  OR
+SIGNAL DETECTED — N probe(s) degraded >1 marker; <target-file> earns its slot
+```
+
+Degradation threshold: **SIGNAL DETECTED** if any probe's ablation hits fall more than 1 below baseline hits. **SAFE TO CUT** otherwise.
+
+### 7. Memory Protocol
+
+```bash
+mkdir -p "$HARNESS/memory/$TODAY"
+cat >> "$HARNESS/memory/$TODAY/log.md" <<EOF
+
+## [Context Audit] — $(date -u +%H:%M) UTC
+- **Result**: OP
+- **Budget**: Z tokens total (scored files + skill metadata)
+- **Top finding**: <VERDICT> — <file> (<tokens> tokens, <citations> citations)
+- **Ablation**: SAFE TO CUT | SIGNAL DETECTED | N/A
+- **Observation**: [one sentence — the single most actionable finding]
+EOF
+```
+
+See `context/rules/memory.md` for the canonical Memory Improvement Protocol.
+
+## Guidelines
+
+- All Tier-1 scoring is deterministic — same shell commands twice produce the same scores. No LLM judgment in Tier 1.
+- Tier-2 ablation uses `trap` to restore the target file even if `claude -p` errors mid-run.
+- The skill-metadata aggregate row gets a budget line but no verdict (it's aggregate; verdicts apply per-file only).
+- Tier-2 probe results are probabilistic, not deterministic — `claude -p` is non-deterministic. Run ablation twice if a verdict is borderline.
+- For before/after token diff: the Memory log's `Budget:` line from each run is the comparison data point. No separate snapshot mechanism needed for the diff.
+- When `--baseline` mode is used, probe outputs are persisted to `memory/YYYY-MM-DD/context-audit-baseline/` and are gitignored (daily memory dirs are gitignored per `.gitignore`).
+- Do not penalize `CLAUDE.md` on Dimension B (load-bearing) because it's the source of truth and may have few inbound citations by design — it doesn't need to be cited; it is the orchestrator instructions.
+
+## Reference
+
+### Verdict thresholds
+
+| Score | Verdict | Recommended action |
+|-------|---------|-------------------|
+| 7–8 | KEEP | No action |
+| 5–6 | TRIM | Edit for concision; remove duplicate sections |
+| 3–4 | DEMOTE | Move to on-demand; remove from auto-load set |
+| 0–2 | CUT | Remove; run Tier-2 ablation first if B score > 0 |
+
+### Probe file format
+
+```yaml
+---
+name: <identifier>
+target: <rule-filename>   # which default-loaded file this probe exercises
+markers:
+  - <keyword or phrase that should appear when the rule is present>
+  - ...
+---
+
+<Prompt text — what gets sent to claude -p. One task that requires the target rule to answer correctly.>
+```
+
+### Ablation runner (standalone)
+
+For running ablation outside a Claude session:
+
+```bash
+.claude/skills/context-audit/runner.sh --ablate context/rules/<file>.md
+```
+
+See `runner.sh` in this skill directory.
+
+### Scoring cheatsheet
+
+| Dimension | 2 (healthy) | 1 (warning) | 0 (noise) |
+|-----------|------------|-------------|-----------|
+| Footprint | < 500 tokens | 500–1,500 | > 1,500 |
+| Load-bearing | 5+ citations | 1–4 citations | 0 citations |
+| Integrity | 0 broken refs | 1–2 broken | 3+ broken |
+| Redundancy | no overlap | 1 overlap file | 2+ overlap files |

--- a/.claude/skills/context-audit/probes/probe-advisor.md
+++ b/.claude/skills/context-audit/probes/probe-advisor.md
@@ -1,0 +1,12 @@
+---
+name: probe-advisor
+target: advisor-model.md
+markers:
+  - "Goal:"
+  - "Constraints"
+  - "Acceptance criteria"
+  - "Start here"
+  - "Out of scope"
+---
+
+I need to delegate a task to a sub-agent: audit all Python files in the repo for unused imports and produce a report. Please write the advisor briefing I should prepend to that agent's prompt.

--- a/.claude/skills/context-audit/probes/probe-git-branch.md
+++ b/.claude/skills/context-audit/probes/probe-git-branch.md
@@ -1,0 +1,10 @@
+---
+name: probe-git-branch
+target: git.md
+markers:
+  - "feat/"
+  - "development"
+  - issue
+---
+
+I need to create a new branch for GitHub issue #42 that adds a dark mode toggle to the UI. What branch name should I use and which base branch should I target? Give me the exact git command.

--- a/.claude/skills/context-audit/probes/probe-git-pr.md
+++ b/.claude/skills/context-audit/probes/probe-git-pr.md
@@ -1,0 +1,10 @@
+---
+name: probe-git-pr
+target: git.md
+markers:
+  - "FROM "
+  - "TO "
+  - "Closes #"
+---
+
+I'm ready to open a pull request for branch feat/42-dark-mode-toggle targeting development. What should the exact PR title and body look like? Show me the gh command.

--- a/.claude/skills/context-audit/probes/probe-memory.md
+++ b/.claude/skills/context-audit/probes/probe-memory.md
@@ -1,0 +1,11 @@
+---
+name: probe-memory
+target: memory.md
+markers:
+  - "Result:"
+  - "Observation:"
+  - "log.md"
+  - "MEMORY.md"
+---
+
+I just finished running a skill. Walk me through exactly what I need to log, in what file, and in what format. Include the heading format and required fields.

--- a/.claude/skills/context-audit/probes/probe-readme.md
+++ b/.claude/skills/context-audit/probes/probe-readme.md
@@ -1,0 +1,10 @@
+---
+name: probe-readme
+target: directory-readme.md
+markers:
+  - "README.md"
+  - "one-line"
+  - "gitignore"
+---
+
+I just created a new top-level directory called `exports/` that will hold generated output files that are gitignored. What do I need to add so this directory is properly anchored in the repo and documented for other contributors?

--- a/.claude/skills/context-audit/probes/probe-recursive.md
+++ b/.claude/skills/context-audit/probes/probe-recursive.md
@@ -1,0 +1,10 @@
+---
+name: probe-recursive
+target: recursive-delegation.md
+markers:
+  - "Max depth"
+  - "Step budget"
+  - "Max children"
+---
+
+I want to orchestrate a multi-level delegation: a root agent spawns three child agents, each of which should further spawn sub-agents to analyze their assigned directory. What fields must I include in the root briefing to authorize recursive delegation, and what must each child pass down?

--- a/.claude/skills/context-audit/probes/probe-sandbox.md
+++ b/.claude/skills/context-audit/probes/probe-sandbox.md
@@ -1,0 +1,10 @@
+---
+name: probe-sandbox
+target: sandbox-processes.md
+markers:
+  - tmux
+  - "new-session"
+  - "tee /tmp/"
+---
+
+I need to start a dev server inside the sandbox that I can inspect, restart, and attach to later. What's the correct way to launch it so it survives disconnects and is visible in a list?

--- a/.claude/skills/context-audit/runner.sh
+++ b/.claude/skills/context-audit/runner.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# context-audit runner — Tier-2 ablation harness
+# Usage:
+#   ./runner.sh --ablate <relative-path>   # e.g. context/rules/recursive-delegation.md
+#   ./runner.sh --baseline                 # record baseline probe outputs only
+#
+# Must be run from the harness root (/home/sandbox/harness).
+
+set -euo pipefail
+
+HARNESS="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SKILL_DIR="$HARNESS/.claude/skills/context-audit"
+PROBE_DIR="$SKILL_DIR/probes"
+TODAY=$(date -u +%Y-%m-%d)
+RESULTS="/tmp/context-audit-$(date +%s)"
+mkdir -p "$RESULTS"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+extract_body() {
+  # Strip YAML frontmatter; print body (everything after closing ---)
+  awk '/^---/{n++; if(n==2){p=1;next}} p{print}' "$1"
+}
+
+extract_markers() {
+  # Print one marker per line from probe frontmatter markers: list
+  awk '/^markers:/{f=1;next} f && /^  - /{print substr($0,5)} f && /^[a-z]/{exit}' "$1"
+}
+
+run_probes() {
+  local label="$1"
+  for probe in "$PROBE_DIR"/*.md; do
+    pname=$(basename "$probe" .md)
+    printf "  %-30s → %s/%s-%s.txt\n" "$pname" "$RESULTS" "$label" "$pname"
+    claude -p "$(extract_body "$probe")" --output-format text \
+      > "$RESULTS/${label}-${pname}.txt" 2>&1
+  done
+}
+
+evaluate() {
+  local target_base="$1"
+  echo ""
+  echo "## Ablation: $target_base — $(date -u '+%Y-%m-%d %H:%M') UTC"
+  echo ""
+  printf "%-30s  %9s  %9s  %7s  %4s  %s\n" \
+    "Probe" "Baseline" "Ablation" "Markers" "Drop" "Severity"
+  printf "%-30s  %9s  %9s  %7s  %4s  %s\n" \
+    "-----" "--------" "--------" "-------" "----" "--------"
+
+  any_high=0
+  for probe in "$PROBE_DIR"/*.md; do
+    pname=$(basename "$probe" .md)
+    baseline_hits=0; ablation_hits=0; total=0
+    while IFS= read -r marker; do
+      [ -z "$marker" ] && continue
+      total=$((total + 1))
+      grep -qi "$marker" "$RESULTS/baseline-${pname}.txt" 2>/dev/null \
+        && baseline_hits=$((baseline_hits + 1)) || true
+      grep -qi "$marker" "$RESULTS/ablation-${pname}.txt" 2>/dev/null \
+        && ablation_hits=$((ablation_hits + 1)) || true
+    done < <(extract_markers "$probe")
+
+    drop=$((baseline_hits - ablation_hits))
+    if [ "$drop" -le 0 ]; then severity="none"
+    elif [ "$drop" -eq 1 ]; then severity="LOW"
+    else severity="HIGH"; any_high=1
+    fi
+
+    printf "%-30s  %4d/%-4d  %4d/%-4d  %7d  %4d  %s\n" \
+      "$pname" "$baseline_hits" "$total" "$ablation_hits" "$total" \
+      "$total" "$drop" "$severity"
+  done
+
+  echo ""
+  if [ "$any_high" -eq 0 ]; then
+    echo "### Verdict: SAFE TO CUT — all probes degraded ≤ 1 marker"
+  else
+    echo "### Verdict: SIGNAL DETECTED — probe(s) dropped >1 marker; file earns its slot"
+  fi
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+MODE="${1:-}"
+if [ -z "$MODE" ]; then
+  echo "Usage: $0 --baseline | --ablate <relative-path>"
+  exit 1
+fi
+
+if [ "$MODE" = "--baseline" ]; then
+  echo "=== Baseline probe run ==="
+  run_probes "baseline"
+  # Persist to memory for durable comparison
+  mkdir -p "$HARNESS/memory/$TODAY/context-audit-baseline"
+  cp "$RESULTS"/baseline-*.txt "$HARNESS/memory/$TODAY/context-audit-baseline/"
+  echo ""
+  echo "Baseline saved → memory/$TODAY/context-audit-baseline/"
+  exit 0
+fi
+
+if [ "$MODE" = "--ablate" ]; then
+  TARGET_REL="${2:-}"
+  if [ -z "$TARGET_REL" ]; then
+    echo "Error: --ablate requires a file argument (relative to harness root)"
+    exit 1
+  fi
+  TARGET="$HARNESS/$TARGET_REL"
+  if [ ! -f "$TARGET" ]; then
+    echo "Error: file not found: $TARGET"
+    exit 1
+  fi
+  TARGET_BASE=$(basename "$TARGET_REL")
+
+  # Safety: don't ablate CLAUDE.md (removes orchestrator identity)
+  if [ "$TARGET_BASE" = "CLAUDE.md" ]; then
+    echo "Error: CLAUDE.md cannot be ablated — results would be meaningless"
+    exit 1
+  fi
+
+  echo "=== Baseline probe run (full context) ==="
+  run_probes "baseline"
+
+  echo ""
+  echo "=== Ablation: temporarily removing $TARGET_REL ==="
+  # Restore on any exit
+  trap 'if [ -f "${TARGET}.bak" ]; then mv "${TARGET}.bak" "$TARGET"; echo "Restored $TARGET_REL"; fi' EXIT
+  mv "$TARGET" "${TARGET}.bak"
+
+  run_probes "ablation"
+
+  # Restore now (trap also fires but idempotent)
+  mv "${TARGET}.bak" "$TARGET"
+
+  evaluate "$TARGET_BASE"
+  exit 0
+fi
+
+echo "Unknown argument: $MODE"
+echo "Usage: $0 --baseline | --ablate <relative-path>"
+exit 1

--- a/.mifune/skills.lock
+++ b/.mifune/skills.lock
@@ -6,6 +6,14 @@
   "generated_by": "git-sync/manual",
   "generated_at": "2026-05-22T00:00:00Z",
   "skills": {
+    "context-audit": {
+      "source": "github:mifunedev/skills",
+      "registry_version": "2026.5.22",
+      "skill_version": "0.1.0",
+      "commit": "1af15c40d8ddb1e76b22af2b1b0db724258a1586",
+      "checksum": "sha256:53667528b352d239470147611a97d5882c05edca82c22c86fdaccaf36b9c7b05",
+      "installed_paths": [".claude/skills/context-audit"]
+    },
     "agent-browser": {
       "source": "github:mifunedev/skills",
       "registry_version": "2026.5.17",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ Remove the sandbox.
 | `/delegate` | Parallel sub-agent coordinator — execute a plan in waves |
 | `/harness-audit` | Spawn 4 parallel sub-agents (PM/Implementer/Critic/Explorer) to audit the harness |
 | `/skill-lint` | Score skills for staleness across 5 dimensions |
+| `/context-audit` | Score default-loaded context budget (4 dimensions, KEEP/TRIM/DEMOTE/CUT); optional Tier-2 ablation harness verifies cuts are safe |
 | `/strategic-proposal` | 5-expert council + Critic for roadmap planning |
 | `/render-html` | Render an artifact as a bespoke, self-contained HTML file under `memory/<date>/<slug>.html` for one-shot human review (audit synthesis, council output, lint matrix, weekly digest) |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- `/context-audit` skill (`.claude/skills/context-audit/`) — data-backed, repeatable eval for the default-loaded context budget. Tier-1 scores each file on 4 dimensions (footprint, load-bearing, integrity, redundancy) and emits KEEP/TRIM/DEMOTE/CUT verdicts. Tier-2 ablation harness (`runner.sh` + 7 probe files) removes a target file, runs a fixed task suite via `claude -p`, and measures behavior degradation — the only provably safe gate for cutting load-bearing content ([#333](https://github.com/ryaneggz/open-harness/issues/333)).
 - `/render-html` skill (`.claude/skills/render-html/SKILL.md`) — orchestrator skill for rendering an artifact as a bespoke, self-contained HTML file under `memory/<UTC-date>/<slug>.html` for one-shot human review (audit synthesis, council output, lint matrix, weekly digest). Output is gitignored via existing `memory/[0-9]*/` rule ([#314](https://github.com/ryaneggz/open-harness/issues/314)).
 - `/interview` skill (`.claude/skills/interview/SKILL.md`) — adaptive pre-work clarifier that batches 2–4 task-specific questions through `AskUserQuestion`, echoes a 2–3 sentence scope brief, and proceeds. Skips trivial tasks with an announcement. Serves as the in-tree reference pattern for `AskUserQuestion`-based elicitation in future skills ([#316](https://github.com/ryaneggz/open-harness/issues/316)).
 


### PR DESCRIPTION
## Summary

- Adds `/context-audit` skill with a data-backed, repeatable eval process for the default-loaded context window
- **Tier-1 scorecard**: inventories all default-loaded files (CLAUDE.md, context/rules/*, context/*.md, MEMORY.md, skill metadata), scores each on 4 deterministic dimensions (footprint, load-bearing, integrity, redundancy), emits KEEP/TRIM/DEMOTE/CUT verdicts and a total token budget
- **Tier-2 ablation harness**: `runner.sh` + 7 probe files — removes a target file, runs the probe suite via `claude -p`, measures behavior degradation; provides the only provably safe gate for cutting load-bearing content

## Files

```
.claude/skills/context-audit/
  SKILL.md          — skill instructions (Tier-1 + Tier-2 procedures)
  runner.sh         — standalone ablation runner (--baseline | --ablate <file>)
  probes/
    probe-git-branch.md   — exercises git.md branch-naming rules
    probe-git-pr.md       — exercises git.md PR title/body conventions
    probe-advisor.md      — exercises advisor-model.md briefing structure
    probe-recursive.md    — exercises recursive-delegation.md fields
    probe-memory.md       — exercises memory.md log protocol
    probe-sandbox.md      — exercises sandbox-processes.md tmux conventions
    probe-readme.md       — exercises directory-readme.md README convention
```

## Test plan

- [ ] Run `/context-audit` — should produce scored table with KEEP/TRIM/DEMOTE/CUT verdicts
- [ ] Run `runner.sh --baseline` — should run all 7 probes and save to `memory/<date>/context-audit-baseline/`
- [ ] Run `runner.sh --ablate context/rules/recursive-delegation.md` — should report SAFE TO CUT or SIGNAL DETECTED based on baseline vs. ablation marker hits
- [ ] Verify `runner.sh` restores the ablated file even on error (trap)
- [ ] Confirm `/context-audit` appears in AGENTS.md skills table

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)