### PR TITLE
FROM task/402-fix-release-shipspec-skills TO development

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -18,7 +18,16 @@ This skill exists for the parts that are tedious to run by hand: version auto-in
 ### Step 1 — Resolve repo + version
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+# Resolve the canonical remote: prefer 'upstream' (fork layout where origin is
+# a private fork), else 'origin' (standard single-remote layout). All release
+# pushes target $REMOTE so a release never lands on a private fork by accident.
+if git remote get-url upstream >/dev/null 2>&1; then
+  REMOTE=upstream
+else
+  REMOTE=origin
+fi
+REPO=$(gh repo view "$(git remote get-url "$REMOTE")" --json nameWithOwner -q .nameWithOwner)
+git fetch "$REMOTE" --tags --quiet                     # version detection needs canonical tags
 TODAY=$(date '+%Y.%-m.%-d')
 
 if ! git tag --list "$TODAY" | grep -q .; then
@@ -95,13 +104,13 @@ the branch model).
 PREV_BRANCH=$(git branch --show-current)               # expected: development
 
 # Push the CHANGELOG promotion commit to development.
-git push origin "$PREV_BRANCH"
+git push "$REMOTE" "$PREV_BRANCH"
 
 # Promote development → main. main MUST be strictly behind development
 # (fast-forwardable). Abort if it has diverged — reconcile manually first.
-git fetch origin main "$PREV_BRANCH"
-if git merge-base --is-ancestor origin/main "origin/$PREV_BRANCH"; then
-  git push origin "origin/$PREV_BRANCH:main"           # clean fast-forward
+git fetch "$REMOTE" main "$PREV_BRANCH"
+if git merge-base --is-ancestor "$REMOTE/main" "$REMOTE/$PREV_BRANCH"; then
+  git push "$REMOTE" "$REMOTE/$PREV_BRANCH:main"       # clean fast-forward
   echo "main fast-forwarded to $PREV_BRANCH"
 else
   echo "Aborting: main has diverged from $PREV_BRANCH — reconcile before releasing." >&2
@@ -109,9 +118,9 @@ else
 fi
 
 # Cut the release branch from main and tag it.
-git checkout -b "release/$VERSION" origin/main
-git push origin "release/$VERSION"
-git tag "$VERSION" && git push origin "$VERSION"    # triggers release.yml
+git checkout -b "release/$VERSION" "$REMOTE/main"
+git push "$REMOTE" "release/$VERSION"
+git tag "$VERSION" && git push "$REMOTE" "$VERSION"    # triggers release.yml
 ```
 
 After step 4, `main` and `development` are converged (both at the
@@ -141,8 +150,16 @@ done
 
 ```bash
 gh release view "$VERSION" --repo "$REPO"
-gh api "users/${REPO%%/*}/packages/container/${REPO##*/}/versions" \
-  --jq '.[0] | {tags: .metadata.container.tags, created: .created_at}'
+
+# GHCR package owner may be an org or a user — try org first, fall back to user.
+# Listing needs the read:packages scope; the release.yml docker-push step is the
+# authoritative confirmation if the token lacks it.
+OWNER=${REPO%%/*}; PKG=${REPO##*/}
+gh api "orgs/$OWNER/packages/container/$PKG/versions" \
+    --jq '.[0] | {tags: .metadata.container.tags, created: .created_at}' 2>/dev/null \
+  || gh api "users/$OWNER/packages/container/$PKG/versions" \
+    --jq '.[0] | {tags: .metadata.container.tags, created: .created_at}' 2>/dev/null \
+  || echo "(package listing needs read:packages scope — verify via the release.yml run's docker push step)"
 ```
 
 ### Step 7 — Return to previous branch + report

--- a/.claude/skills/ship-spec/SKILL.md
+++ b/.claude/skills/ship-spec/SKILL.md
@@ -76,7 +76,7 @@ Both critics receive an additional cross-check instruction: read `.claude/protec
 > Focus on:
 > 1. **Vague acceptance criteria** — flag any AC that isn't directly verifiable
 > 2. **Missing dependencies** — what does each story silently assume exists?
-> 3. **Pattern conflicts** — does any story break an existing convention in this repo? Read `.claude/rules/*.md` and `tasks/openharness-v07-convergence/prd.json` for established patterns.
+> 3. **Pattern conflicts** — does any story break an existing convention in this repo? Read `.claude/rules/*.md` (and any sibling `tasks/*/prd.json`, if present) for established patterns.
 > 4. **Scope creep within stories** — are any "single iteration" stories actually 2+ stories?
 > 5. **Hidden destructive operations** — does any story imply file deletion / branch deletion / PR closure that isn't explicitly gated?
 > 6. **Protected-path violations** — does any story propose touching a `.claude/protected-paths.txt` entry without override note? If yes, raise SEVERITY: H and tag the finding with `[PROTECTED-PATH]`.
