### PR TITLE
Public eval and drift infrastructure

### DIFF
--- a/.claude/skills/drift-check/SKILL.md
+++ b/.claude/skills/drift-check/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: drift-check
+description: |
+  Detect and report three classes of silent harness drift: framework drift
+  (origin↔upstream), branch-behind/append-file drift, and cron-staleness
+  drift. Never auto-remediates — prints a recommended command for each
+  finding without executing it.
+  TRIGGER when: asked to check for drift, before a session-critical commit,
+  after a long session gap, when MEMORY.md or log.md may have been
+  concurrently modified, or on suspicion that a recently-merged cron is
+  not running.
+---
+
+# Drift Check
+
+Read-only harness drift detector. Reports three drift classes and prints a
+recommended remediation command for each finding — never executes any
+remediation. This skill never mutates local branches, the working tree,
+committed history, the remote, or host state. The sole permitted write is
+`git fetch` (updates only remote-tracking refs + `FETCH_HEAD`), which is
+non-destructive.
+
+## Instructions
+
+Run all three sections in order and collect the one-line summary for each.
+At the end, emit the aggregate `DRIFT:` line only when at least one class
+is non-clean.
+
+---
+
+### (A) Framework drift (origin↔upstream)
+
+**Goal**: detect how far `origin/development` lags behind `upstream/development`.
+
+**Step A-1 — preflight upstream remote:**
+
+```bash
+git remote get-url upstream 2>/dev/null
+```
+
+If this command exits non-zero, print:
+
+```
+DRIFT-CHECK: upstream remote not configured — framework drift cannot be checked
+```
+
+and skip the rest of Section (A). Do NOT run `git fetch upstream` if the
+remote does not exist.
+
+**Step A-2 — timeout-wrapped fetch:**
+
+```bash
+timeout 15s git fetch upstream 2>&1
+```
+
+If the fetch times out or exits non-zero (network unavailable, DNS failure,
+auth error), print:
+
+```
+DRIFT-CHECK: upstream fetch failed (offline/timeout) — framework drift unknown
+```
+
+and skip the rest of Section (A).
+
+**Step A-3 — count divergence:**
+
+```bash
+git rev-list --left-right --count origin/development...upstream/development
+```
+
+Output is `<left>\t<right>` where `left` = commits origin is ahead,
+`right` = commits origin is behind upstream. Report:
+
+```
+DRIFT-CHECK (A): origin/development is N behind upstream/development (M ahead)
+```
+
+If `right` is `0`, print a single `OK` token for class A:
+
+```
+(A) Framework drift: OK
+```
+
+**Step A-4 — derive changed paths and print remediation (only when N > 0):**
+
+```bash
+git diff --name-only origin/development...upstream/development
+```
+
+Capture the list of changed paths. Print the recommended remediation with
+the real paths substituted — NEVER a bare pathless checkout, NEVER a
+placeholder:
+
+```
+  Recommended: git checkout upstream/development -- <path1> <path2> ...
+```
+
+If the path list is empty despite a non-zero behind count (e.g., pure
+rename history), print `  (no changed paths detected — inspect manually)`.
+
+---
+
+### (B) Branch-behind / append-file drift
+
+**Goal**: detect whether HEAD is behind its remote tracking branch, the
+working tree is dirty, or the current branch is unexpected. This section
+is motivated by the append-only-file stale-view trap: `memory/MEMORY.md`
+and `memory/<date>/log.md` are appended by concurrent sessions; if HEAD
+drifts behind `origin/<branch>`, the in-context view of these files lags
+behind reality.
+
+**Step B-1 — identify current branch:**
+
+```bash
+BRANCH=$(git branch --show-current)
+echo "Current branch: $BRANCH"
+```
+
+**Step B-2 — unexpected-branch check:**
+
+The expected branch is `development`. Any other branch is flagged as
+unexpected UNLESS it matches the regex `^(feat|fix|task|audit|skill|agent)/`
+(a legitimate work branch). A work-branch warning is informational only,
+not an error.
+
+```bash
+# Pseudocode — implement as inline shell logic:
+if [ "$BRANCH" != "development" ]; then
+  if echo "$BRANCH" | grep -qE '^(feat|fix|task|audit|skill|agent)/'; then
+    echo "DRIFT-CHECK (B): on work branch '$BRANCH' (expected: development) — informational"
+  else
+    echo "DRIFT-CHECK (B): UNEXPECTED branch '$BRANCH' (expected: development or a feat/fix/task/audit/skill/agent/ work branch)"
+  fi
+fi
+```
+
+**Step B-3 — timeout-wrapped fetch (offline-safe):**
+
+```bash
+timeout 15s git fetch origin 2>&1
+```
+
+If the fetch fails or times out, note it and continue with local tracking
+data only:
+
+```
+DRIFT-CHECK (B): origin fetch failed (offline/timeout) — using cached tracking refs
+```
+
+**Step B-4 — behind/ahead count:**
+
+```bash
+git rev-list --left-right --count HEAD...origin/$BRANCH
+```
+
+Output is `<ahead>\t<behind>`. Report:
+
+```
+DRIFT-CHECK (B): HEAD is N behind / M ahead of origin/<branch>
+```
+
+If both counts are `0` and the working tree is clean and the branch is
+expected, print a single `OK` token for class B:
+
+```
+(B) Branch-behind drift: OK
+```
+
+**Step B-5 — dirty working tree:**
+
+```bash
+git status --porcelain
+```
+
+If output is non-empty, print:
+
+```
+DRIFT-CHECK (B): working tree is dirty — N uncommitted change(s)
+  Recommended: git status to review, then git add / git commit or git restore as appropriate
+```
+
+When behind count > 0, print:
+
+```
+  Recommended: git pull --ff-only origin/<branch>
+```
+
+---
+
+### (C) Host/state drift (cron-staleness)
+
+**Goal**: detect crons that were merged after the running `system-cron`
+runtime started (they are inert until the runtime is restarted). This is
+the cron boot-load gap: `scripts/cron-runtime.ts` calls `loadCrons()` once
+at boot, so a newly-merged `crons/*.md` file is not picked up until the
+next restart.
+
+For deep host resource triage (memory, disk, CPU, Docker), defer to
+`/health-check` — this section targets only cron-staleness.
+
+**Step C-1 — resolve runtime start time:**
+
+Prefer the PID stored in `crons/.pid` via `/proc/<pid>/stat`:
+
+```bash
+PID=$(cat crons/.pid 2>/dev/null)
+if [ -n "$PID" ] && [ -r "/proc/$PID/stat" ]; then
+  # Field 22 of /proc/<pid>/stat is process start time in clock ticks
+  # since system boot. Combine with btime from /proc/stat for wall-clock.
+  BTIME=$(grep '^btime ' /proc/stat | awk '{print $2}')
+  STARTTIME_TICKS=$(awk '{print $22}' /proc/$PID/stat)
+  CLK_TCK=$(getconf CLK_TCK 2>/dev/null || echo 100)
+  RUNTIME_START=$(( BTIME + STARTTIME_TICKS / CLK_TCK ))
+  echo "DRIFT-CHECK (C): cron runtime start time (from /proc): $(date -d @$RUNTIME_START -u '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null || date -r $RUNTIME_START -u '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null || echo $RUNTIME_START)"
+else
+  RUNTIME_START=""
+fi
+```
+
+If `/proc/<pid>/stat` is inaccessible (PID namespace isolation, non-Linux
+host, stale PID), fall back to the `system-cron` tmux session creation
+time:
+
+```bash
+if [ -z "$RUNTIME_START" ]; then
+  TMUX_START=$(tmux display-message -p '#{session_created}' -t system-cron 2>/dev/null)
+  if [ -n "$TMUX_START" ] && [ "$TMUX_START" -gt 0 ] 2>/dev/null; then
+    RUNTIME_START=$TMUX_START
+    echo "DRIFT-CHECK (C): cron runtime start time (from tmux session): $(date -d @$RUNTIME_START -u '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null || echo $RUNTIME_START)"
+  fi
+fi
+```
+
+If neither source resolves a start time, print and skip the comparison:
+
+```
+DRIFT-CHECK: cron runtime start time unavailable — restart runtime if a cron was recently merged
+```
+
+Then print a single `OK` token for class C:
+
+```
+(C) Cron-staleness drift: OK (start time unavailable — assumed clean)
+```
+
+**Step C-2 — compare cron file mtimes:**
+
+When `RUNTIME_START` is set, check each `crons/*.md` for a mtime strictly
+after the runtime start time:
+
+```bash
+INERT=()
+for f in crons/*.md; do
+  FILE_MTIME=$(stat -c '%Y' "$f" 2>/dev/null || stat -f '%m' "$f" 2>/dev/null)
+  if [ -n "$FILE_MTIME" ] && [ "$FILE_MTIME" -gt "$RUNTIME_START" ]; then
+    INERT+=("$f")
+    echo "DRIFT-CHECK (C): $f modified after runtime start — inert until runtime restart"
+  fi
+done
+```
+
+If `INERT` is empty, print a single `OK` token for class C:
+
+```
+(C) Cron-staleness drift: OK
+```
+
+**Step C-3 — recommend restart (only when inert files found):**
+
+Print (do not execute):
+
+```
+  Recommended: restart the system-cron tmux session
+    tmux kill-session -t system-cron
+    # then relaunch via the documented runtime-start procedure in scripts/cron-runtime.ts
+```
+
+Note: this recommendation names the session and references the documented
+relaunch — it does not emit a host-mutating command (the restart itself
+is an intentional operator action, not performed by this skill).
+
+---
+
+## Output Contract
+
+- Each class prints exactly one summary line when clean: `(A) Framework drift: OK`, `(B) Branch-behind drift: OK`, `(C) Cron-staleness drift: OK`.
+- When a class has findings, it prints one or more `DRIFT-CHECK (<letter>): ...` detail lines followed by a `Recommended:` block.
+- When at least one class is non-clean, print a final aggregate line:
+
+```
+DRIFT: <comma-separated summary of non-clean classes>
+```
+
+Example (all clean):
+
+```
+(A) Framework drift: OK
+(B) Branch-behind drift: OK
+(C) Cron-staleness drift: OK
+```
+
+Example (A and C non-clean):
+
+```
+DRIFT-CHECK (A): origin/development is 3 behind upstream/development (0 ahead)
+  Recommended: git checkout upstream/development -- context/rules/git.md scripts/cron-runtime.ts
+DRIFT-CHECK (B): ...
+(B) Branch-behind drift: OK
+DRIFT-CHECK (C): crons/heartbeat.md modified after runtime start — inert until runtime restart
+  Recommended: restart the system-cron tmux session ...
+DRIFT: framework drift (3 behind upstream), cron-staleness drift (1 inert file)
+```
+
+The heartbeat surfaces the `DRIFT:` aggregate line in its log entry and
+reply when drift is found. When all classes are clean, the heartbeat
+appends nothing extra — the existing `HEARTBEAT_OK` reply is unchanged.

