### PR TITLE
feat: add optional Grok Build CLI support

### DIFF
--- a/.devcontainer/.example.env
+++ b/.devcontainer/.example.env
@@ -27,6 +27,7 @@
 #   CRON_AGENT_BIN        → crons.agent_bin:
 #   INSTALL_AGENT_BROWSER → install.agent_browser:
 #   INSTALL_OPENCODE      → install.opencode:
+#   INSTALL_GROK_BUILD    → install.grok_build:
 #   INSTALL_DEEPAGENTS    → install.deepagents:
 #   INSTALL_HERMES        → install.hermes:
 #   GIT_USER_NAME         → git.user_name:
@@ -43,6 +44,12 @@
 # Create one at: https://github.com/settings/tokens?type=beta
 # Scopes needed: repo, read:org, admin:public_key (for SSH key upload)
 GH_TOKEN=
+
+# ─── xAI / Grok Build ───────────────────────────────────────────────
+# Optional API key fallback for the Grok Build CLI. The preferred browser or
+# device auth flow writes persistent state under ~/.grok (Docker volume), but
+# this secret can be passed through for non-interactive use.
+# XAI_API_KEY=
 
 # ─── Slack bot (Pi extension) ────────────────────────────────────────
 # The in-tree Pi extension at .pi/extensions/slack/ bridges Slack

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -90,7 +90,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate \
 #
 # AGENTS is a comma-separated list of default agent CLI keys to install.
 # The default is claude-code + codex + pi-coding-agent. Optional CLIs
-# such as OpenCode, DeepAgents, and Hermes are controlled by their own
+# such as OpenCode, Grok Build, DeepAgents, and Hermes are controlled by their own
 # INSTALL_* build flags. pi-coding-agent is installed later under the
 # sandbox user's npm prefix so `pi update` can self-update without sudo.
 # The pi-coding-agent key resolves to @earendil-works/pi-coding-agent
@@ -101,6 +101,7 @@ SHELL ["/bin/bash", "-c"]
 
 ARG AGENTS="claude-code,codex,pi-coding-agent"
 ARG INSTALL_OPENCODE=false
