### PR TITLE
FROM task/362-sequoia-wiki-source TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- `wiki/sequoia-capital-the-next-1t-company.md` captures the Sequoia/AI Opportunities thesis that AI-native winners may sell completed services work rather than software tools ([#362](https://github.com/ryaneggz/open-harness/issues/362)).
 - `fast-check` ^4.8.0 added to root devDependencies and vitest include glob extended to cover `apps/**/__tests__/**/*.test.ts` — enables property-based tests across all TypeScript surfaces ([#354](https://github.com/ryaneggz/open-harness/issues/354)).
 - `/imagine` skill (`.claude/skills/imagine/SKILL.md`) — one-shot draft PRD sketch generator. Takes a free-text `<scenario>`, derives a slug via `/prd`'s rule, and writes a 7-section sketch (Scenario / Intent / Sketch / mermaid Diagram / Rough goals / Story seeds / Open questions for /prd) to `.claude/specs/<slug>/spec.md`. Output is gitignored scratch (`.gitignore:51`); purpose-built as input for `/ship-spec --plan <path>`. No clarifying questions — ambiguities go into the spec body so the user can edit before formalizing.
 - `scripts/__tests__/cron-runtime.property.test.ts` — never-throw regression-prevention property test for `parseCronFile` using fast-check; 100 arbitrary string pairs, zero source changes ([#354](https://github.com/ryaneggz/open-harness/issues/354)).

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -26,3 +26,4 @@ Schema rule, frontmatter spec, and all authoring conventions: `context/rules/wik
 
 | Slug | Title | Tags | Updated |
 | --- | --- | --- | --- |
+| sequoia-capital-the-next-1t-company | Sequoia $1T AI Services Thesis | [ai, services, strategy, venture, open-harness] | 2026-05-26 |

--- a/wiki/raw/2026-05-26-sequoia-capital-the-next-1t-company.md
+++ b/wiki/raw/2026-05-26-sequoia-capital-the-next-1t-company.md
@@ -1,0 +1,19 @@
+# Source: https://www.theaiopportunities.com/p/sequoia-capital-the-next-1t-company?utm_campaign=post&utm_medium=web
+
+Fetched: 2026-05-26
+Canonical URL: https://www.theaiopportunities.com/p/sequoia-capital-the-next-1t-company
+Title: Sequoia Capital: The next $1T company won’t sell software. It will sell the work.
+Subtitle: Why the biggest AI companies of this cycle may look less like SaaS, and more like services firms rebuilt from scratch
+Author: Guillermo Flor
+Published: 2026-03-07
+Source status: Substack article with paid-gated continuation; this snapshot stores metadata and the public preview only.
+
+## Public preview excerpt / notes
+
+Sequoia partner Julien Bek's thesis is framed as: "The next $1 trillion company will be a software company masquerading as a services firm." The article argues that many AI founders may be building the wrong layer if they stop at copilots, tools, or software that helps a human do a job better. The larger opportunity is to build companies that do the job itself: not software for accountants, but the company that closes the books; not software for lawyers, but the company that reviews contracts; not software for insurance teams, but the company that handles claims.
+
+The mechanism: selling tools leaves a company exposed to model improvements and feature competition every few months, while selling completed work makes each AI improvement a margin, speed, quality, or price advantage. The budget framing is that services/labor spend is much larger than software spend — the article cites roughly $6 spent on services for every $1 spent on software — so the prize may be the labor budget rather than the SaaS budget.
+
+The preview connects this to older service-business rollup logic: investors have long tried to consolidate fragmented services and make them more scalable/software-like. AI changes the magnitude because software can now perform meaningful parts of the work, not merely support professionals doing it.
+
+The public preview says the full deep dive covers five Sequoia-mentioned founders already building this way, how these companies structure trust with customers, and where the largest opportunities remain.

--- a/wiki/sequoia-capital-the-next-1t-company.md
+++ b/wiki/sequoia-capital-the-next-1t-company.md
@@ -1,0 +1,27 @@
+---
+title: "Sequoia $1T AI Services Thesis"
+slug: sequoia-capital-the-next-1t-company
+tags: [ai, services, strategy, venture, open-harness]
+created: 2026-05-26
+updated: 2026-05-26
+sources:
+  - raw/2026-05-26-sequoia-capital-the-next-1t-company.md
+related: []
+confidence: provisional
+---
+
+# Sequoia $1T AI Services Thesis
+
+## Summary
+Sequoia partner Julien Bek's thesis, as summarized by The AI Opportunities, is that the next trillion-dollar AI company may look less like SaaS and more like a services firm rebuilt around software: it will sell completed work, not tools. For Open Harness, the strategic signal is that an agent engine should not assume the durable product shape is "software for operators"; the scalable shape may be whichever service workflow the engine can own end-to-end with measurable quality, cost, and trust advantages.
+
+## Detail
+The article's core distinction is tool-selling versus work-selling. Copilots and productivity software help a human perform a job, but remain exposed to rapid model improvement, feature commoditization, and incumbent workflow gravity. A work-selling company absorbs the job itself: closing books rather than selling accounting software, reviewing contracts rather than selling legal tooling, handling claims rather than selling insurance-team workflow software.
+
+The budget argument matters. If services/labor spend is many times larger than software spend, the AI opportunity is not only expanding SaaS budgets; it is attacking labor/service budgets that historically sat outside software pricing. The preview cites roughly $6 of services spend for every $1 of software spend.
+
+This is not simply "AI rollups." Traditional rollups consolidated fragmented services and tried to add operational leverage. The AI-native version can build the service delivery layer around models and agents from day one, letting every model improvement compound into lower cost, faster cycle time, better throughput, or higher gross margin. That makes model progress a tailwind for the operator, not a threat to a thin software feature.
+
+Open Harness implication: treat the harness as a reusable service-delivery engine. The right evaluation question is not "can this automate a task?" but "does this task produce enough signal, trust, recurrence, and measurable output quality that Open Harness can become the operating substrate for a service?" Shape follows signal: use agent workflows to discover which service loops produce reliable outcomes, then productize the loops that can be sold as work.
+
+## See Also


### PR DESCRIPTION
Closes #362

## Summary
- Adds a source-backed wiki entry for The AI Opportunities / Sequoia thesis that AI-native winners may sell completed services work rather than software tools.
- Adds a compact raw snapshot containing source metadata and the public preview notes.
- Regenerates the wiki index and adds a changelog entry.

## Validation
- `git diff --cached --check`
- custom wiki schema/source/word-count validation (`339` body words)

## Note
The source is a Substack article with a paid-gated continuation, so the raw snapshot intentionally stores metadata and public-preview synthesis only, not paid article text.
