### PR TITLE
FROM task/339-context-audit-resync TO development

### DIFF
--- a/.claude/skills/context-audit/LICENSE
+++ b/.claude/skills/context-audit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mifune Dev (mifune.dev)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/context-audit/SKILL.md
+++ b/.claude/skills/context-audit/SKILL.md
@@ -8,7 +8,6 @@ description: |
   TRIGGER when: asked to audit context window, check default context load,
   "what's in my context", evaluate rules for signal vs noise, or before/after
   any change to context/rules/ or CLAUDE.md.
-argument-hint: "all | --baseline | --ablate <relative-path>"
 ---
 
 # Context Audit

--- a/.mifune/skills.lock
+++ b/.mifune/skills.lock
@@ -10,8 +10,8 @@
       "source": "github:mifunedev/skills",
       "registry_version": "2026.5.22",
       "skill_version": "0.1.0",
-      "commit": "1af15c40d8ddb1e76b22af2b1b0db724258a1586",
-      "checksum": "sha256:53667528b352d239470147611a97d5882c05edca82c22c86fdaccaf36b9c7b05",
+      "commit": "f95011fe743994778ab2a01b16d31bae21f0ca38",
+      "checksum": "sha256:02dd6324bb7ab62331a42fa414e2325bbb293c4e6f0ebb8aeead09f3948595a1",
       "installed_paths": [".claude/skills/context-audit"]
     },
     "agent-browser": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 - All 15 skills in `.claude/skills/` now sourced from and version-pinned to `github.com/mifunedev/skills` (commit `c559c100`) via `.mifune/skills.lock`; `interview` and `render-html` contributed upstream and added to the lock ([#327](https://github.com/ryaneggz/open-harness/issues/327)).
 - `README.md`, `docs/installation.md`, and `docs/quickstart.md` restructured to surface fork-and-clone and clone-and-own as first-class install paths alongside the upstream one-liner; `scripts/install.sh` local-run detection is now the documented bootstrap for self-hosters ([#331](https://github.com/ryaneggz/open-harness/issues/331)).
 - Skill `LICENSE` files updated to `Copyright (c) 2026 Mifune Dev (mifune.dev)` to match upstream correction.
+- Re-synced `context-audit` to the portable upstream form ([mifunedev/skills#6](https://github.com/mifunedev/skills/pull/6)): removed the top-level `argument-hint` frontmatter key, repinned `.mifune/skills.lock` (`commit` `f95011fe`, checksum `02dd6324`), and added the previously-missing `LICENSE` for folder parity ([#339](https://github.com/ryaneggz/open-harness/issues/339)).
 ### Fixed
 ### Removed
 - `config.example.json` and its install-time seeding step (`scripts/install.sh`); the base ships zero compose overlays and all readers tolerate a missing `config.json`, so the example template was dead weight. Packs that need overlays create their own `config.json` ([#323](https://github.com/ryaneggz/open-harness/issues/323)).


### PR DESCRIPTION
Closes #339

Re-syncs the harness `context-audit` skill to its merged, portable upstream form now that [mifunedev/skills#6](https://github.com/mifunedev/skills/pull/6) is in `master`.

## Changes
- **Strip** top-level `argument-hint` from `.claude/skills/context-audit/SKILL.md` (forbidden by `skills-ref` portability policy; `--baseline`/`--ablate` stay documented in the body).
- **Repin** `.mifune/skills.lock` → `commit f95011fe`, `checksum 02dd6324` (was `1af15c40` / `53667528`).
- **Add** the previously-missing `LICENSE` (MIT, Mifune Dev) — every other skill folder has one; `context-audit` didn't.

## Notes
- The lock `checksum` is the upstream registry folder-algorithm value (path prefixes differ from `.claude/skills/`, so it is a pinned registry identity, not a local hash — consistent with all other entries).
- Companion to the `reflect` work: PR #338 (skill) carries its own lock backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)