### PR TITLE
FROM docs/readme-org-fork-model TO development

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ make destroy
 
 ## 🤝 Contributing & community
 
-Issues and PRs welcome at [github.com/mifunedev/openharness](https://github.com/mifunedev/openharness). If Open Harness is useful to you, please [give us a star](https://github.com/mifunedev/openharness/stargazers).
+Open Harness is maintained under the [`mifunedev`](https://github.com/mifunedev) org — the canonical repo is [github.com/mifunedev/openharness](https://github.com/mifunedev/openharness). To run your own, fork it (see **Option B** above) and open PRs back upstream. Issues and PRs welcome; if Open Harness is useful to you, please [give us a star](https://github.com/mifunedev/openharness/stargazers).
 
 ## 📄 License
 


### PR DESCRIPTION
Documents the org + fork model in the README after the move to `mifunedev/openharness`:
- States the project is maintained under the `mifunedev` org with the canonical repo at `mifunedev/openharness`.
- Points self-hosters at the existing fork flow (Option B) and PRing upstream.

The `@ryaneggz/mifune` pack links and `oh.mifune.dev` domain are intentionally unchanged — neither moved with the GitHub-org transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)