--- a/.claude/skills/eval/SKILL.md
+++ b/.claude/skills/eval/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: eval
+description: >-
+  Run the context fitness-function probe suite (evals/probes/*.sh) against real
+  state and write the evals/RESULTS.md benchmark. Each probe is a deterministic
+  3-state oracle (PASS/REGRESSION/SKIPPED); a green→red transition is surfaced as
+  a REGRESSION naming the lesson it closes. Tier-B behavioral evals are out of scope.
+  TRIGGER when: asked to run evals, check the probe suite, "run /eval", verify a
+  lesson's probe is green, benchmark the harness, or before/after editing a
+  rule/skill that a probe guards.
+---
+
+# Eval
+
+The runner for the harness **fitness function**. It discovers `evals/probes/*.sh`,
+runs each against *real state*, and writes the `evals/RESULTS.md` scoreboard. A
+rectification is provably "done" when its probe is green; a recurrence shows up as
+a **REGRESSION** (was-PASS, now-fail) naming the `# source:` lesson. The full
+contract — 3-state exit oracle, header convention, correction-surface triage — is
+in [`evals/README.md`](../../../evals/README.md).
+
+## Usage
+
+```bash
+bash .claude/skills/eval/run.sh                 # run the whole suite, rewrite RESULTS.md
+bash .claude/skills/eval/run.sh --probe <id>    # run one probe, update only its row
+bash .claude/skills/eval/run.sh --tier A        # run only Tier-A probes
+```
+
+Exit-code oracle (per probe): `0`=PASS, `1`=REGRESSION, `2`=SKIPPED (not
+applicable — excluded from pass-rate), `124`=TIMEOUT, other=ERROR. Each probe is
+wrapped in `timeout 30s`. Runner aggregate exit (the process `$?` of `run.sh`
+itself): `0` when no new green→red regression occurred this run, `1` when one or
+more new regressions were detected (`${#regressions[@]} > 0`). When invoked via the
+Bash tool as `bash .claude/skills/eval/run.sh`, the agent caller reads `$?` directly
+to gate on success — the printed `REGRESSIONS (...)` stdout block and per-probe stderr
+lines remain the human-readable signal.
+
+## What the runner does
+
+1. **Recover orphaned ablation backups** (M-2): if `evals/.ablation-active`
+   exists from a crashed ablation, restore each `<target>.bak` before running.
+2. **Discover + run** every probe matching the filters; extract `# tier:` /
+   `# source:` via the exact header grep.
+3. **Compute the delta** vs the prior `RESULTS.md` row. **First run** (no prior
+   row) emits `new-pass`/`new-fail` and raises NO regression without prior state.
+4. **Surface regressions** — any `PASS → (REGRESSION|TIMEOUT|ERROR)` transition is
+   printed first, naming the probe's `source`.
+5. **Rewrite `RESULTS.md`** — overwrite the row for each probe run; carry prior
+   rows for probes not run this invocation (so the scoreboard stays complete).
+
+## Ablation
+
+`run.sh --ablate <context-file> --probe <id>` runs a probe with and without a
+target rule/memory file loaded (reusing `scripts/ablate.sh`'s swap/restore/trap
+mechanics — NOT the `claude -p` oracle) and reports `LOAD-BEARING` (regression on
+removal) or `PRUNABLE`. This is the prune-half of the fitness function.
+
+## When NOT to use
+
+- **Tier-B behavioral evals** (sub-agent + LLM-judge of judgment-call behavior)
+  are deferred — `/eval` is deterministic only. Never hard-gate on a noisy metric.
+- For *scoring* context files for staleness/budget, that is `/context-audit` and
+  `/skill-lint` — `/eval` checks behavior/state, not prose quality.
+
+## Memory Protocol
+
+After a run, append to `memory/<UTC-date>/log.md` per `context/rules/memory.md`:
+
+```markdown
+## eval -- HH:MM UTC
+- **Result**: OP
+- **Ran**: <n> probes (<p> PASS / <r> REGRESSION / <s> SKIPPED)
+- **Regressions**: <named, or none>
+- **Observation**: <one sentence>
+```

--- a/.claude/skills/eval/run.sh
+++ b/.claude/skills/eval/run.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# /eval runner — discover evals/probes/*.sh, run each against real state, and
+# write the evals/RESULTS.md benchmark scoreboard (overwrite-row-per-probe).
+# Exit-code oracle per probe: 0=PASS 1=REGRESSION 2=SKIPPED 124=TIMEOUT other=ERROR.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"     # .claude/skills/eval -> repo root
+PROBES_DIR="$ROOT/evals/probes"
+RESULTS="$ROOT/evals/RESULTS.md"
+TIMEOUT_SECS=30
+
+FILTER_PROBE=""
+FILTER_TIER=""
+ABLATE_TARGET=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --probe)  FILTER_PROBE="${2:-}"; shift 2 ;;
+    --tier)   FILTER_TIER="${2:-}"; shift 2 ;;
+    --ablate) ABLATE_TARGET="${2:-}"; shift 2 ;;
+    -h|--help) echo "usage: run.sh [--probe <id>] [--tier A|ablation] [--ablate <file> --probe <id>]"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 64 ;;
+  esac
+done
+
+# --- M-2: recover orphaned ablation backups from a crashed prior run ---
+# scripts/ablate.sh records in-flight "<target>\t<bak>" lines in this sentinel;
+# if a prior ablation was SIGKILLed before its trap fired, restore here.
+SENTINEL="$ROOT/evals/.ablation-active"
+if [ -f "$SENTINEL" ]; then
+  while IFS=$'\t' read -r target bak; do
+    if [ -n "${bak:-}" ] && [ -f "$bak" ]; then
+      mv -f "$bak" "$target" && echo "recovered orphaned ablation backup -> $target" >&2
+    fi
+  done < "$SENTINEL"
+  rm -f "$SENTINEL"
+fi
+
+# --- ablation mode (M-1): run one probe with/without a target file via the shared
+#     swap/restore/trap mechanics in scripts/ablate.sh; reports LOAD-BEARING|PRUNABLE ---
+if [ -n "$ABLATE_TARGET" ]; then
+  [ -n "$FILTER_PROBE" ] || { echo "--ablate requires --probe <id>" >&2; exit 64; }
+  ABL_PROBE="$PROBES_DIR/$FILTER_PROBE.sh"
+  [ -f "$ABL_PROBE" ] || { echo "no such probe: $FILTER_PROBE" >&2; exit 64; }
+  case "$ABLATE_TARGET" in
+    /*) ABL_TGT="$ABLATE_TARGET" ;;                 # absolute — use as-is
+    *)  ABL_TGT="$ROOT/$ABLATE_TARGET" ;;           # relative — resolve against eval repo root, NOT cwd
+  esac
+  exec bash "$ROOT/scripts/ablate.sh" "$ABL_TGT" "$ABL_PROBE"
+fi
+
+hdr() { grep -E "^# $1:" "$2" 2>/dev/null | head -1 | sed "s/^# $1:[[:space:]]*//" || true; }
+prior_row() {
+  [ -f "$RESULTS" ] || return 0
+  grep -E "^\| ${1} \|" "$RESULTS" 2>/dev/null | head -1 || true
+}
+prior_status() { prior_row "$1" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$5); print $5}'; }
+
+now="$(date -u +'%Y-%m-%d %H:%M')"
+declare -A NEWROW
+regressions=()
+ran=0
+
+shopt -s nullglob
+for probe in "$PROBES_DIR"/*.sh; do
+  id="$(basename "$probe" .sh)"
+  tier="$(hdr tier "$probe")";  tier="${tier:-?}"
+  src="$(hdr source "$probe")"; src="${src:-?}"
+  [ -n "$FILTER_PROBE" ] && [ "$id" != "$FILTER_PROBE" ] && continue
+  [ -n "$FILTER_TIER"  ] && [ "$tier" != "$FILTER_TIER" ] && continue
+
+  set +e
+  reason="$(timeout "$TIMEOUT_SECS" bash "$probe" 2>&1 1>/dev/null)"
+  code=$?
+  set -e
+  case "$code" in
+    0) status="PASS" ;;
+    1) status="REGRESSION" ;;
+    2) status="SKIPPED" ;;
+    124) status="TIMEOUT" ;;
+    *) status="ERROR" ;;
+  esac
+  reason="${reason%%$'\n'*}"   # first stderr line only
+
+  prior="$(prior_status "$id")"
+  if [ -z "$prior" ]; then
+    if [ "$status" = "PASS" ]; then delta="new-pass"; else delta="new-fail"; fi
+  elif [ "$prior" = "$status" ]; then
+    delta="unchanged"
+  else
+    delta="${prior}->${status}"
+  fi
+  # green->red is the recurrence signal; first run has no prior, so never fires
+  if [ "$prior" = "PASS" ] && [ "$status" != "PASS" ] && [ "$status" != "SKIPPED" ]; then
+    regressions+=("$id ($src): was PASS, now $status — ${reason:-no reason}")
+  fi
+
+  NEWROW[$id]="| $id | $tier | $now | $status | $src |"
+  printf '%-32s %-11s %s\n' "$id" "$status" "$delta" >&2
+  ran=$((ran + 1))
+done
+
+# --- rewrite RESULTS.md: new rows for probes run; carry prior rows for the rest ---
+cat > "$RESULTS" <<'HDR'
+# Probe results — benchmark scoreboard
+
+Current status per probe id, written by `/eval`. Policy: **overwrite the row per
+probe id; git history is the time series.** Schema and exit-code semantics are in
+[`evals/README.md`](README.md). `SKIPPED` does not count toward pass-rate.
+
+| probe | tier | last-run (UTC) | status | source |
+|-------|------|----------------|--------|--------|
+HDR
+for probe in "$PROBES_DIR"/*.sh; do
+  id="$(basename "$probe" .sh)"
+  if [ -n "${NEWROW[$id]+x}" ]; then
+    printf '%s\n' "${NEWROW[$id]}" >> "$RESULTS"
+  else
+    pr="$(prior_row "$id")"
+    if [ -n "$pr" ]; then
+      printf '%s\n' "$pr" >> "$RESULTS"
+    else
+      printf '| %s | %s | — | (not run) | %s |\n' "$id" "$(hdr tier "$probe")" "$(hdr source "$probe")" >> "$RESULTS"
+    fi
+  fi
+done
+printf '\n<!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->\n' >> "$RESULTS"
+
+# --- summary to stdout: regressions first ---
+if [ "${#regressions[@]}" -gt 0 ]; then
+  echo "REGRESSIONS (${#regressions[@]}):"
+  for r in "${regressions[@]}"; do echo "  - $r"; done
+fi
+echo "ran $ran probe(s); wrote $RESULTS"
+if [ "${#regressions[@]}" -gt 0 ]; then exit 1; fi
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ Remove the sandbox.
 | `/harness-audit` | Spawn 4 parallel sub-agents (PM/Implementer/Critic/Explorer) to audit the harness |
 | `/skill-lint` | Score skills for staleness across 5 dimensions |
 | `/context-audit` | Score default-loaded context budget (4 dimensions, KEEP/TRIM/DEMOTE/CUT); optional Tier-2 ablation harness verifies cuts are safe |
+| `/eval` | Run the context fitness-function probe suite (`evals/probes/*.sh`) against real state, write the `evals/RESULTS.md` benchmark, surface green→red regressions naming the lesson each closes |
 | `/strategic-proposal` | 5-expert council + Critic for roadmap planning |
 | `/render-html` | Render an artifact as a bespoke, self-contained HTML file under `memory/<date>/<slug>.html` for one-shot human review (audit synthesis, council output, lint matrix, weekly digest) |
 | `/retro` | Scientific session-closing pass — turns session observations into falsifiable hypotheses with cited evidence, assigns a verdict (supported/refuted/inconclusive) and confidence, assesses six learning/knowledge subsystems (continual learning, context compression, reinforcement learning, wiki, docs, memory scaffolding) through the session lens, then proposes `MEMORY.md`/`IDENTITY.md` additions for confirmation before writing (always logs). Operationalizes `context/rules/memory.md` |
@@ -127,6 +128,7 @@ Remove the sandbox.
 | `/wiki-ingest` | Capture a source (URL or file path) or promote a sub-agent draft into the wiki; supports `<url\|path> [--slug <override>]` and `--from-draft <slug>` forms |
 | `/wiki-query` | Search the wiki by topic and load top matches into context; splits multi-word topics into OR terms, caps reads at 3 entries by `updated:` descending |
 | `/wiki-lint` | Health-check the wiki corpus for staleness, deprecated entries, orphans, and broken links; regenerates `wiki/README.md` atomically (supports `--dry-run`) |
+| `/drift-check` | Detect framework (origin↔upstream), branch-behind, and cron-staleness drift; report remediation — never mutates state |
 
 Provision / destroy / repair are plain `docker compose` commands — see
 the `Lifecycle` section above. There is no dedicated skill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- `/eval` skill and `evals/` probe corpus: deterministic shell probes with a 3-state oracle, an overwrite-row `evals/RESULTS.md` benchmark, and an aggregate non-zero exit only for new green→red regressions ([#410](https://github.com/mifunedev/openharness/issues/410)).
+- `scripts/ablate.sh` provides shared swap/restore/trap mechanics for evaluating whether a context file is load-bearing under a deterministic probe ([#410](https://github.com/mifunedev/openharness/issues/410)).
+- `/drift-check` detects framework drift, branch/append-file drift, and cron-staleness drift without mutating local state; the heartbeat now surfaces its findings when present ([#410](https://github.com/mifunedev/openharness/issues/410)).
 - `CI: Harness` now runs on pull requests and harness infrastructure paths, adds workspace and standalone `packages/oh` typecheck gates, cancels superseded runs, and adds boot-path linting with `shellcheck`/`hadolint` ([#408](https://github.com/mifunedev/openharness/issues/408)).
 - `release.yml` now validates lint, format, typecheck, build, package tests, and root script tests before publishing release artifacts ([#408](https://github.com/mifunedev/openharness/issues/408)).
 - `SECURITY.md` documents supported versions, private vulnerability reporting, automated hardening, and the sandbox trust boundary ([#408](https://github.com/mifunedev/openharness/issues/408)).

--- a/crons/README.md
+++ b/crons/README.md
@@ -19,6 +19,7 @@ timezone: America/Los_Angeles
 enabled: true
 overlap: false           # skip new fire if previous still running
 catchup: false           # don't replay missed fires after downtime
+tmux: false              # optional — run each fire in its own detached tmux session
 description: <one-line>
 ---
 
@@ -37,6 +38,58 @@ Body becomes the agent prompt at fire time.
   (preserves history).
 - Runtime artefacts in this directory (`.cron.log`, `.pid`) are
   gitignored; markdown definitions are tracked.
+
+## Status tokens
+
+The runtime appends one tab-separated line per event to the gitignored
+`crons/.cron.log`, shaped `<iso-timestamp>\t<id>\t<status>\t<msg>`. The
+status column is one of:
+
+| Token | Meaning |
+|-------|---------|
+| `BOOT` | Runtime started and scheduled its crons (`id` is `system`; `msg` is the cron count). |
+| `SPAWNED` | A `tmux: true` fire launched its detached session (`msg` is the session name). |
+| `FIRE` | A scheduled job fired and began running its body. |
+| `OK` | The fired child process exited cleanly (exit code 0). |
+| `EXIT_n` | The fired child process exited non-zero with code `n`. |
+| `ERR` | The child process failed to spawn (process-level error, not a job throw). |
+| `ERR_JOB` | A synchronous cron job-callback threw; recorded instead of being swallowed. Format: `<id>\tERR_JOB\t<error-string>`. |
+| `SKIPPED_OVERLAP` | A fire was skipped because the previous run was still in flight (`overlap: false`). |
+
+`BODY_RELOADED` and `BODY_RELOAD_ERR` are documented under
+[Hot-reload](#hot-reload).
+
+## Scheduled jobs
+
+| File | Schedule | Description |
+|------|----------|-------------|
+| `heartbeat.md` | `0 * * * *` (hourly) | Hourly pulse — review memory, surface anything urgent |
+| `cleanup-tasks.md` | `0 23 * * 0` (Sun 23:00 PT by default) | Weekly Ralph session sweep — archive completed tasks |
+
+## tmux sessions
+
+A job with `tmux: true` in its frontmatter runs each fire in its own detached
+tmux session instead of an in-process child, so the user can attach to a run,
+read its scrollback, and reattach later.
+
+- **Session name**: `<id>-<MMDD>-<HHMM>` (e.g. `heartbeat-0610-1805`), derived from the fire time. The runtime logs `SPAWNED <session>` to `.cron.log`.
+- **Env exported into the agent**: `CRON_TMUX_SESSION=<session>` and `CRON_KEEP_MARKER=/tmp/<session>.keep`.
+- **Keep-marker contract**: if the agent `touch`es `$CRON_KEEP_MARKER` before exiting, the session persists by resuming the run's own conversation as a live, attachable agent (`claude --continue` — idle until you `tmux attach -t <session>` and drive it), falling back to a shell if that exits; otherwise it auto-closes when the agent finishes.
+- **Overlap guard**: a per-id pidfile `/tmp/cron-<id>.pid` blocks a new fire while a previous one is still running when `overlap: false`; the skipped fire logs `SKIPPED_OVERLAP`.
+
+Jobs with `tmux` absent or `false` keep the default in-process spawn.
+
+## Hot-reload
+
+A cron definition's **body** (the agent prompt) hot-reloads at fire time: the
+runtime re-reads the file just before each fire, so edits take effect at the
+next scheduled fire without a restart. On a read/parse error, the runtime falls
+back to the cached boot-time body and logs `BODY_RELOAD_ERR`. When a fire's body
+differs from the boot-time cached version, a `BODY_RELOADED` line appears in
+`crons/.cron.log` — this signal recurs on every fire after an edit until the
+runtime is restarted, which re-baselines. Frontmatter changes (`schedule`,
+`enabled`, `timezone`, `overlap`) require a runtime restart; no watcher is
+implemented.
 
 ## Override
 

--- a/crons/heartbeat.md
+++ b/crons/heartbeat.md
@@ -27,6 +27,13 @@ that catches anything time-sensitive without doing real work.
     `WATCHING: <item> (un-checkable)` and skip — do not invent ad-hoc
     checks. Do NOT edit `crons/heartbeat.md` yourself; sessions own
     that file.
+2.7. Run `/drift-check`. If it reports any findings (framework drift
+    `origin`↔`upstream`, branch-behind/append-file drift, or
+    cron-staleness drift), surface each finding in
+    `memory/<today>/log.md` and include it in the reply as
+    `DRIFT: <summary>`. When `/drift-check` reports all classes clean,
+    append nothing extra — the existing `HEARTBEAT_OK` reply stays
+    unchanged; do NOT add a per-pulse "no drift" block on clean runs.
 3. Decide whether anything needs action right now.
 4. If yes, act. If no, append a brief "nothing pressing" note to
    `memory/<today>/log.md` and exit.
@@ -39,6 +46,9 @@ that catches anything time-sensitive without doing real work.
 - Pending `## Active items` → include in reply as
   `WATCHING: <item> (added <date>, age <Nd>)`. Resolved-this-pulse →
   `RESOLVED: <item> — remove the line in next session`.
+- Drift detected by `/drift-check` → include in reply as
+  `DRIFT: <summary>` and note in `memory/<today>/log.md`. Clean run →
+  no extra output.
 - Append the result to `memory/<today>/log.md` either way.
 - **Mandatory closing step (do this even after long action chains):**
   append one liveness line to `crons/.cron.log`:

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,108 @@
+# evals/ — Context fitness-function probe corpus
+
+This directory is the harness's **fitness function**: a corpus of deterministic
+**probes** that turn lessons into runnable, exit-code-scored checks against
+*real state*. A rectification is provably "done" when its probe is green; a
+recurrence surfaces as a was-green-now-red regression. See
+`context/rules/memory.md` for how lessons map to probes.
+
+## Subfolders
+
+| Path | Holds |
+|------|-------|
+| `probes/` | One `<id>.sh` per probe (Tier-A deterministic + `ablation`). |
+| `RESULTS.md` | The benchmark scoreboard — current status per probe id (see schema below). |
+
+## Probe contract
+
+A probe is an executable shell script at `evals/probes/<id>.sh` with a
+**3-state exit-code oracle**:
+
+| Exit | Meaning | Counts toward benchmark? |
+|------|---------|--------------------------|
+| `0` | **PASS** — desired state present / bad condition absent | yes (pass) |
+| `1` | **REGRESSION** — the bad condition is present | yes (fail) |
+| `2` | **SKIPPED** — not applicable in this environment (e.g. target sandbox absent) | no — neither pass nor regression |
+
+Exit `0` when a probe *cannot verify anything* (e.g. an absent sandbox) is
+**forbidden** — use `2` so a silent green never masks an unverifiable check.
+Any other non-zero exit is treated as an error (non-PASS). `stderr` MUST carry a
+one-line human reason for the result.
+
+### Probe header (metadata)
+
+Every probe declares three comment lines (the runner extracts them with the
+exact contract `grep -E '^# (tier|source|desc):'`):
+
+```sh
+#!/usr/bin/env bash
+# tier: A          # A | ablation
+# source: issue #410   # the lesson/rule this probe closes
+# desc: /eval run.sh exits non-zero when a prior PASS regresses
+set -euo pipefail
+# ... inspect REAL state (running processes, actual files, live sandbox) — never mocks ...
+```
+
+Probes MUST inspect real state/artifacts, never synthetic fixtures — except
+hook-unit-test probes, which use the documented file-fixture driver pattern
+(test driver written to a script file, sensitive tokens in shell variables).
+
+A probe that references repo files MUST resolve the repo root from
+`${BASH_SOURCE[0]}` — never cwd, never a hard-coded absolute path. `/eval` runs
+probes from an arbitrary working directory, so the canonical preamble is:
+
+```sh
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"   # evals/probes/<id>.sh -> root
+```
+
+### Timeout
+
+Every probe must complete within a bounded time; the `/eval` runner wraps each
+in `timeout` (default 30s) and marks a hung probe `TIMEOUT` (non-PASS).
+
+## RESULTS.md schema
+
+`RESULTS.md` is the benchmark. Policy: **overwrite the current-status row per
+probe id**; git history is the time series (no unbounded append). On the first
+run (no prior rows) every probe is emitted as `new-pass`/`new-fail` and NO
+`REGRESSION` is raised without a prior state.
+
+| Column | Meaning |
+|--------|---------|
+| `probe` | probe id (`<id>` of `evals/probes/<id>.sh`) |
+| `tier` | `A` \| `ablation` |
+| `last-run (UTC)` | timestamp of the most recent `/eval` that ran it |
+| `status` | `PASS` \| `REGRESSION` \| `SKIPPED` \| `TIMEOUT` |
+| `source` | the lesson/rule the probe closes |
+
+## Correction-surface triage
+
+Not every lesson becomes a probe. Route each lesson to the **cheapest reliable
+surface** first:
+
+| Surface | Use when | Artifact |
+|---------|----------|----------|
+| **harden** | the lesson is a guardrail | a hook + a unit-test probe |
+| **proceduralize** | the lesson is a technique | a skill step + a doc-lint probe |
+| **eval** | genuine judgment residue only | (Tier-B — deferred; never a hard gate in v1) |
+
+## Runner
+
+`/eval` (`.claude/skills/eval/`) discovers `evals/probes/*.sh`, runs each, and
+writes `RESULTS.md`. Run it manually when validating a change, or wire it into a
+site-specific cron only after deciding that scheduled evals should be enabled for
+that installation.
+
+### Runner aggregate exit code
+
+The runner's **aggregate** exit code is distinct from the per-probe 3-state
+oracle (the `| Exit | Meaning |` table in [Probe contract](#probe-contract)
+above, which governs individual probe results).
+
+| Exit | Meaning |
+|------|---------|
+| `0` | No new green→red regressions this run. Pre-existing `REGRESSION` rows whose status is unchanged do **not** trigger a non-zero exit. |
+| `1` | One or more probes transitioned from a prior `PASS` to `REGRESSION` in this run. |
+
+This `0`/`1` contract is the gate callers should use when deciding whether a run
+is clean.

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -1,0 +1,13 @@
+# Probe results — benchmark scoreboard
+
+Current status per probe id, written by `/eval`. Policy: **overwrite the row per
+probe id; git history is the time series.** Schema and exit-code semantics are in
+[`evals/README.md`](README.md). `SKIPPED` does not count toward pass-rate.
+
+| probe | tier | last-run (UTC) | status | source |
+|-------|------|----------------|--------|--------|
+| eval-runner-exit | A | 2026-06-12 02:28 | PASS | issue #410 — eval runner aggregate exit contract |
+| health-check-docker-stats | A | 2026-06-12 02:28 | PASS | issue #408 — health-check in-container RAM reclaim |
+| skill-paths | A | 2026-06-12 02:28 | PASS | issue #408 — harness-audit & skill-lint stale path references |
+
+<!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/eval-runner-exit.sh
+++ b/evals/probes/eval-runner-exit.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #410 — eval runner aggregate exit contract
+# desc: /eval run.sh exits non-zero when regressions array is non-empty (exit-gate contract)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUN_SH="${RUN_SH:-$ROOT/.claude/skills/eval/run.sh}"
+
+if [[ ! -f "$RUN_SH" ]]; then
+  echo "SKIPPED: eval runner absent: $RUN_SH" >&2
+  exit 2
+fi
+
+# Read only the file tail to assert the gate is CO-LOCATED at the exit point.
+tail_content="$(tail -n 12 "$RUN_SH")"
+
+# Require that the regressions-count check AND the exit 1 appear together in the tail.
+if ! grep -qE 'regressions\[@\].*-gt 0.*exit 1' <<<"$tail_content"; then
+  echo "REGRESSION: run.sh tail does not contain the co-located regressions-gated exit-1 guard (if [ \"\${#regressions[@]}\" -gt 0 ]; then exit 1; fi)" >&2
+  exit 1
+fi
+
+echo "PASS: run.sh tail contains the regressions-gated non-zero exit guard co-located at the exit point" >&2
+exit 0

--- a/evals/probes/health-check-docker-stats.sh
+++ b/evals/probes/health-check-docker-stats.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #408 — health-check in-container RAM reclaim
+# desc: /health-check retains the docker stats in-container-reclaim step
+set -euo pipefail
+
+# Resolve repo root from this script's location, never cwd: /eval runs probes
+# from an arbitrary working directory.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILL="$ROOT/.claude/skills/health-check/SKILL.md"
+
+if [[ ! -f "$SKILL" ]]; then
+  echo "SKIPPED: skill file not found at $SKILL" >&2
+  exit 2
+fi
+
+if grep -qF 'docker stats' "$SKILL"; then
+  echo "PASS: 'docker stats' step present in $SKILL" >&2
+  exit 0
+else
+  echo "REGRESSION: 'docker stats' step missing from $SKILL" >&2
+  exit 1
+fi

--- a/evals/probes/skill-paths.sh
+++ b/evals/probes/skill-paths.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #408 — harness-audit & skill-lint stale path references
+# desc: skill instructions must not reference the retired renamed dirs docs/wiki/ or workspace/heartbeats/
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILLS="$ROOT/.claude/skills"
+
+if [[ ! -d "$SKILLS" ]]; then
+  echo "SKIPPED: skills dir absent: $SKILLS" >&2
+  exit 2
+fi
+
+# Guard ONLY the two truly-dead renamed-directory tokens from the wiki/cron
+# restructure (docs/wiki/ -> wiki/, workspace/heartbeats/ -> crons/). These have
+# no legitimate use anywhere under .claude/skills/. We deliberately do NOT guard
+# apps/docs/, bare MEMORY.md, or workspace/.claude/skills/ — those have legitimate
+# or intentional (guarded dual-scope) uses in other skills and would false-positive.
+#
+# Exclusion: harness-context/SKILL.md contains the prose string "docs/wiki/changelog"
+# (an enumeration of surfaces, not a path). Exclude it by FULL PATH via a piped
+# `grep -v` — GNU `grep --exclude` matches basenames only and is not used here.
+hits=$(grep -rnE 'docs/wiki/|workspace/heartbeats/' "$SKILLS" \
+         | grep -v 'harness-context/SKILL.md' || true)
+
+if [[ -n "$hits" ]]; then
+  echo "REGRESSION: retired path token(s) reappeared in .claude/skills/ (docs/wiki/ -> wiki/, workspace/heartbeats/ -> crons/):" >&2
+  echo "$hits" >&2
+  exit 1
+fi
+
+echo "PASS: no retired docs/wiki/ or workspace/heartbeats/ token in .claude/skills/ (excl harness-context prose)" >&2
+exit 0

--- a/scripts/ablate.sh
+++ b/scripts/ablate.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Shared ablation mechanics for the harness fitness function: back up a context
+# file, remove it (so a probe/oracle runs WITHOUT it), and restore on EXIT —
+# even after a crash, via the evals/.ablation-active sentinel that /eval recovers
+# on startup.
+#
+# Only the swap/restore/trap MECHANICS are shared (prd.md §10 M-1). Each caller
+# supplies its own oracle:
+#   - /eval --ablate : deterministic shell-probe exit code (this file's CLI mode)
+#   - /context-audit : `claude -p` marker scoring (sources the functions below)
+#
+# Source for the functions:
+#   source scripts/ablate.sh
+#   ablate_swap_out <target>   # back up + remove target; arms EXIT-restore trap + sentinel
+#   ablate_restore  <target>   # restore now (also runs automatically on EXIT)
+# Or run as a CLI for a single deterministic probe:
+#   scripts/ablate.sh <target-file> <probe-script>   # -> LOAD-BEARING | PRUNABLE | CHANGED
+set -euo pipefail
+
+_ablate_root() { cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd; }
+ABLATE_SENTINEL="$(_ablate_root)/evals/.ablation-active"
+
+ablate_swap_out() {
+  local target="$1" bak="$1.bak"
+  cp "$target" "$bak"
+  printf '%s\t%s\n' "$target" "$bak" >> "$ABLATE_SENTINEL"   # crash-recovery record
+  # shellcheck disable=SC2064  # expand $target now, not at trap time
+  trap "ablate_restore '$target'" EXIT
+  mv -f "$bak" "$target.__ablated_bak" 2>/dev/null || true   # keep backup under a stable name
+  mv -f "$target" "$bak"                                      # remove target (backup is .bak)
+  mv -f "$target.__ablated_bak" "$bak" 2>/dev/null || true
+}
+
+ablate_restore() {
+  local target="$1" bak="$1.bak"
+  [ -f "$bak" ] && mv -f "$bak" "$target"
+  if [ -f "$ABLATE_SENTINEL" ]; then
+    grep -vF -- "$target	$bak" "$ABLATE_SENTINEL" > "$ABLATE_SENTINEL.tmp" 2>/dev/null || true
+    mv -f "$ABLATE_SENTINEL.tmp" "$ABLATE_SENTINEL" 2>/dev/null || true
+    [ -s "$ABLATE_SENTINEL" ] || rm -f "$ABLATE_SENTINEL"
+  fi
+}
+
+# --- CLI mode: ablate a single deterministic probe ---
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  target="${1:?usage: ablate.sh <target-file> <probe-script>}"
+  probe="${2:?usage: ablate.sh <target-file> <probe-script>}"
+  [ -f "$target" ] || { echo "ablate: target not found: $target" >&2; exit 2; }
+  [ -f "$probe" ]  || { echo "ablate: probe not found: $probe" >&2; exit 2; }
+  run_probe() { if bash "$probe" >/dev/null 2>&1; then echo 0; else echo $?; fi; }
+
+  with="$(run_probe)"
+  ablate_swap_out "$target"
+  without="$(run_probe)"
+  ablate_restore "$target"
+  trap - EXIT
+
+  if [ "$with" = "0" ] && [ "$without" != "0" ]; then verdict="LOAD-BEARING"
+  elif [ "$with" = "$without" ]; then verdict="PRUNABLE"
+  else verdict="CHANGED"; fi
+  echo "$verdict (with=$with without=$without) target=$(basename "$target") probe=$(basename "$probe")"
+fi


### PR DESCRIPTION
## Summary

Second stacked public PR after #409. Adds eval/drift infrastructure while keeping autonomous autopilot behavior out of this tranche.

- adds `/eval` plus `evals/` probe contract and initial `RESULTS.md` benchmark
- adds public-safe probes only: eval runner exit contract, `/health-check` docker-stats guard, and stale skill-path guard
- adds shared `scripts/ablate.sh` mechanics
- adds `/drift-check` and wires heartbeat to surface drift findings
- registers `/eval` and `/drift-check` in `AGENTS.md`
- documents cron status tokens, `tmux: true`, and body hot-reload behavior introduced by the hardening base

Closes #410

## Scrubbed Exclusions

- omitted `evals/probes/next-dev-prod.sh` because it checks host-specific `mifunedev/website` state
- omitted autopilot-specific probes (`clean-restore`, `eval-gate`) until the autopilot PR
- did not add `crons/eval-weekly.md`; scheduled evals stay opt-in
- preserved public timezone defaults (`America/Los_Angeles`)
- no `tasks/**`, `memory/**`, `wiki/**`, or private-session benchmark rows

## Validation

- `bash .claude/skills/eval/run.sh` — 3 probes PASS; wrote public `evals/RESULTS.md`
- `pnpm install --frozen-lockfile`
- `pnpm test:scripts` — 13 files / 143 tests passed
- `bash -n .claude/skills/eval/run.sh scripts/ablate.sh evals/probes/*.sh`
- `shellcheck -S warning .claude/skills/eval/run.sh scripts/ablate.sh evals/probes/*.sh`
- `git diff --check`
- added-line marker scan for personal/private strings and excluded paths