### PR TITLE
FROM task/373-wiki-slug-compliance TO development

### DIFF
--- a/.claude/skills/wiki-ingest/SKILL.md
+++ b/.claude/skills/wiki-ingest/SKILL.md
@@ -100,8 +100,14 @@ Slug derivation follows `context/rules/wiki.md` § 3 verbatim. Summary for refer
    Re-run with --slug <override>, e.g.:
      /wiki-ingest <url> --slug karpathy-llm-wiki
    ```
-4. **File paths**: use the basename without extension, slugified per rule 2. `--slug <override>` is optional; if absent, the basename is used.
-5. **Charset constraint**: the final slug must match `[a-z0-9-]+`. Reject before any file is written.
+4. **Social / share URLs**: if the URL host is a known social platform (`linkedin.com`, `x.com`, `twitter.com`, `threads.net`, `facebook.com`, `instagram.com`), OR the last path segment contains a run of ≥ 10 consecutive digits (an embedded share/activity ID), OR the slugified segment would exceed 60 characters, the segment contains no meaningful label. `/wiki-ingest` MUST require `--slug <override>` and exit with an error if it is absent:
+   ```
+   ERROR: URL segment is a social/share URL with no meaningful label (social host, >=10-digit share/activity ID, or >60-char slug).
+   Re-run with --slug <override>, e.g.:
+     /wiki-ingest <url> --slug inspectable-agent-harness
+   ```
+5. **File paths**: use the basename without extension, slugified per rule 2. `--slug <override>` is optional; if absent, the basename is used.
+6. **Charset constraint**: the final slug must match `[a-z0-9-]+`. Reject before any file is written.
 
 If `--slug <override>` is provided, use it directly (still validate charset).
 
@@ -110,19 +116,23 @@ If `--slug <override>` is provided, use it directly (still validate charset).
 #### 4a. URL ingest
 
 1. WebFetch the URL to retrieve the page body.
-2. Get today's UTC date:
+   - For LinkedIn/social pages, inspect embedded metadata and JSON-LD (`articleBody`, `headline`, `comment`, `og:description`, `twitter:description`) when the visible DOM is gated or duplicated. Capture useful comments only when they materially clarify the source claim; keep the wiki page bounded and point to the raw snapshot for the full capture.
+2. Normalize the displayed source URL before writing synthesized wiki/log text:
+   - Strip common tracking-only query params (`utm_*`, `rcm`, `fbclid`, `gclid`, etc.) when they are not needed for retrieval.
+   - If preserving a raw fetched URL for provenance, redact secret-like/tracking values in human-facing summaries/logs (e.g. `rcm=[REDACTED]`).
+3. Get today's UTC date:
    ```bash
    TODAY=$(date -u +%Y-%m-%d)
    ```
-3. Ensure `wiki/raw/` exists (§ 2).
-4. Write snapshot to `wiki/raw/<yyyy-mm-dd>-<slug>.md`:
+4. Ensure `wiki/raw/` exists (§ 2).
+5. Write snapshot to `wiki/raw/<yyyy-mm-dd>-<slug>.md`:
    ```
    # Source: <url>
 
    <fetched body>
    ```
-   The header line `# Source: <url>` is mandatory. The fetched body follows on the next line after a blank line. Snapshots are immutable once written — do not overwrite an existing snapshot. If `wiki/raw/<today>-<slug>.md` already exists, generate a unique path (e.g., append `-2`, `-3`).
-5. Proceed to § 6 (write or update `wiki/<slug>.md`).
+   The header line `# Source: <url>` is mandatory. Prefer the normalized/redacted URL in this header unless the exact retrieval URL is essential to reproduce the fetch. The fetched body follows on the next line after a blank line. Snapshots are immutable once written — do not overwrite an existing snapshot. If `wiki/raw/<today>-<slug>.md` already exists, generate a unique path (e.g., append `-2`, `-3`).
+6. Proceed to § 6 (write or update `wiki/<slug>.md`).
 
 #### 4b. File path ingest
 
@@ -258,6 +268,7 @@ Then apply the qualify/improve pass per `context/rules/memory.md` § Write:
 
 ## Anti-patterns
 