+ARG INSTALL_GROK_BUILD=false
 
 RUN set -e; \
     declare -A PKG=( \
@@ -117,7 +118,12 @@ RUN set -e; \
         else echo "Unknown agent: $a"; exit 1; fi; \
     done; \
     if [ "${INSTALL_OPENCODE}" = "true" ]; then npm install -g opencode-ai; \
-    else echo "Skipping OpenCode CLI install (INSTALL_OPENCODE=false)"; fi
+    else echo "Skipping OpenCode CLI install (INSTALL_OPENCODE=false)"; fi; \
+    if [ "${INSTALL_GROK_BUILD}" = "true" ]; then \
+        curl -fsSL https://x.ai/cli/install.sh | HOME=/opt/grok-build GROK_BIN_DIR=/opt/grok-build/bin bash -s 0.2.39; \
+        ln -sf /opt/grok-build/bin/grok /usr/local/bin/grok; \
+        rm -f /usr/local/bin/agent; \
+    else echo "Skipping Grok Build CLI install (INSTALL_GROK_BUILD=false)"; fi
 
 # ─── Open Harness `oh` CLI ──────────────────────────────────────────
 # Build the in-tree `oh` CLI (packages/oh/) into a self-contained bundle,

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,9 +2,10 @@
 # ===========================================
 # Base sandbox compose. The base ships with zero in-tree overlays;
 # agent auth and tool state persist in named volumes managed by Docker
-# (claude-auth, codex-auth, pi-auth, opencode-auth, deepagents-auth,
-# cloudflared-auth, gh-config), and the bind-mounted repo's UID is synced
-# into the sandbox user by entrypoint.sh on first boot.
+# (claude-auth, codex-auth, pi-auth, opencode-auth, grok-auth,
+# deepagents-auth, cloudflared-auth, gh-config), and the bind-mounted
+# repo's UID is synced into the sandbox user by entrypoint.sh on first boot.
+# Grok Build uses ~/.grok for user state/auth, persisted by grok-auth.
 # Hermes uses the project-local bind-mounted `.hermes/` directory as
 # HERMES_HOME for all runtime state, including auth.json (gitignored).
 #
@@ -23,6 +24,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
       args:
         INSTALL_OPENCODE: ${INSTALL_OPENCODE:-false}
+        INSTALL_GROK_BUILD: ${INSTALL_GROK_BUILD:-false}
         INSTALL_DEEPAGENTS: ${INSTALL_DEEPAGENTS:-false}
         INSTALL_HERMES: ${INSTALL_HERMES:-false}
     volumes:
@@ -32,6 +34,7 @@ services:
       - codex-auth:/home/sandbox/.codex
       - pi-auth:/home/sandbox/.pi
       - opencode-auth:/home/sandbox/.local/share/opencode
+      - grok-auth:/home/sandbox/.grok
       - deepagents-auth:/home/sandbox/.deepagents
       - cloudflared-auth:/home/sandbox/.cloudflared
       - gh-config:/home/sandbox/.config/gh
@@ -44,6 +47,7 @@ services:
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GH_TOKEN=${GH_TOKEN:-}
+      - XAI_API_KEY=${XAI_API_KEY:-}
       - INSTALL_AGENT_BROWSER=${INSTALL_AGENT_BROWSER:-false}
       - INSTALL_HERMES=${INSTALL_HERMES:-false}
       - HERMES_HOME=/home/sandbox/harness/.hermes
@@ -63,6 +67,7 @@ volumes:
   codex-auth:
   pi-auth:
   opencode-auth:
+  grok-auth:
   deepagents-auth:
   cloudflared-auth:
   gh-config:

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -13,7 +13,7 @@ if [ -S "$SOCK" ]; then
 fi
 
 # Fix ownership of mounted volumes (created as root by Docker).
-for dir in .claude .codex .pi .deepagents .hermes .cloudflared .config/gh .ssh; do
+for dir in .claude .codex .pi .grok .deepagents .hermes .cloudflared .config/gh .ssh; do
   if [ -d "/home/sandbox/$dir" ]; then
     chown -R sandbox:sandbox "/home/sandbox/$dir" 2>/dev/null || true
     [ "$dir" = ".ssh" ] && chmod 700 "/home/sandbox/$dir" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ make shell       # enter the isolated sandbox
 #   pi         # Pi Coding Agent
 #   deepagents # LangChain DeepAgents (optional: set install.deepagents: true in harness.yaml and rebuild)
 #   hermes     # Nous Research Hermes (optional: set install.hermes: true in harness.yaml and rebuild)
+#   grok       # xAI Grok Build (optional: set install.grok_build: true in harness.yaml and rebuild)
 make destroy     # stop and remove the sandbox
 make help        # all targets
 ```
@@ -92,7 +93,7 @@ make shell
 
 | | |
 |---|---|
-| **Core agents** | Defaults: Claude Code, Codex, Pi. Optional: OpenCode, DeepAgents, Hermes |
+| **Core agents** | Defaults: Claude Code, Codex, Pi. Optional: OpenCode, DeepAgents, Hermes, Grok Build |
 | **Runtimes** | Node 22, pnpm, Bun, uv (Python) |
 | **DevOps** | Docker CLI + Compose, GitHub CLI, cloudflared, tmux, croner |
 | **Browser** | agent-browser + Chromium (headless) |

--- a/docs/harnesses/grok-build.md
+++ b/docs/harnesses/grok-build.md
@@ -1,0 +1,115 @@
+---
+sidebar_position: 8
+title: "Grok Build"
+---
+
+# Grok Build
+
+Grok Build is xAI's proprietary terminal coding agent, shipped as the `grok` CLI. Open Harness installs it with xAI's official installer from `https://x.ai/cli/install.sh`.
+
+Grok Build is **optional** in Open Harness and is **excluded from the default image**. Enable it only when you want the xAI Grok Build CLI available in the sandbox.
+
+## Install (optional)
+
+Enable Grok Build in `harness.yaml`:
+
+```yaml
+install:
+  grok_build: true
+```
+
+Or set the legacy build flag in `.devcontainer/.env`:
+
+```bash
+INSTALL_GROK_BUILD=true
+```
+
+Then rebuild/restart the sandbox:
+
+```bash
+make stop && make sandbox
+```
+
+Open Harness uses the upstream installer during image build, pinned to the version verified when this support was added:
+
+```bash
+curl -fsSL https://x.ai/cli/install.sh | bash -s 0.2.39
+```
+
+Verify the install inside the sandbox:
+
+```bash
+grok --version
+```
+
+If `grok` is not found, confirm `install.grok_build: true` is set in `harness.yaml` (or `INSTALL_GROK_BUILD=true` in `.devcontainer/.env`) and rebuild.
+
+## Authentication
+
+Use one of the Grok Build auth flows inside the sandbox:
+
+```bash
+# Recommended for headless/remote sandboxes
+grok login --device-auth
+
+# Interactive OAuth flow
+grok login
+```
+
+For service-account or automation-style setup, provide an xAI API key through
+the `XAI_API_KEY` environment variable, either in `.devcontainer/.env` or in
+the shell that launches `grok`. Treat `.devcontainer/.env` and Compose
+environment variables as convenience secret storage only; users and processes
+with Docker/container access may be able to inspect them.
+
+:::warning Auth precedence
+Cached OAuth/session state in `~/.grok/auth.json` takes precedence over `XAI_API_KEY`. If Grok Build appears to ignore a new API key, run `grok logout` or reset the `grok-auth` volume, then try again.
+:::
+
+## Common usage
+
+```bash
+# Start an interactive Grok Build session
+grok
+
+# Run a one-shot prompt/headless task
+grok -p "Summarize the changes on this branch"
+
+# ACP stdio mode
+grok agent stdio
+```
+
+Run interactive sessions in tmux so they survive SSH or editor disconnects:
+
+```bash
+tmux new-session -d -s agent-grok 'grok'
+tmux attach -t agent-grok
+```
+
+## State persistence
+
+Open Harness mounts the `grok-auth` named volume at `/home/sandbox/.grok` (`~/.grok`) alongside the other agent auth volumes. This volume persists **Grok user state written under `~/.grok`** across container rebuilds, such as:
+
+- auth and cached sessions (`auth.json`)
+- config
+- sessions and conversation state
+- memory
+- skills/plugins
+- logs
+
+:::warning Volume removal deletes Grok state
+`make destroy` and `docker compose down -v` remove named volumes, including `grok-auth`. Use `make stop` when you want Grok Build state under `~/.grok` to survive.
+:::
+
+## Dangerous flags
+
+Grok Build exposes flags that can bypass approval or permission prompts, including `--always-approve`, `--yolo`, and `--permission-mode bypassPermissions`.
+
+:::warning Use only for trusted tasks
+These flags can allow broad tool use inside the sandbox. Only use them when you understand and accept the risk for the specific task and repository. Open Harness documents these flags as warning-only; it does not normalize or recommend yolo-mode examples.
+:::
+
+## Upstream documentation
+
+- [Grok CLI](https://x.ai/cli)
+- [xAI Build overview](https://docs.x.ai/build/overview)

--- a/docs/harnesses/overview.md
+++ b/docs/harnesses/overview.md
@@ -5,7 +5,7 @@ title: "Harnesses Overview"
 
 # Harnesses Overview
 
-Open Harness ships with three agent CLIs in the default sandbox image: **Claude Code** (default), **Codex**, and **Pi**. **OpenCode**, **DeepAgents**, and **Hermes** are optional image-level installs controlled by `harness.yaml` `install:` keys (or `.devcontainer/.env` build flags). **T3 Code** runs on demand via `npx t3` as a browser UI on port 3773. Inside the sandbox, launch whichever you prefer — switch between them at any time, or keep long-running sessions in tmux.
+Open Harness ships with three agent CLIs in the default sandbox image: **Claude Code** (default), **Codex**, and **Pi**. **OpenCode**, **DeepAgents**, **Hermes**, and **Grok Build** are optional image-level installs controlled by `harness.yaml` `install:` keys (or `.devcontainer/.env` build flags). **T3 Code** runs on demand via `npx t3` as a browser UI on port 3773. Inside the sandbox, launch whichever you prefer — switch between them at any time, or keep long-running sessions in tmux.
 
 The sandbox is the product; the harness is your call. To go beyond the preinstalled options, install via `npm` / `pip` / `cargo` inside the sandbox, edit the Dockerfile, or layer in a harness pack such as [`@ryaneggz/mifune`](https://github.com/ryaneggz/mifune). For Pi+Slack specifically, the recommended path is the in-tree extension at [`.pi/extensions/slack/`](../integrations/slack.md). The product surface is one developer, one project, one harness — not racing or stacking multiple CLIs against each other.
 
@@ -19,6 +19,7 @@ The sandbox is the product; the harness is your call. To go beyond the preinstal
 | [Pi](./pi.md) | Lightweight, customizable harness | `pi` | default |
 | [DeepAgents](./deepagents.md) | LangChain's multi-provider terminal agent | `deepagents` | optional: `install.deepagents: true` in `harness.yaml` |
 | [Hermes](./hermes.md) | Nous Research's self-improving terminal agent | `hermes` | optional: `install.hermes: true` in `harness.yaml` |
+| [Grok Build](./grok-build.md) | xAI's proprietary Grok Build terminal agent | `grok` | optional: `install.grok_build: true` in `harness.yaml` |
 | [T3 Code](./t3code.md) | Browser UI over Claude/Codex/OpenCode (port 3773) | `npx t3` | on-demand |
 
 ## Verifying installation
@@ -32,6 +33,7 @@ pi --version
 opencode --version      # install.opencode: true
 deepagents -v           # install.deepagents: true
 hermes --version        # install.hermes: true
+grok --version          # install.grok_build: true
 
 npx t3 --version        # T3 Code (not preinstalled — fetched on demand)
 ```
@@ -46,6 +48,7 @@ Open Harness ships Claude Code, Codex, and Pi in the default image. Authenticate
 - **Pi**: configure provider keys via environment variables (see [Pi](./pi.md)).
 - **DeepAgents**: write provider keys to `~/.deepagents/.env` (see [DeepAgents](./deepagents.md)).
 - **Hermes**: run `hermes setup` (see [Hermes](./hermes.md)).
+- **Grok Build**: run `grok login --device-auth` for headless/remote auth, `grok login` for interactive OAuth, or set `XAI_API_KEY` as a fallback (see [Grok Build](./grok-build.md)). Cached `~/.grok/auth.json` takes precedence over `XAI_API_KEY`.
 - **T3 Code**: authenticate one of Claude / Codex / OpenCode first, then `npx t3` and open the printed pairing URL (see [T3 Code](./t3code.md)).
 
 ## Default surfaces

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -141,7 +141,7 @@ Debian Bookworm (slim). The `sandbox` user has passwordless sudo.
 
 ### AI agent CLIs
 
-Default CLIs are always present. Optional CLIs are installed at image build time when their `.devcontainer/.env` flag is `true`.
+Default CLIs are always present. Optional CLIs are excluded from the default image and installed at image build time when their `harness.yaml` install key (or legacy `.devcontainer/.env` flag) is enabled.
 
 | Tool | Command | Source | Status |
 |------|---------|--------|--------|
@@ -151,6 +151,7 @@ Default CLIs are always present. Optional CLIs are installed at image build time
 | OpenCode | `opencode` | `opencode-ai` — terminal coding agent with OpenAI OAuth support | optional: set `install.opencode: true` in `harness.yaml` (or `INSTALL_OPENCODE=true` in `.devcontainer/.env`) |
 | DeepAgents | `deepagents` | LangChain's multi-provider terminal agent (`deepagents-cli` via `uv tool install`) | optional: set `install.deepagents: true` in `harness.yaml` (or `INSTALL_DEEPAGENTS=true` in `.devcontainer/.env`) |
 | Hermes | `hermes` | Nous Research's self-improving agent CLI | optional: set `install.hermes: true` in `harness.yaml` (or `INSTALL_HERMES=true` in `.devcontainer/.env`) |
+| Grok Build | `grok` | xAI's proprietary Grok Build CLI (`@xai-official/grok@0.2.39`, Node >=20) | optional: set `install.grok_build: true` in `harness.yaml` (or `INSTALL_GROK_BUILD=true` in `.devcontainer/.env`) |
 | agent-browser | `agent-browser` | Headless Chromium for web-capable agents | optional: set `install.agent_browser: true` in `harness.yaml` (or `INSTALL_AGENT_BROWSER=true` in `.devcontainer/.env`) |
 
 ### Runtimes & package managers
@@ -202,9 +203,12 @@ Auth credentials survive container rebuilds via named Docker volumes:
 - `pi-auth` → `~/.pi` (Pi Agent OAuth)
 - `deepagents-auth` → `~/.deepagents` (DeepAgents provider keys, memory, skills, sessions; used when DeepAgents is enabled (`install.deepagents: true` in `harness.yaml`)). Repo-local `.deepagents/` is **project data** and follows normal `.gitignore` and code-review rules — never put secrets there.
 - `hermes-auth` → `~/.hermes` (Hermes auth only; non-auth runtime state defaults to project-local `~/harness/.hermes` when Hermes is enabled (`install.hermes: true` in `harness.yaml`))
+- `grok-auth` → `~/.grok` (all Grok Build user state: auth, config, sessions, memory, skills/plugins, logs; mounted alongside the other agent auth volumes and used by Grok Build when `install.grok_build: true` in `harness.yaml`). Cached OAuth/session state in `~/.grok/auth.json` takes precedence over `XAI_API_KEY`; if an API key seems ignored, run `grok logout` or reset the volume.
 - `cloudflared-auth` → `~/.cloudflared` (Cloudflare tunnel credentials, when used)
 - `gh-config` → `~/.config/gh` (GitHub CLI tokens)
 
 Hermes is split: when Hermes is enabled (`install.hermes: true` in `harness.yaml`), `HERMES_HOME` defaults to the project-local bind-mounted `~/harness/.hermes/` directory, while auth remains in the `~/.hermes` named volume and is linked into the project-local home as `auth.json`. The entrypoint also seeds `config.yaml` with `skills.external_dirs: ["/home/sandbox/harness/.claude/skills"]` so Hermes can load the harness' in-repo skills by default. Project-local runtime contents are gitignored except `.hermes/README.md`; `make destroy` removes the auth volume but not the bind-mounted project runtime directory.
+
+`make destroy` and `docker compose down -v` remove named volumes, including `grok-auth`; use `make stop` when you want Grok Build credentials and state to survive.
 
 Downstream harness packs and Pi extensions can introduce additional volumes or bind-mount overlays by listing tracked compose files under `compose.overrides:` in `harness.yaml`, or by adding user-local files to `composeOverrides[]` in `config.json` (gitignored).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,7 +45,7 @@ directory: `/home/sandbox/harness`.
 ## Pick your harness
 
 The default sandbox ships with Claude Code, Codex, and Pi. OpenCode,
-DeepAgents, and Hermes are optional image-level installs; T3 Code runs on
+DeepAgents, Hermes, and Grok Build are optional image-level installs; T3 Code runs on
 demand via `npx`. Authenticate at least one harness before use:
 
 - **[Claude Code](./harnesses/claude-code.md)**: run `claude` and follow the OAuth prompt
@@ -54,6 +54,7 @@ demand via `npx`. Authenticate at least one harness before use:
 - **[Pi](./harnesses/pi.md)**: configure provider keys via environment variables
 - **[DeepAgents](./harnesses/deepagents.md)**: set `install.deepagents: true` in `harness.yaml` (or `INSTALL_DEEPAGENTS=true` in `.devcontainer/.env`), rebuild, then write provider keys to `~/.deepagents/.env`
 - **[Hermes](./harnesses/hermes.md)**: set `install.hermes: true` in `harness.yaml` (or `INSTALL_HERMES=true` in `.devcontainer/.env`), rebuild, then run `hermes setup`
+- **[Grok Build](./harnesses/grok-build.md)**: set `install.grok_build: true` in `harness.yaml` (or `INSTALL_GROK_BUILD=true` in `.devcontainer/.env`), rebuild, verify `grok --version`, then run `grok login --device-auth` (headless/remote) or `grok login`
 - **[T3 Code](./harnesses/t3code.md)**: authenticate one of Claude / Codex / OpenCode, then `npx t3` (browser UI on port 3773)
 
 Claude Code remains the documented default. See
@@ -83,6 +84,7 @@ install:
   opencode: false
   deepagents: false
   hermes: false
+  grok_build: false
   agent_browser: false
 ```
 
@@ -104,6 +106,7 @@ install:
 | `install.opencode` | Set `true` to include OpenCode in the sandbox image |
 | `install.deepagents` | Set `true` to include DeepAgents in the sandbox image |
 | `install.hermes` | Set `true` to include Hermes in the sandbox image; state defaults to `~/harness/.hermes`, auth lives in `~/.hermes` |
+| `install.grok_build` | Set `true` to include Grok Build in the sandbox image; all Grok user state lives in the persisted `~/.grok` volume |
 
 Apply changes with `make destroy && make sandbox`.
 

--- a/harness.yaml
+++ b/harness.yaml
@@ -23,6 +23,7 @@ git:
 
 install:
   # opencode: false            # INSTALL_OPENCODE — OpenCode CLI (build arg)
+  # grok_build: false          # INSTALL_GROK_BUILD — Grok Build CLI (build arg)
   # deepagents: false          # INSTALL_DEEPAGENTS — DeepAgents CLI (build arg)
   # hermes: false              # INSTALL_HERMES — Hermes CLI (build arg + runtime)
   # agent_browser: false       # INSTALL_AGENT_BROWSER — agent-browser + Chromium (~1 GB)

--- a/install/banner.sh
+++ b/install/banner.sh
@@ -82,6 +82,23 @@ if command -v opencode >/dev/null 2>&1; then
   fi
 fi
 
+# grok — optional image-level CLI; auth state lives under ~/.grok, with
+# XAI_API_KEY as a secret-only non-interactive fallback.
+grok_status="[✗]"
+grok_detail="not installed — enable via install.grok_build / INSTALL_GROK_BUILD"
+if command -v grok >/dev/null 2>&1; then
+  if [ -s "${HOME}/.grok/auth.json" ]; then
+    grok_status="[✓]"
+    grok_detail="authenticated"
+  elif [ -n "${XAI_API_KEY:-}" ]; then
+    grok_status="[✓]"
+    grok_detail="configured via XAI_API_KEY"
+  else
+    grok_status="[✓]"
+    grok_detail="installed — run: grok login --device-auth (or grok login)"
+  fi
+fi
+
 # deepagents — installed status from PATH; configured status from
 # ~/.deepagents/.env or ~/.deepagents/config.toml so that an empty mounted
 # directory (named volume on first boot) is not treated as authenticated.
@@ -136,6 +153,7 @@ printf '    %-6s %-11s %s\n' "$gh_status"         "gh"          "$gh_detail"
 printf '    %-6s %-11s %s\n' "$claude_status"     "claude"      "$claude_detail"
 printf '    %-6s %-11s %s\n' "$codex_status"      "codex"       "$codex_detail"
 printf '    %-6s %-11s %s\n' "$opencode_status"   "opencode"    "$opencode_detail"
+printf '    %-6s %-11s %s\n' "$grok_status"       "grok"        "$grok_detail"
 printf '    %-6s %-11s %s\n' "$pi_status"         "pi"          "$pi_detail"
 printf '    %-6s %-11s %s\n' "$deepagents_status" "deepagents"  "$deepagents_detail"
 printf '    %-6s %-11s %s\n' "$hermes_status"     "hermes"      "$hermes_detail"
@@ -143,6 +161,7 @@ printf '    %-6s %-11s %s\n' "$oh_status"         "openharness" "$oh_detail"
 printf '\n'
 shortcuts="claude · codex · pi"
 command -v opencode >/dev/null 2>&1 && shortcuts="$shortcuts · opencode"
+command -v grok >/dev/null 2>&1 && shortcuts="$shortcuts · grok"
 command -v deepagents >/dev/null 2>&1 && shortcuts="$shortcuts · deepagents"
 command -v hermes >/dev/null 2>&1 && shortcuts="$shortcuts · hermes"
 printf '  Shortcuts: %s · tmux attach -t system-cron\n' "$shortcuts"

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -87,6 +87,7 @@ const config: Config = {
           { from: "/docs/agents/claude-code", to: "/docs/harnesses/claude-code" },
           { from: "/docs/agents/codex", to: "/docs/harnesses/codex" },
           { from: "/docs/agents/deepagents", to: "/docs/harnesses/deepagents" },
+          { from: "/docs/agents/grok-build", to: "/docs/harnesses/grok-build" },
           { from: "/docs/agents/opencode", to: "/docs/harnesses/opencode" },
           { from: "/docs/agents/pi", to: "/docs/harnesses/pi" },
           { from: "/docs/agents/t3code", to: "/docs/harnesses/t3code" },

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -11,7 +11,7 @@ curl -fsSL https://oh.mifune.dev/install.sh | bash
 cd ~/.openharness && make shell
 
 # inside the sandbox, pick your agent
-claude        # or codex, opencode, pi, deepagents`;
+claude        # or codex, opencode, pi, deepagents, hermes, grok`;
 
 const AGENTS: Array<{
   name: string;
@@ -57,6 +57,18 @@ const AGENTS: Array<{
     ),
   },
   {
+    name: "Hermes",
+    description: "Nous Research's self-improving agent CLI.",
+    href: "/docs/harnesses/hermes",
+    icon: <img src="https://hermes-agent.nousresearch.com/favicon.ico" alt="" width={28} height={28} />,
+  },
+  {
+    name: "Grok Build",
+    description: "xAI's terminal coding agent and CLI.",
+    href: "/docs/harnesses/grok-build",
+    icon: <img src="https://x.ai/favicon.ico" alt="" width={28} height={28} />,
+  },
+  {
     name: "T3 Code",
     description: "Browser UI over Claude/Codex/OpenCode (port 3773).",
     href: "/docs/harnesses/t3code",
@@ -88,7 +100,7 @@ const WHY: Array<{ title: string; body: string }> = [
 
 export default function Home(): React.ReactElement {
   return (
-    <Layout description="We provide the sandbox; you choose the agent. Open Harness is a long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, Pi, or DeepAgents inside.">
+    <Layout description="We provide the sandbox; you choose the agent. Open Harness is a long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, Pi, DeepAgents, Hermes, or Grok Build inside.">
       <main>
         <section className={styles.hero}>
           <div className={styles.heroBg} aria-hidden="true" />
@@ -102,7 +114,7 @@ export default function Home(): React.ReactElement {
                 We provide the sandbox. You choose the harness.
               </h1>
               <p className={styles.heroSubtitle}>
-                A long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, Pi, or DeepAgents inside, and let it work on demand or on a cron while you sleep.
+                A long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, Pi, DeepAgents, Hermes, or Grok Build inside, and let it work on demand or on a cron while you sleep.
               </p>
               <div className={styles.heroButtons}>
                 <Link
@@ -142,7 +154,7 @@ export default function Home(): React.ReactElement {
           <div className={styles.container}>
             <h2 className={styles.sectionTitle}>Pick your agent.</h2>
             <p className={styles.sectionLede}>
-              Claude Code, Codex, OpenCode, Pi, and DeepAgents ship preinstalled. Switch between them inside the sandbox — or add your own by editing the Dockerfile.
+              Claude Code, Codex, and Pi ship preinstalled. OpenCode, DeepAgents, Hermes, and Grok Build are opt-in image installs. Switch between them inside the sandbox — or add your own by editing the Dockerfile.
             </p>
             <div className={styles.agentGrid}>
               {AGENTS.map((agent) => (

--- a/scripts/__tests__/harness-config.test.ts
+++ b/scripts/__tests__/harness-config.test.ts
@@ -69,6 +69,12 @@ describe("harness-config.sh env mode", () => {
     expect(stdout.trim()).toBe("INSTALL_OPENCODE=true");
   });
 
+  it("maps install.grok_build: true → INSTALL_GROK_BUILD=true", () => {
+    const f = fixture("install:\n  grok_build: true\n");
+    const { stdout } = run(["env", f]);
+    expect(stdout.trim()).toBe("INSTALL_GROK_BUILD=true");
+  });
+
   it("handles values with spaces: git.user_name → GIT_USER_NAME", () => {
     const f = fixture("git:\n  user_name: Ryan Eggz\n");
     const { stdout } = run(["env", f]);

--- a/scripts/harness-config.sh
+++ b/scripts/harness-config.sh
@@ -63,6 +63,7 @@ BEGIN {
     envmap["git.user_name"]         = "GIT_USER_NAME"
     envmap["git.user_email"]        = "GIT_USER_EMAIL"
     envmap["install.opencode"]      = "INSTALL_OPENCODE"
+    envmap["install.grok_build"]    = "INSTALL_GROK_BUILD"
     envmap["install.deepagents"]    = "INSTALL_DEEPAGENTS"
     envmap["install.hermes"]        = "INSTALL_HERMES"
     envmap["install.agent_browser"] = "INSTALL_AGENT_BROWSER"


### PR DESCRIPTION
## Summary
- cherry-pick the merged Grok Build support from ryaneggz/openharness#16 into mifunedev/openharness
- adds opt-in Grok Build install via `install.grok_build` / `INSTALL_GROK_BUILD`
- uses xAI's official installer, persists `~/.grok` in a `grok-auth` volume, and documents install/auth/state/dangerous flags
- updates the docs landing page agent grid to include Hermes and Grok Build logos

Source cherry-pick: e65c9b6f68443bd2f44d7e79c0b44c9fecd878e0

## Verification
- `git diff --check HEAD~1 HEAD`
- `pnpm exec vitest run scripts/__tests__/harness-config.test.ts` — 14/14 passing
- `pnpm --dir packages/docs typecheck`
- `pnpm --dir packages/docs build`

Runtime/product validation of Grok Build is intentionally left for maintainer testing.
