### PR TITLE
FROM fix/404-docs-pages-fork-guard TO development

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,19 +50,22 @@ jobs:
         working-directory: packages/docs
         run: pnpm run build
 
+      # Pages deploy only runs on the canonical repo. Forks build-validate docs
+      # (the build job above) but skip deploy — they have no Pages site enabled,
+      # and configure-pages would fail with "Resource not accessible by integration".
       - name: Configure Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mifunedev/openharness'
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mifunedev/openharness'
         uses: actions/upload-pages-artifact@v3
         with:
           path: packages/docs/build
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mifunedev/openharness'
     needs: build
     runs-on: ubuntu-latest
     concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ### Changed
 
 ### Fixed
+- `Docs: build & deploy` workflow no longer fails on forks: the Pages `Configure`/`Upload`/`Deploy` steps are gated to the canonical repo (`github.repository == 'mifunedev/openharness'`), so forks build-validate docs without attempting a Pages deploy. Also removed a dangling `docs/harnesses/t3code.md` link to the deleted `integrations/cloudflare.md` ([#404](https://github.com/mifunedev/openharness/issues/404)).
 - `/release` skill now resolves the canonical remote (prefers `upstream`, else `origin`) for `REPO` and all release pushes, so a release can't accidentally land on a private fork; GHCR verification tries the org package path before the user path ([#402](https://github.com/mifunedev/openharness/issues/402)).
 - `/ship-spec` Stage 7 now clones a self-contained `.claude/skills/ship-spec/templates/prompt.md` instead of the deleted `tasks/archive/openharness-v07-convergence/prompt.md`; repointed the two other dead references to that task ([#402](https://github.com/mifunedev/openharness/issues/402)).
 

--- a/docs/harnesses/t3code.md
+++ b/docs/harnesses/t3code.md
@@ -56,7 +56,7 @@ Open the printed pairing URL in your host browser. Reattach to the session at an
 tmux attach -t agent-t3code
 ```
 
-If you can't reach `localhost:3773` from the host, expose port 3773 from the sandbox container (compose overlay or `docker run -p 3773:3773`), or front it with a Cloudflare tunnel — see [Cloudflare integration](../integrations/cloudflare.md).
+If you can't reach `localhost:3773` from the host, expose port 3773 from the sandbox container (compose overlay or `docker run -p 3773:3773`), or front it with a Cloudflare tunnel (`cloudflared`).
 
 ## Tips
 


### PR DESCRIPTION
Closes #404

## What

Gate the `Docs: build & deploy` Pages steps + deploy job to the canonical repo (`github.repository == 'mifunedev/openharness'`).

## Why

The workflow triggers on push to `main` in any repo. On a private fork without GitHub Pages enabled (e.g. `ryaneggz/openharness`), `Configure Pages` fails with `Resource not accessible by integration` — the docs **build** passes, but the run goes red on the Pages deploy. Forks should validate the docs build without trying to publish.

## Changes

- `.github/workflows/docs.yml` — `Configure Pages`, `Upload Pages artifact`, and the `deploy` job each carry `&& github.repository == 'mifunedev/openharness'`. Upstream behavior unchanged (condition is true there); forks now build-only.
- `docs/harnesses/t3code.md` — drop dangling link to deleted `integrations/cloudflare.md` (was a Docusaurus `warn`).

## Verification

- Build job still runs on forks (docs validated).
- Pages deploy only on `mifunedev/openharness` push-to-main.
- No `cloudflare.md` broken-link warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