+- **Monolithic ingest scripts when a safety gate is likely** — avoid bundling network fetch, raw snapshot write, wiki synthesis, and log append into one large `execute_code` call. If approval or shell-safety friction appears, split the ingest into auditable steps: fetch/snapshot with a small `terminal` command, create or update `wiki/<slug>.md` with `write_file`/`patch`, then append the memory log separately. The invariant is the same (raw snapshot + bounded synthesized entry + log), but smaller tool calls are easier to approve, verify, and recover.
 - **Writing directly to `wiki/` from a sub-agent context** — always use the draft path + `--from-draft` promotion. The orchestrator is the sole writer.
 - **Hardcoding today's date in `--from-draft` resolution** — glob `memory/*/wiki-drafts/<slug>.md` and sort by the ISO date in the directory name, not by mtime and not by assuming today.
 - **Using mtime for stale detection** — mtime is unreliable across git checkouts and Docker volume remounts. Always derive staleness from the ISO date in the parent directory name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ### Changed
 - Release process now promotes `development` → `main` (fast-forward) before cutting the release branch and tag, keeping `main` as the authoritative release line; `/release` skill and `.claude/rules/git.md` § Releases document the `development → main → release → tag → sync` flow and abort if `main` has diverged.
 - Renamed the top-level `apps/` directory to `packages/` and updated workspace, docs, Dockerfile, CI, and test discovery paths to match.