@@ -181,11 +181,11 @@ The skill produces `tasks/<slug>/prd.json` with `branchName: <prefix>/<N>-<slug>
 
 ### Stage 7 — Scaffold `prompt.md` + `progress.txt`
 
-Clone `tasks/openharness-v07-convergence/prompt.md` as the template. Adapt:
-- Replace `openharness-v07-convergence` with `<slug>` throughout
-- Replace `task/210-openharness-v07-convergence` with `<prefix>/<N>-<slug>`
-- Update the read-context list (step 1) to point at this task's prd.md, prd.json, critique.md, progress.txt
-- Reference `.claude/rules/advisor-model.md` for any critic-gated stories
+Clone `.claude/skills/ship-spec/templates/prompt.md` as the template (it ships with `<slug>`, `<prefix>/<N>-<slug>`, `<NNN>`, and `#<issue>` placeholders). Adapt:
+- Replace `<slug>` with this task's slug throughout
+- Replace `<prefix>/<N>-<slug>` with the real branch name
+- Replace `#<issue>` with the tracking issue number
+- Confirm the read-context list (step 1) points at this task's prd.md, prd.json, critique.md, progress.txt (the template already references `.claude/rules/advisor-model.md` for critic-gated stories)
 
 Write `tasks/<slug>/progress.txt` with header only:
 
@@ -342,4 +342,4 @@ v1 stops at draft PR because the loop launch is the highest-blast-radius step in
 | `/ci-status` skill | `.claude/skills/ci-status/SKILL.md` | (v2 — CI verification) |
 | advisor-model rule | `.claude/rules/advisor-model.md` | Critic-gate pattern (3-step variant) |
 | Protected-paths list | `.claude/protected-paths.txt` | Stage 3 — load-bearing items critics must not propose deleting |
-| Convergence task template | `tasks/openharness-v07-convergence/` | Stage 7 — prompt.md template |
+| Ralph prompt template | `.claude/skills/ship-spec/templates/prompt.md` | Stage 7 — prompt.md template |

