### PR TITLE
FROM task/cleanup-tasks-pr-workflow TO development

### DIFF
--- a/crons/cleanup-tasks.md
+++ b/crons/cleanup-tasks.md
@@ -20,22 +20,47 @@ subfolder.
 
 1. Compute `TODAY=$(date -u +%Y-%m-%d)` and ensure
    `tasks/archive/$TODAY/` exists.
-2. For each `tasks/<taskdesc>/` (skipping `tasks/archive/`):
+2. **Pre-flight:** verify the working tree is clean
+   (`git status --porcelain` empty). If dirty, abort the sweep, append
+   a note to `memory/$TODAY/log.md`, and skip to step 7. Do not
+   contaminate the archive branch with unrelated changes.
+3. Resolve `$BASE` = default target branch per `context/rules/git.md`
+   (`development` → `main` → `master`, whichever exists). Fetch it
+   (`git fetch origin "$BASE"`) and create the archive branch off
+   `origin/$BASE`:
+   `git switch -c "archive/$TODAY" "origin/$BASE"`.
+   If the branch already exists (re-run on same day), switch to it
+   instead.
+4. For each `tasks/<taskdesc>/` (skipping `tasks/archive/`):
    - If `progress.txt` ends with a line matching exactly
      `STATUS: COMPLETE`:
      - Kill the matching tmux session if one exists:
        `tmux kill-session -t <taskdesc> 2>/dev/null || true`.
-     - Move the folder: `mv tasks/<taskdesc> tasks/archive/$TODAY/<taskdesc>`.
+     - Move the folder: `git mv tasks/<taskdesc> tasks/archive/$TODAY/<taskdesc>`
+       (falls back to `mv` + `git add` if `git mv` rejects an untracked path).
    - Otherwise, leave the folder in place and append a one-line note to
      `memory/$TODAY/log.md` recording that `<taskdesc>` is still active
      (include the last `progress.txt` modification time).
-3. After the sweep, append a single summary line to
-   `memory/$TODAY/log.md`: `cleanup-tasks: archived N, skipped M`.
-4. **Mandatory closing step:** append one liveness line to `crons/.cron.log`:
+5. If anything was archived this run (`N > 0`):
+   - Stage the moves: `git add tasks/`.
+   - Commit: `git commit -m "archive: weekly cleanup $TODAY (N tasks)"`.
+   - Push: `git push -u origin "archive/$TODAY"`.
+   - Open a PR (or update an existing one for the same branch) per
+     `context/rules/git.md` conventions:
+     `gh pr create --base "$BASE" --head "archive/$TODAY" \
+        --title "FROM archive/$TODAY TO $BASE" \
+        --body "Weekly task sweep — archived N completed tasks, skipped M still-active.\n\nArchived: <list>\nSkipped: <list>"`.
+     If `gh pr create` reports the PR already exists, capture its URL
+     via `gh pr view --json url -q .url` instead.
+6. After the sweep, append a single summary line to
+   `memory/$TODAY/log.md`: `cleanup-tasks: archived N, skipped M, pr <url-or-none>`.
+7. **Mandatory closing step:** append one liveness line to `crons/.cron.log`:
    `printf '[%s] cleanup-tasks: %s\n' "$(date -Iseconds)" "OK (archived N, skipped M)" >> crons/.cron.log`.
    Create the file if it does not exist.
 
 ## Reporting
 
-- Nothing to archive and nothing stale → reply `HEARTBEAT_OK`.
-- Otherwise → list of archived and skipped task names with counts.
+- Nothing to archive and nothing stale → reply `HEARTBEAT_OK` (no
+  branch, no PR).
+- Otherwise → list of archived and skipped task names with counts, plus
+  the PR URL on a final line.


### PR DESCRIPTION
## Summary
Updates `crons/cleanup-tasks.md` so the weekly sweep lands via PR instead of writing to `development` directly.

- Working-tree pre-flight (`git status --porcelain` must be empty); dirty trees abort the sweep with a memory-log note.
- Resolves the default base branch (per `context/rules/git.md`), then creates `archive/$TODAY` off `origin/$BASE`.
- Uses `git mv` for the moves and commits as `archive: weekly cleanup $TODAY (N tasks)`.
- Pushes the branch and opens a PR titled `FROM archive/$TODAY TO $BASE`; on re-run for the same day, reuses the existing PR via `gh pr view`.
- Memory log line now includes the PR URL; closing liveness line and `HEARTBEAT_OK` short-circuit unchanged.

## Why
Direct commits to `development` from cron bypass review and make the archive sweep invisible in GitHub. Using `archive/<date>` as the branch prefix makes weekly cleanups trivially identifiable in the PR list.

## Test plan
- [ ] Manually dry-run the new procedure on a future cleanup cycle and confirm a PR is created with the `archive/YYYY-MM-DD` head branch.
- [ ] Verify the dirty-working-tree pre-flight aborts cleanly (e.g. by adding an unrelated file before the sweep).
- [ ] Confirm the re-run path (same-day re-execution) reuses the existing PR rather than failing.

Companion archive PR for today's sweep: #360.