+- `/wiki-ingest` now requires an explicit `--slug` override for social/share URLs (`linkedin.com`, `x.com`, etc.), segments with a ≥10-digit share/activity ID, or slugs over 60 chars — closing a `context/rules/wiki.md` §3 gap that let raw LinkedIn share slugs through ([#373](https://github.com/ryaneggz/open-harness/issues/373)).
 ### Fixed
+- Renamed three wiki entries ingested from LinkedIn share URLs to short semantic slugs (`inspectable-agent-harness`, `latmd-knowledge-graph`, `codegraph-mcp`), fixed their cross-links, and regenerated the stale `wiki/README.md` index ([#373](https://github.com/ryaneggz/open-harness/issues/373)).
 ### Removed
 ### Deprecated
 ### Security

--- a/context/rules/wiki.md
+++ b/context/rules/wiki.md
@@ -92,8 +92,14 @@ Slugs are derived from the source URL or file path. Rules, in order:
 2. **Lowercased kebab-case**: lowercase the segment; replace non-`[a-z0-9]` runs with a single `-`; strip leading/trailing `-`.
 3. **Gist / UUID URLs**: if the last path segment is a UUID or hash (e.g., `https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f`), the segment contains no meaningful label. `/wiki-ingest` MUST require `--slug <override>` and exit with an error if it is absent.
    - Example: `/wiki-ingest https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f --slug karpathy-llm-wiki`
-4. **File paths**: use the basename without extension, slugified per rule 2. `--slug <override>` is optional; without it, the basename is used.
-5. **Charset constraint**: the final slug MUST match `[a-z0-9-]+`. Any slug that does not pass this check is rejected by `/wiki-ingest` before any file is written.
+4. **Social / share URLs**: if the URL host is a known social platform (`linkedin.com`, `x.com`, `twitter.com`, `threads.net`, `facebook.com`, `instagram.com`), OR the last path segment contains a run of ≥ 10 consecutive digits (an embedded share/activity ID), OR the slugified segment would exceed 60 characters, the segment contains no meaningful label. `/wiki-ingest` MUST require `--slug <override>` and exit with an error if it is absent:
+   ```
+   ERROR: URL segment is a social/share URL with no meaningful label (social host, >=10-digit share/activity ID, or >60-char slug).
+   Re-run with --slug <override>, e.g.:
+     /wiki-ingest <url> --slug inspectable-agent-harness
+   ```
+5. **File paths**: use the basename without extension, slugified per rule 2. `--slug <override>` is optional; without it, the basename is used.
+6. **Charset constraint**: the final slug MUST match `[a-z0-9-]+`. Any slug that does not pass this check is rejected by `/wiki-ingest` before any file is written.
 
 ---
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -21,10 +21,15 @@ This directory holds structured entity pages compiled and maintained by the orch
 ## Canonical docs
 
 Schema rule, frontmatter spec, and all authoring conventions: `context/rules/wiki.md`
-
 ## Index
 
 | Slug | Title | Tags | Updated |
 | --- | --- | --- | --- |
-| learn-harness-engineering | Learn Harness Engineering (Walking Labs course) | [harness, agents, education, course, open-harness] | 2026-05-26 |
+| latmd-knowledge-graph | Lat.md Project Knowledge Graph for Agent Context | [agent-context, knowledge-graph, markdown, test-specs, semantic-search] | 2026-05-30 |
+| codegraph-mcp | CodeGraph MCP for Reducing Agent Code-Exploration Tool Calls | [codegraph, mcp, code-exploration, tree-sitter, sqlite, tool-calls] | 2026-05-30 |
+| inspectable-agent-harness | Inspectable Agent Harness Workflows | [claude-code, agent-harness, coding-agents, ai-engineering] | 2026-05-29 |
+| opencode | OpenCode CLI | [agent, cli, opencode, optional, primitive] | 2026-05-28 |
+| deepagents | DeepAgents CLI | [agent, cli, langchain, deepagents, optional, primitive] | 2026-05-28 |
 | sequoia-capital-the-next-1t-company | Sequoia $1T AI Services Thesis | [ai, services, strategy, venture, open-harness] | 2026-05-26 |
+| learn-harness-engineering | Learn Harness Engineering (Walking Labs course) | [harness, agents, education, course, open-harness] | 2026-05-26 |
+| hermes-agent | Hermes Agent CLI | [agent, cli, nousresearch, hermes, primitive] | 2026-05-26 |

--- a/wiki/codegraph-mcp.md
+++ b/wiki/codegraph-mcp.md
@@ -1,0 +1,23 @@
+---
+title: "CodeGraph MCP for Reducing Agent Code-Exploration Tool Calls"
+slug: codegraph-mcp
+tags: [codegraph, mcp, code-exploration, tree-sitter, sqlite, tool-calls]
+created: 2026-05-30
+updated: 2026-05-30
+sources:
+  - raw/2026-05-30-codegraph-mcp.md
+related: [latmd-knowledge-graph, inspectable-agent-harness]
+confidence: provisional
+---
+
+# CodeGraph MCP for Reducing Agent Code-Exploration Tool Calls
+
+## Summary
+A LinkedIn post by Eric Vyacheslav argues that CodeGraph can reduce Claude Code's repository-exploration tool calls by pre-indexing a codebase into a local knowledge graph. The post frames CodeGraph as an open-source MCP server using Tree-sitter, SQLite, full-text search, and a file watcher so agents can query symbols, callers, edges, entry points, and snippets instead of repeatedly grepping and reading files.
+
+## Detail
+The source claims that Claude Code exploration often spends tokens and wall-clock time on repeated grep, glob, and file-read calls, especially when sub-agents scan repositories. CodeGraph's proposed fix is a local MCP server that indexes the repository upfront and lets the agent retrieve entry points, related symbols, callers/callees, and code snippets in a single graph query. The LinkedIn post cites benchmark claims of 92% fewer tool calls on average, 71% faster exploration overall, a 94% drop on a TypeScript repo, and a 96% drop on a Java codebase. The linked project's current README presents more conservative revalidated numbers: roughly 22% cheaper, 47% fewer tokens, 20% faster, and 50% fewer tool calls across seven repositories. CodeGraph is positioned as local-first: Tree-sitter parses source into syntax trees, SQLite stores symbols and edges with full-text search, a watcher keeps indexes fresh, and no API keys are required. For Open Harness, the relevant question is whether CodeGraph should become an opt-in or default in-sandbox MCP capability for code navigation, distinct from the wiki/Lat.md-style durable knowledge layer.
+
+## See Also
+- [[latmd-knowledge-graph]]
+- [[inspectable-agent-harness]]

--- a/wiki/inspectable-agent-harness.md
+++ b/wiki/inspectable-agent-harness.md
@@ -1,0 +1,21 @@
+---
+title: "Inspectable Agent Harness Workflows"
+slug: inspectable-agent-harness
+tags: [claude-code, agent-harness, coding-agents, ai-engineering]
+created: 2026-05-29
+updated: 2026-05-29
+sources:
+  - raw/2026-05-29-inspectable-agent-harness.md
+related: []
+confidence: provisional
+---
+
+# Inspectable Agent Harness Workflows
+
+## Summary
+A LinkedIn post by André Lindenberg frames Claude Code as making a broader agent-harness workflow pattern visible. It highlights Pi, pi-subagents, pi-dynamic-workflows, and Atomic as examples of orchestration systems that let coding agents explore while keeping their process inspectable.
+
+## Detail
+The source argues that the key value in modern coding-agent harnesses is not only autonomous code generation, but inspectable orchestration around agent work. It cites Pi users already using pi-subagents for chained and parallel review flows, background runs, forked context, worktrees, artifacts, and saved `.chain.md` workflows. It also notes pi-dynamic-workflows as adding JavaScript-style orchestration, while Atomic adds TypeScript workflows, review gates, human-in-the-loop checkpoints, artifacts, and provider choice. The post's thesis is concise: let agents explore, but make the process and outputs visible enough for humans and other agents to review, gate, and reuse. Tags on the post include Claude Code, AgentHarness, CodingAgents, and AIEngineering.
+
+## See Also

--- a/wiki/latmd-knowledge-graph.md
+++ b/wiki/latmd-knowledge-graph.md
@@ -1,0 +1,22 @@
+---
+title: "Lat.md Project Knowledge Graph for Agent Context"
+slug: latmd-knowledge-graph
+tags: [agent-context, knowledge-graph, markdown, test-specs, semantic-search]
+created: 2026-05-30
+updated: 2026-05-30
+sources:
+  - raw/2026-05-30-latmd-knowledge-graph.md
+related: [inspectable-agent-harness]
+confidence: provisional
+---
+
+# Lat.md Project Knowledge Graph for Agent Context
+
+## Summary
+A LinkedIn post by Eric Vyacheslav argues that agents lose context when a growing codebase relies on a single flat `AGENTS.md` file. It presents Lat.md as a project-root markdown knowledge graph: a `lat.md/` folder with linked architecture, business-logic, and test-spec documents plus CLI validation and search.
+
+## Detail
+The source claims `AGENTS.md` becomes overloaded as repositories grow because design decisions and domain constraints are buried in one flat file. Lat.md’s proposed fix is a folder of markdown files at the project root, connected with wiki-style links. The files document architecture, business logic, and test specifications, while links can connect sections to source symbols, implementation concepts, and inline comments. The described CLI includes `lat init` for scaffolding, `lat check` for reference validation, `lat search` for semantic queries, and `lat section` for graph navigation. The post’s value proposition is that agents stop grepping blindly and can retrieve decisions, constraints, domain context, and past-session knowledge quickly. It also highlights test-spec backlinks as a way to require implementation/tests to stay connected to documented requirements. For Open Harness, the relevant insight is not necessarily a new `lat.md/` directory, but the broader pattern: durable, linked project knowledge that is validated and queryable by agents rather than loaded wholesale into startup context.
+
+## See Also
+- [[inspectable-agent-harness]]


### PR DESCRIPTION
Closes #373

## What

Three wiki entries were ingested from LinkedIn share URLs with junk slugs (embedded share-ID + 4-char suffix), e.g. `alindnbrg-claudecode-…-share-7466225009481637888-zqxe`. This PR remediates them and closes the rule gap that allowed them.

## Changes

- **Renamed 3 entries → short semantic slugs** (+ their gitignored `raw/` snapshots): `inspectable-agent-harness`, `latmd-knowledge-graph`, `codegraph-mcp`. Updated every `slug:`/`sources:`/`related:` field and `[[…]]` cross-link.
- **Hardened `context/rules/wiki.md` §3** with a new rule (mirrored byte-identically into the `wiki-ingest` skill): social hosts (`linkedin.com`, `x.com`, …), ≥10-digit share/activity IDs, or >60-char slugs now require an explicit `--slug` override.
- **Regenerated `wiki/README.md`** via `/wiki-lint` (the index was stale — listed only 2 of 8 entries; now all 8).

## Root cause

§3 rule 1 only forced `--slug` when the *whole* last URL segment matched `^[0-9a-f-]{8,}$` (pure UUID/hash). LinkedIn share segments contain real words plus an embedded numeric ID, so they passed through to kebab-casing and produced unbounded junk slugs.

## Note on scope

The `wiki-ingest` SKILL.md diff also carries **pre-existing working-tree §4a edits** (social-page JSON-LD metadata extraction + source-URL normalization/redaction) that were already staged before this session. They're on the same social-URL-ingestion theme, so they're bundled here rather than orphaned — flagging for reviewer awareness.

## Verification

- All `[[cross-links]]` resolve; zero leftover junk IDs in entry bodies.
- `/wiki-lint`: 0 stale, 0 deprecated, 0 broken links.
- Rule/skill lockstep: rule-4 prose + error block byte-identical in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)