--- a/.claude/skills/ship-spec/templates/prompt.md
+++ b/.claude/skills/ship-spec/templates/prompt.md
@@ -1,0 +1,99 @@
+# Ralph iteration — <slug>
+
+You are one iteration of a Ralph loop implementing the `<slug>` task. The full plan is in `tasks/<slug>/prd.md` and the structured task list is in `tasks/<slug>/prd.json`. The loop calls you again until `progress.txt` contains a line `STATUS: COMPLETE`.
+
+## Your job in one iteration
+
+Pick **one** user story, implement it, commit, mark it `passes: true`, and append a progress entry. Then exit. The next iteration handles the next story. Do not attempt multiple stories per iteration.
+
+## Steps every iteration
+
+1. **Read context** — in this order:
+   - `tasks/<slug>/prd.json` — find the lowest-`priority` story where `passes: false`. That is your story for this iteration.
+   - `tasks/<slug>/progress.txt` — read the "Codebase Patterns" section at the top (if any) and the most recent few iterations to see what's been done.
+   - `tasks/<slug>/critique.md` — if present, the critic findings the stories must satisfy.
+   - `.claude/rules/git.md` for branch + commit conventions.
+   - `.claude/rules/sandbox-processes.md` for tmux session conventions if your story spawns processes.
+   - `.claude/rules/advisor-model.md` for any critic-gated story.
+
+2. **Verify branch** — your branch is `<prefix>/<N>-<slug>` (per `prd.json` `branchName`). If you are not on it:
+   ```bash
+   git fetch origin
+   git checkout -b <prefix>/<N>-<slug> origin/development 2>/dev/null \
+     || git checkout <prefix>/<N>-<slug>
+   ```
+   Never push to `development` or `main` directly.
+
+3. **Implement the chosen story** — make the file changes, additions, deletions specified in the story's `acceptanceCriteria`. Confine the work to that story; resist scope creep.
+
+4. **Run quality checks** before commit:
+   ```bash
+   pnpm run type-check 2>/dev/null || true
+   pnpm run lint 2>/dev/null || true
+   pnpm run test 2>/dev/null || true
+   ```
+   If checks fail, fix them. Do not commit broken code.
+
+5. **Commit** with this message format (per `.claude/rules/git.md`):
+   ```
+   <type>: US-<NNN> — <story title>
+   ```
+   Where `<type>` is `task` for most stories, `feat` for net-new functionality, `fix` for bugs. Example: `task: US-001 — <story title>`. Stage only files touched by this story.
+
+6. **Update `prd.json`** — set `passes: true` for the completed story, and set `notes` to a one-line summary including iteration number and date:
+   ```json
+   "notes": "Completed iteration 3 on <YYYY-MM-DD>; commit abc1234"
+   ```
+
+7. **Append to `progress.txt`** — append (never replace) using this format:
+   ```markdown
+   ## US-<NNN> — <YYYY-MM-DD HH:MM UTC>
+
+   **Title**: <story title>
+   **Files changed**: <list>
+   **Commit**: <short SHA>
+   **Result**: PASS | BLOCKED | DEFERRED
+
+   ### What I did
+   <2-4 sentences>
+
+   ### Learnings for future iterations
+   <patterns, gotchas, useful context>
+
+   ---
+   ```
+
+8. **Codebase Patterns** — if you discovered a pattern other iterations should know (a non-obvious convention, a shared utility, a gotcha), append it to (or create) the `## Codebase Patterns` section at the **top** of `progress.txt`. Keep entries general and reusable, not story-specific.
+
+9. **Stop condition** — after step 7, check whether all stories in `prd.json` now have `passes: true`. If yes, append a final line on its own to `progress.txt`:
+   ```
+   STATUS: COMPLETE
+   ```
+   This terminates the Ralph loop. The loop runner reads `progress.txt` for this exact string at the start of each iteration.
+
+10. **End response normally** — do not emit any completion sentinel in your reply text. Only the `STATUS: COMPLETE` line in `progress.txt` matters.
+
+## Blocked or deferred stories
+
+If the chosen story cannot be completed this iteration:
+
+- **Blocked** (external dependency, missing context, ambiguity): append to `progress.txt` with `**Result**: BLOCKED` and an explanation. Do NOT mark `passes: true`. The next iteration will skip this story (find the next lowest-priority `passes: false` that isn't already BLOCKED in recent progress entries) or escalate.
+- **Deferred** (out of scope per the PRD's Non-Goals): append with `**Result**: DEFERRED`. Do NOT mark `passes: true`. The story stays for human review.
+
+## Critical rules
+
+- **One story per iteration.** Resist doing two.
+- **Never push** to `development` or `main`. Branch is `<prefix>/<N>-<slug>`.
+- **Never skip pre-commit hooks** (`--no-verify`).
+- **Never run `git clone` or `git init`** — you're already in a checkout.
+- **Confine writes** to repo-tracked paths. Do not write outside the repo or to `~/`.
+- **Phase ordering matters.** Stories are priority-ordered by dependency — implement them in `priority` order. If a story depends on an artifact a later story creates, it is mis-ordered; surface it rather than implementing out of order.
+- **CHANGELOG discipline.** Per `.claude/rules/git.md`, every story with user-visible impact must add an entry under `## [Unreleased]` in the same commit. The PRD's individual stories spell out which `### Added`, `### Removed`, `### Changed` section to use.
+- **Don't modify completed stories** unless the current story explicitly requires it.
+
+## Reference
+
+- PRD: `tasks/<slug>/prd.md`
+- Structured stories: `tasks/<slug>/prd.json`
+- Branch: `<prefix>/<N>-<slug>`
+- Issue: #<issue>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ### Changed
 
 ### Fixed
+- `/release` skill now resolves the canonical remote (prefers `upstream`, else `origin`) for `REPO` and all release pushes, so a release can't accidentally land on a private fork; GHCR verification tries the org package path before the user path ([#402](https://github.com/mifunedev/openharness/issues/402)).
+- `/ship-spec` Stage 7 now clones a self-contained `.claude/skills/ship-spec/templates/prompt.md` instead of the deleted `tasks/archive/openharness-v07-convergence/prompt.md`; repointed the two other dead references to that task ([#402](https://github.com/mifunedev/openharness/issues/402)).
 
 ### Removed
 


### PR DESCRIPTION
Closes #402

Two orchestrator-skill fixes surfaced by the org-migration cleanup (#400).

## `/release` — canonical-remote resolution
After the org move, `origin` is the **private fork** and `upstream` is the canonical public repo. The skill previously drove `REPO` and every push off `origin`, so a release would have tagged/published on the fork.
- Resolve `REMOTE` = `upstream` when present, else `origin` (standard single-remote layout still works).
- `REPO` is derived from `$REMOTE`'s URL; tag/version detection fetches `$REMOTE` tags first.
- All Step 4 pushes (`development`, `main` FF, release branch, tag) target `$REMOTE`.
- Step 6 GHCR verification tries the **org** package path before the user path, degrading gracefully without `read:packages`.

## `/ship-spec` — self-contained Stage 7 template
Stage 7 cloned `tasks/openharness-v07-convergence/prompt.md` — already stale (it lived under `tasks/archive/`, removed in #400).
- Added `.claude/skills/ship-spec/templates/prompt.md` (genericized, ships with `<slug>` / `<prefix>/<N>-<slug>` / `#<issue>` placeholders).
- Repointed Stage 7, the critic-stage patterns read, and the resources table off the deleted task.

No runtime/app code — orchestrator skill docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
