### PR TITLE
FROM task/make-shell-service-arg TO development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Provision the agent sandbox. The sandbox uses `.devcontainer/` as the base envir
    ```bash
    make shell     # default; bash also available
    ```
-   Pass an optional compose service to scope to a different container, e.g. `make shell postgres SHELL_USER=postgres`.
+   Pass an optional container name to attach to a different running container, e.g. `make shell portfolio-advisor` (add `SHELL_USER=<user>` if the target has no `sandbox` user).
 
    **Option B — VS Code Attach to Container (local):**
    Dev Containers extension → "Attach to Running Container" → select the `openharness` container
@@ -75,7 +75,7 @@ Verify the sandbox is healthy.
    ```bash
    make shell
    ```
-   Pass an optional compose service to scope to a different container, e.g. `make shell postgres SHELL_USER=postgres`.
+   Pass an optional container name to attach to a different running container, e.g. `make shell portfolio-advisor` (add `SHELL_USER=<user>` if the target has no `sandbox` user).
    - `AGENTS.md` exists in `workspace/`
    - Target agent CLI is installed (`claude --version`)
    - Docker socket accessible if needed (`docker ps`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Provision the agent sandbox. The sandbox uses `.devcontainer/` as the base envir
    ```bash
    make shell     # default; bash also available
    ```
+   Pass an optional compose service to scope to a different container, e.g. `make shell postgres SHELL_USER=postgres`.
 
    **Option B — VS Code Attach to Container (local):**
    Dev Containers extension → "Attach to Running Container" → select the `openharness` container
@@ -74,6 +75,7 @@ Verify the sandbox is healthy.
    ```bash
    make shell
    ```
+   Pass an optional compose service to scope to a different container, e.g. `make shell postgres SHELL_USER=postgres`.
    - `AGENTS.md` exists in `workspace/`
    - Target agent CLI is installed (`claude --version`)
    - Docker socket accessible if needed (`docker ps`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ### Changed
 - `.pi/extensions/path-guard.ts` refactored to expose `SENSITIVE_PATHS` as a named export and extract the sensitive-path check into a new `isSensitivePath(p: string): boolean` named export; default-export behavior unchanged ([#354](https://github.com/ryaneggz/open-harness/issues/354)).
 - Export `isHelpFlag` and `isVersionFlag` from `apps/oh/src/cli.ts` for testability (#354).
+- `make shell [service]` now accepts an optional compose service name; defaults to `sandbox`. Pair with `SHELL_USER=<user>` for services without a `sandbox` user (e.g., postgres).
 ### Fixed
 - Secret-exposure hooks (`.claude/hooks/{deny-env-dump,deny-secret-paths}.sh`) no longer deny operations on tracked template env files (`.example.env`, `.env.example`, `.env.sample`, `.env.template`); real `.env`, `.env.local`, `.env.production` continue to deny. Path-branch was split out of monolithic `DENY` so allowlist applies only to `READ_CMD`-anchored secret-path matches; `\benv\b` patterns retightened to `(^|[^A-Za-z0-9._/-])env` (command-position) to fix a pre-existing false-positive on any path ending in `.env`. Codex wrapper inherits the fix ([#356](https://github.com/ryaneggz/open-harness/issues/356)).
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ### Changed
 - `.pi/extensions/path-guard.ts` refactored to expose `SENSITIVE_PATHS` as a named export and extract the sensitive-path check into a new `isSensitivePath(p: string): boolean` named export; default-export behavior unchanged ([#354](https://github.com/ryaneggz/open-harness/issues/354)).
 - Export `isHelpFlag` and `isVersionFlag` from `apps/oh/src/cli.ts` for testability (#354).
-- `make shell [service]` now accepts an optional compose service name; defaults to `sandbox`. Pair with `SHELL_USER=<user>` for services without a `sandbox` user (e.g., postgres).
+- `make shell [container]` now accepts an optional running container name and runs `docker exec`; defaults to `$(SANDBOX_NAME)`. Pair with `SHELL_USER=<user>` for containers without a `sandbox` user.
 ### Fixed
 - Secret-exposure hooks (`.claude/hooks/{deny-env-dump,deny-secret-paths}.sh`) no longer deny operations on tracked template env files (`.example.env`, `.env.example`, `.env.sample`, `.env.template`); real `.env`, `.env.local`, `.env.production` continue to deny. Path-branch was split out of monolithic `DENY` so allowlist applies only to `READ_CMD`-anchored secret-path matches; `\benv\b` patterns retightened to `(^|[^A-Za-z0-9._/-])env` (command-position) to fix a pre-existing false-positive on any path ending in `.env`. Codex wrapper inherits the fix ([#356](https://github.com/ryaneggz/open-harness/issues/356)).
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 # Open Harness — Makefile
 # Override sandbox name: make shell SANDBOX_NAME=mycontainer
+# Connect to a non-default service: make shell postgres
+# Connect as a specific user: make shell postgres SHELL_USER=postgres
 
 -include .devcontainer/.env
 
 SANDBOX_NAME      ?= openharness
+SHELL_USER        ?= sandbox
 COMPOSE_BASE      := -f .devcontainer/docker-compose.yml
 # Base ships with no required overlays. Downstream packs (Pi extensions,
 # BYO harness packs) register their own by appending paths to
@@ -13,6 +16,15 @@ COMPOSE_OVERRIDES := $(shell command -v jq >/dev/null 2>&1 && [ -f config.json ]
     jq -r '.composeOverrides[]?' config.json 2>/dev/null | sed 's|^|-f |' | tr '\n' ' ')
 COMPOSE           := docker compose $(COMPOSE_BASE) $(COMPOSE_OVERRIDES)
 
+SHELL_SERVICE ?= sandbox
+ifeq ($(firstword $(MAKECMDGOALS)),shell)
+  SHELL_POS_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  ifneq ($(SHELL_POS_ARGS),)
+    SHELL_SERVICE := $(firstword $(SHELL_POS_ARGS))
+    $(foreach a,$(SHELL_POS_ARGS),$(eval $a:;@:))
+  endif
+endif
+
 .DEFAULT_GOAL := help
 
 .PHONY: sandbox shell destroy stop logs ps restart help
@@ -20,8 +32,8 @@ COMPOSE           := docker compose $(COMPOSE_BASE) $(COMPOSE_OVERRIDES)
 sandbox: ## Provision and start the sandbox
 	$(COMPOSE) up -d --build
 
-shell: ## Connect to the sandbox (agent choice happens inside)
-	docker exec -it -u sandbox $(SANDBOX_NAME) zsh
+shell: ## Connect to a compose service shell (default: sandbox). Usage: make shell [service] [SHELL_USER=user]
+	$(COMPOSE) exec -u $(SHELL_USER) $(SHELL_SERVICE) zsh
 
 destroy: ## Stop and remove the sandbox (volumes wiped)
 	$(COMPOSE) down -v

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Open Harness — Makefile
 # Override sandbox name: make shell SANDBOX_NAME=mycontainer
-# Connect to a non-default service: make shell postgres
-# Connect as a specific user: make shell postgres SHELL_USER=postgres
+# Connect to a different running container: make shell portfolio-advisor
+# Connect as a specific user: make shell some-container SHELL_USER=postgres
 
 -include .devcontainer/.env
 
@@ -16,11 +16,11 @@ COMPOSE_OVERRIDES := $(shell command -v jq >/dev/null 2>&1 && [ -f config.json ]
     jq -r '.composeOverrides[]?' config.json 2>/dev/null | sed 's|^|-f |' | tr '\n' ' ')
 COMPOSE           := docker compose $(COMPOSE_BASE) $(COMPOSE_OVERRIDES)
 
-SHELL_SERVICE ?= sandbox
+SHELL_CONTAINER ?= $(SANDBOX_NAME)
 ifeq ($(firstword $(MAKECMDGOALS)),shell)
   SHELL_POS_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
   ifneq ($(SHELL_POS_ARGS),)
-    SHELL_SERVICE := $(firstword $(SHELL_POS_ARGS))
+    SHELL_CONTAINER := $(firstword $(SHELL_POS_ARGS))
     $(foreach a,$(SHELL_POS_ARGS),$(eval $a:;@:))
   endif
 endif
@@ -32,8 +32,8 @@ endif
 sandbox: ## Provision and start the sandbox
 	$(COMPOSE) up -d --build
 
-shell: ## Connect to a compose service shell (default: sandbox). Usage: make shell [service] [SHELL_USER=user]
-	$(COMPOSE) exec -u $(SHELL_USER) $(SHELL_SERVICE) zsh
+shell: ## Connect to a running container (default: $(SANDBOX_NAME)). Usage: make shell [container] [SHELL_USER=user]
+	docker exec -it -u $(SHELL_USER) $(SHELL_CONTAINER) zsh
 
 destroy: ## Stop and remove the sandbox (volumes wiped)
 	$(COMPOSE) down -v

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -23,6 +23,7 @@ The sandbox is a Docker container running on your host (or a remote server). Get
 cd ~/.openharness
 make shell
 ```
+Pass an optional compose service to scope to a different container, e.g. `make shell postgres SHELL_USER=postgres`.
 
 You land inside the container as the `sandbox` user. This is enough to run CLI agents and configure Slack. Container ports are **not** forwarded to your laptop — you cannot open `localhost:3000` in your browser via this method alone.
 

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -23,7 +23,7 @@ The sandbox is a Docker container running on your host (or a remote server). Get
 cd ~/.openharness
 make shell
 ```
-Pass an optional compose service to scope to a different container, e.g. `make shell postgres SHELL_USER=postgres`.
+Pass an optional container name to attach to a different running container, e.g. `make shell portfolio-advisor` (add `SHELL_USER=<user>` if the target has no `sandbox` user).
 
 You land inside the container as the `sandbox` user. This is enough to run CLI agents and configure Slack. Container ports are **not** forwarded to your laptop — you cannot open `localhost:3000` in your browser via this method alone.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,7 +37,7 @@ the sandbox up via `docker compose`.
 cd ~/.openharness
 make shell
 ```
-Pass an optional compose service to scope to a different container, e.g. `make shell postgres SHELL_USER=postgres`.
+Pass an optional container name to attach to a different running container, e.g. `make shell portfolio-advisor` (add `SHELL_USER=<user>` if the target has no `sandbox` user).
 
 Either way you're inside the isolated sandbox as the `sandbox` user. Working
 directory: `/home/sandbox/harness`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,6 +37,7 @@ the sandbox up via `docker compose`.
 cd ~/.openharness
 make shell
 ```
+Pass an optional compose service to scope to a different container, e.g. `make shell postgres SHELL_USER=postgres`.
 
 Either way you're inside the isolated sandbox as the `sandbox` user. Working
 directory: `/home/sandbox/harness`.

--- a/tasks/make-shell-service-arg/plan.md
+++ b/tasks/make-shell-service-arg/plan.md
@@ -1,0 +1,100 @@
+# Plan: `make shell [service]` — scope to a compose service, default sandbox
+
+## Context
+
+Today the `Makefile` `shell` target hardcodes one path:
+
+```makefile
+shell: ## Connect to the sandbox (agent choice happens inside)
+	docker exec -it -u sandbox $(SANDBOX_NAME) zsh
+```
+
+It always `docker exec`s into the `openharness` container as the `sandbox` user. The harness is moving toward multi-service compose stacks — `.devcontainer/docker-compose.postgres.yml` already adds a `postgres` service (`${SANDBOX_NAME}-postgres`), and overlays are loaded dynamically through `config.json`'s `composeOverrides[]`. Reaching the postgres (or any future overlay) container today means dropping out of Make and constructing a `docker exec` by hand.
+
+Desired behaviour:
+
+- `make shell` — unchanged: opens a shell in the default `sandbox` service as `sandbox` user.
+- `make shell <service>` — opens a shell in the named compose service (`postgres`, future overlays).
+- `make shell <service> SHELL_USER=<user>` — overrides the exec user when the target container has no `sandbox` user (postgres, etc.).
+
+Service resolution goes through `docker compose exec`, so overlay-defined services resolve correctly without re-deriving container names, and arbitrary `docker ps` names outside the compose project are intentionally out of reach.
+
+## Approach
+
+### 1. Makefile changes — `/home/sandbox/harness/Makefile`
+
+Add a `SHELL_USER` variable next to `SANDBOX_NAME` (line 6 area):
+
+```makefile
+SHELL_USER ?= sandbox
+```
+
+Replace the `shell:` target (currently lines 23–24) with a compose-exec variant that reads an optional positional service argument:
+
+```makefile
+shell: ## Connect to a compose service shell. Usage: make shell [service] [SHELL_USER=user]
+	$(COMPOSE) exec -u $(SHELL_USER) $(SHELL_SERVICE) zsh
+```
+
+Add the positional-arg shim just above the target (or grouped with other variable assignments):
+
+```makefile
+SHELL_SERVICE ?= sandbox
+ifeq ($(firstword $(MAKECMDGOALS)),shell)
+  SHELL_POS_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  ifneq ($(SHELL_POS_ARGS),)
+    SHELL_SERVICE := $(firstword $(SHELL_POS_ARGS))
+    $(foreach a,$(SHELL_POS_ARGS),$(eval $a:;@:))
+  endif
+endif
+```
+
+Notes on this idiom:
+
+- Scoped under `ifeq ($(firstword $(MAKECMDGOALS)),shell)` so the catch-all `:; @:` rules only register when `shell` is actually being invoked — does not pollute other targets' namespaces.
+- `SHELL_SERVICE` is overridable via env/make var as well, so `make shell SHELL_SERVICE=postgres` works equivalently to `make shell postgres` for tooling that prefers named vars.
+- `$(COMPOSE)` already resolves to `docker compose $(COMPOSE_BASE) $(COMPOSE_OVERRIDES)` (line 14), so overlay services like `postgres` are visible.
+- Drop the explicit `-it` flag: `docker compose exec` allocates a TTY by default when stdin is a terminal; matches behavior the user expects.
+
+Update the help comment on the `shell` target (rendered by the existing `make help` mechanism at line 44) to document the new form.
+
+### 2. Documentation updates
+
+The bare `make shell` form keeps working unchanged, so existing docs aren't wrong — but the canonical references should mention the new optional argument once, in the same place SANDBOX_NAME is described:
+
+- `/home/sandbox/harness/Makefile` — header comment block already shows `make shell SANDBOX_NAME=mycontainer`; append a similar one-liner for the new form.
+- `/home/sandbox/harness/CLAUDE.md` — § Lifecycle → Setup step 3 (Option A) currently shows `make shell` only. Add a one-line note: `make shell <service>` for non-default services.
+- `/home/sandbox/harness/AGENTS.md` — mirror the CLAUDE.md edit (Explore reported it's a copy at the same line numbers).
+- `/home/sandbox/harness/docs/connecting.md` — Option A section.
+- `/home/sandbox/harness/docs/quickstart.md` — "Enter the sandbox" section.
+
+Skip the per-agent docs under `docs/agents/*.md` and `.pi/extensions/slack/README.md` — they reference `make shell` only as the entry-point command, not as an interface to document.
+
+### 3. CHANGELOG entry
+
+Append to `/home/sandbox/harness/CHANGELOG.md` under `## [Unreleased]` → `### Changed`:
+
+```markdown
+- `make shell [service]` now accepts an optional compose service name; defaults to `sandbox`. Pair with `SHELL_USER=<user>` for services without a `sandbox` user (e.g., postgres).
+```
+
+## Critical files
+
+| File | Change |
+|------|--------|
+| `Makefile` (lines 4–6, 23–24, ~30 lines added) | Add `SHELL_USER`/`SHELL_SERVICE` vars + positional-arg shim; replace `shell:` body to use `$(COMPOSE) exec` |
+| `CLAUDE.md`, `AGENTS.md`, `docs/connecting.md`, `docs/quickstart.md` | One-line addition documenting `make shell <service>` |
+| `CHANGELOG.md` | `### Changed` entry under `[Unreleased]` |
+
+## Verification
+
+Run from the harness root with the sandbox up (`make sandbox` already executed):
+
+1. **Default still works** — `make shell` lands in the `openharness` container as `sandbox` (whoami → `sandbox`, hostname matches container).
+2. **Service arg routes through compose** — with the postgres overlay enabled in `config.json`'s `composeOverrides[]`, run `make shell postgres SHELL_USER=postgres`. Expect a postgres-container shell (psql binary on PATH, `whoami` → `postgres`).
+3. **Service arg without user override surfaces a clear error** — `make shell postgres` (no `SHELL_USER` override) should error from inside the container that user `sandbox` doesn't exist; confirms the override knob is reachable.
+4. **Unknown service fails fast** — `make shell nonexistent` exits with `docker compose`'s "no such service" message; the catch-all `:; @:` does not silently swallow it.
+5. **`SANDBOX_NAME` override still composes correctly** — `make shell SANDBOX_NAME=othersandbox` (with that container provisioned) still works for the default service.
+6. **Make `help` output** — `make help` shows the updated description for `shell`.
+
+Read the modified `Makefile` end-to-end after editing to verify no other target was accidentally affected by the conditional catch-all block.


### PR DESCRIPTION
## Summary

Give `make shell` an optional positional compose service argument and a `SHELL_USER` override knob, so harness engineers can reach overlay containers (postgres, future overlays) without dropping out of Make.

- `make shell` — unchanged: opens a shell in the default `sandbox` service as `sandbox` user
- `make shell <service>` — opens a shell in the named compose service via `$(COMPOSE) exec`
- `make shell <service> SHELL_USER=<user>` — overrides the exec user for containers without a `sandbox` user (e.g. postgres)

Implementation uses an `ifeq ($(firstword $(MAKECMDGOALS)),shell)` guard so the positional catch-all (`:; @:`) only registers when `shell` is the goal — does not pollute other targets' namespaces. Reuses the existing `$(COMPOSE)` variable so overlay services declared in `config.json`'s `composeOverrides[]` resolve correctly.

## Plan

The approved plan is committed in-tree at [`tasks/make-shell-service-arg/plan.md`](../blob/task/make-shell-service-arg/tasks/make-shell-service-arg/plan.md).

## Commits

- `task: scaffold plan for make shell [service]` — plan snapshot
- `feat: make shell accepts optional service argument` — Makefile change
- `task: document make shell [service] argument` — AGENTS.md (CLAUDE.md symlink), docs/connecting.md, docs/quickstart.md
- `task: changelog entry for make shell service arg` — CHANGELOG entry under `[Unreleased]` → `### Changed`

## Test plan

- [ ] `make shell` lands in `openharness` container as `sandbox` user (whoami → sandbox)
- [ ] `make shell postgres SHELL_USER=postgres` lands in the postgres container as postgres user (psql on PATH) — requires postgres overlay enabled in `config.json`
- [ ] `make shell postgres` (no user override) fails with a clear "user sandbox not found" error from the postgres container — confirms the override knob is reachable
- [ ] `make shell nonexistent` exits with `docker compose`'s "no such service" message
- [ ] `make help` shows the updated `shell` target description

Pre-merge dry-run already verified via `make -n shell`, `make -n shell postgres`, `make -n shell postgres SHELL_USER=postgres` — all parse and emit the expected compose command shapes.

Draft PR — verification matrix above is for the orchestrator to run against a live sandbox before promoting to ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)